### PR TITLE
[Improvement] Use judge_kwargs for initializing judges

### DIFF
--- a/vlmeval/api/gpt.py
+++ b/vlmeval/api/gpt.py
@@ -42,7 +42,7 @@ class OpenAIWrapper(BaseAPI):
                  system_prompt: str = None,
                  temperature: float = 0,
                  timeout: int = 60,
-                 api_base: str = 'OFFICIAL',
+                 api_base: str = None,
                  max_tokens: int = 1024,
                  img_size: int = 512,
                  img_detail: str = 'low',
@@ -73,6 +73,15 @@ class OpenAIWrapper(BaseAPI):
         )
         super().__init__(wait=wait, retry=retry, system_prompt=system_prompt, verbose=verbose, **kwargs)
 
+        if api_base is None:
+            if 'OPENAI_API_BASE' in os.environ and os.environ['OPENAI_API_BASE'] != '':
+                self.logger.error('Environment variable OPENAI_API_BASE is set. Will use it as api_base. ')
+                api_base = os.environ['OPENAI_API_BASE']
+            else:
+                api_base = 'OFFICIAL'
+
+        assert api_base is not None
+
         if api_base in APIBASES:
             self.api_base = APIBASES[api_base]
         elif api_base.startswith('http'):
@@ -80,10 +89,6 @@ class OpenAIWrapper(BaseAPI):
         else:
             self.logger.error('Unknown API Base. ')
             sys.exit(-1)
-
-        if 'OPENAI_API_BASE' in os.environ and os.environ['OPENAI_API_BASE'] != '':
-            self.logger.error('Environment variable OPENAI_API_BASE is set. Will override the api_base arg. ')
-            self.api_base = os.environ['OPENAI_API_BASE']
 
     # inputs can be a lvl-2 nested list: [content1, content2, content3, ...]
     # content can be a string or a list of image & text

--- a/vlmeval/evaluate/llavabench.py
+++ b/vlmeval/evaluate/llavabench.py
@@ -69,17 +69,19 @@ def LLaVABench_score(data):
     return pd.DataFrame(ret)
 
 
-def LLaVABench_eval(eval_file, model='gpt-4-0314', nproc=4, verbose=False):
+def LLaVABench_eval(eval_file, **judge_kwargs):
     suffix = '.' + eval_file.split('.')[-1]
     record_file = eval_file.replace(suffix, '_openai_result' + suffix)
     score_file = eval_file.replace(suffix, '_score.csv')
+    nproc = judge_kwargs.pop('nproc', 4)
 
     if not osp.exists(record_file):
         data = load(eval_file)
         lines = [data.iloc[i] for i in range(len(data))]
         model = build_judge(
-            model, temperature=0.2, retry=10, verbose=verbose,
-            system_prompt='You are a helpful and precise assistant for checking the quality of the answer.')
+            temperature=0.2,
+            system_prompt='You are a helpful and precise assistant for checking the quality of the answer.',
+            **judge_kwargs)
         prompts = [build_prompt(line) for line in lines]
         tups = [(model, prompt) for prompt in prompts]
         scores = track_progress_rich(LLaVABench_atomeval, tups, nproc=nproc, chunksize=nproc)

--- a/vlmeval/evaluate/mathvista_eval.py
+++ b/vlmeval/evaluate/mathvista_eval.py
@@ -162,19 +162,19 @@ def MathVista_acc(result_file):
     return res
 
 
-def MathVista_eval(eval_file, model='gpt-4-turbo', nproc=4, verbose=False):
+def MathVista_eval(eval_file, **judge_kwargs):
     logger = get_logger('Evaluation')
 
     suffix = eval_file.split('.')[-1]
     storage = eval_file.replace(f'.{suffix}', f'_{model}.xlsx')
     tmp_file = eval_file.replace(f'.{suffix}', f'_{model}.pkl')
+    nproc = judge_kwargs.pop('nproc', 4)
+
     if osp.exists(storage):
         logger.warning(f'GPT scoring file {storage} already exists, will reuse it in MathVista_eval. ')
     else:
         data = load(eval_file)
-        gpt_version = model
-        model = build_judge(gpt_version, verbose=verbose, max_tokens=128, retry=10)
-
+        model = build_judge(max_tokens=128, **judge_kwargs)
         lt = len(data)
         lines = [data.iloc[i] for i in range(lt)]
         tups = [(model, line) for line in lines]

--- a/vlmeval/evaluate/mmvet_eval.py
+++ b/vlmeval/evaluate/mmvet_eval.py
@@ -108,18 +108,18 @@ def MMVet_acc(result_file):
     return res, res2
 
 
-def MMVet_eval(eval_file, model='gpt-4-turbo', nproc=4, verbose=False):
+def MMVet_eval(eval_file, **judge_kwargs):
     logger = get_logger('Evaluation')
 
     suffix = eval_file.split('.')[-1]
     storage = eval_file.replace(f'.{suffix}', f'_{model}.xlsx')
     tmp_file = eval_file.replace(f'.{suffix}', f'_{model}.pkl')
+    nproc = judge_kwargs.pop('nproc', 4)
     if osp.exists(storage):
         logger.warning(f'GPT scoring file {storage} already exists, will reuse it in MMVet_eval. ')
     else:
         data = load(eval_file)
-        gpt_version = model
-        model = build_judge(gpt_version, verbose=verbose, max_tokens=3, retry=10)
+        model = build_judge(max_tokens=3, **judge_kwargs)
 
         lt = len(data)
         lines = [data.iloc[i] for i in range(lt)]

--- a/vlmeval/evaluate/multiple_choice.py
+++ b/vlmeval/evaluate/multiple_choice.py
@@ -233,7 +233,7 @@ def eval_data_groups(model, data_groups, answer_map, result, result_file, nproc=
     dump(result, result_file)
 
 
-def multiple_choice_eval(eval_file, dataset='default', model='chatgpt-0613', nproc=4, verbose=False):
+def multiple_choice_eval(eval_file, dataset='default', **judge_kwargs):
     logger = get_logger('Evaluation')
 
     # assert dataset is not None
@@ -241,6 +241,7 @@ def multiple_choice_eval(eval_file, dataset='default', model='chatgpt-0613', npr
         dataset = 'MMBench_CN'
     elif dataset == 'MMBench_TEST_EN':
         dataset = 'MMBench'
+    nproc = judge_kwargs.pop('nproc', 4)
 
     if listinstr(['mmbench', 'ccbench'], dataset.lower()):
         data = load(eval_file)
@@ -249,6 +250,7 @@ def multiple_choice_eval(eval_file, dataset='default', model='chatgpt-0613', npr
 
     rd.seed(2680)
     suffix = eval_file.split('.')[-1]
+    model = judge_kwargs['model']
     assert model in ['chatgpt-0613', 'exact_matching', 'gpt-4-0125']
     name_str_map = {
         'chatgpt-0613': 'openai',
@@ -260,7 +262,7 @@ def multiple_choice_eval(eval_file, dataset='default', model='chatgpt-0613', npr
         model = None
     else:
         if INTERNAL or gpt_key_set():
-            model = build_judge(model, verbose=verbose, retry=10)
+            model = build_judge(**judge_kwargs)
         else:
             logger.error('OPENAI_API_KEY is not set properly, will use exact matching for evaluation')
             model = None

--- a/vlmeval/evaluate/yes_or_no.py
+++ b/vlmeval/evaluate/yes_or_no.py
@@ -165,12 +165,13 @@ def YOrN_auxeval(model, line):
     return 'Unknown'
 
 
-def YOrN_eval(eval_file, model='chatgpt-0613', nproc=4, verbose=False, dataset=None):
+def YOrN_eval(eval_file, dataset=None, **judge_kwargs):
     logger = get_logger('Evaluation')
     data = load(eval_file)
     data['prediction'] = [str(x) for x in data['prediction']]
     storage = eval_file.replace('.xlsx', '_auxmatch.xlsx')
     tmp_file = eval_file.replace('.xlsx', '_tmp.pkl')
+    nproc = judge_kwargs.pop('nproc', 4)
 
     if not osp.exists(storage):
         ans_map = {k: YOrN_Extraction(v) for k, v in zip(data['index'], data['prediction'])}
@@ -183,10 +184,8 @@ def YOrN_eval(eval_file, model='chatgpt-0613', nproc=4, verbose=False, dataset=N
         data['extracted'] = [ans_map[x] for x in data['index']]
         unknown = data[data['extracted'] == 'Unknown']
 
-        model_name = 'chatgpt-0613'
-
         if INTERNAL or gpt_key_set():
-            model = build_judge(model_name, verbose=verbose, retry=10)
+            model = build_judge(**judge_kwargs)
         else:
             logger.error('OPENAI_API_KEY is not set properly, will use exact matching for evaluation')
             model = None


### PR DESCRIPTION
1. new env variables can be set in .env
```bash
OPENAI_API_KEY_JUDGE=
OPENAI_API_BASE_JUDGE=
```
2. Support set the judge model with `--judge` in run.py
3. `--retry` also applies to judge model in run.py
