### PR TITLE
Add InternVL-Chat-V1-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ VLMEvalKit will use an **judge LLM** to extract answer from the output if you se
 
 Note that some VLMs may not be able to run under certain transformer versions, we recommend the following settings to evaluate each VLM:
 
-- **Please use** `transformers==4.33.0` **for**: `Qwen series`, `Monkey series`, `InternVL series`, `InternLM-XComposer Series`, `mPLUG-Owl2`, `OpenFlamingo v2`, `IDEFICS series`, `VisualGLM`, `MMAlaya`, `SharedCaptioner`, `MiniGPT-4 series`, `InstructBLIP series`,  `PandaGPT`.
-- **Please use** `transformers==4.37.0 ` **for**: `LLaVA series`, `ShareGPT4V series`, `TransCore-M`, `LLaVA (XTuner)`, `CogVLM Series`, `EMU2 Series`, `Yi-VL Series`, `MiniCPM-V series`, `OmniLMM-12B`, `DeepSeek-VL series`.
+- **Please use** `transformers==4.33.0` **for**: `Qwen series`, `Monkey series`, `InternLM-XComposer Series`, `mPLUG-Owl2`, `OpenFlamingo v2`, `IDEFICS series`, `VisualGLM`, `MMAlaya`, `SharedCaptioner`, `MiniGPT-4 series`, `InstructBLIP series`, `PandaGPT`.
+- **Please use** `transformers==4.37.0 ` **for**: `LLaVA series`, `ShareGPT4V series`, `TransCore-M`, `LLaVA (XTuner)`, `CogVLM Series`, `EMU2 Series`, `Yi-VL Series`, `MiniCPM-V series`, `OmniLMM-12B`, `DeepSeek-VL series`, `InternVL series`.
 - **Please use** `transformers==4.39.0 ` **for**: `LLaVA-Next series`.
 
 ```python

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -70,6 +70,7 @@ internvl_series = {
     'InternVL-Chat-V1-1':partial(InternVLChat, model_path='OpenGVLab/InternVL-Chat-Chinese-V1-1'),
     'InternVL-Chat-V1-2': partial(InternVLChat, model_path='OpenGVLab/InternVL-Chat-Chinese-V1-2'),
     'InternVL-Chat-V1-2-Plus': partial(InternVLChat, model_path='OpenGVLab/InternVL-Chat-Chinese-V1-2-Plus'),
+    'InternVL-Chat-V1-5': partial(InternVLChat, model_path='OpenGVLab/InternVL-Chat-V1-5-Preview'),
 }
 
 yivl_series = {

--- a/vlmeval/evaluate/mathvista_eval.py
+++ b/vlmeval/evaluate/mathvista_eval.py
@@ -164,6 +164,7 @@ def MathVista_acc(result_file):
 
 def MathVista_eval(eval_file, **judge_kwargs):
     logger = get_logger('Evaluation')
+    model = judge_kwargs['model']
 
     suffix = eval_file.split('.')[-1]
     storage = eval_file.replace(f'.{suffix}', f'_{model}.xlsx')

--- a/vlmeval/vlm/internvl_chat.py
+++ b/vlmeval/vlm/internvl_chat.py
@@ -7,6 +7,91 @@ from ..smp import *
 from ..utils import DATASET_TYPE
 import pandas as pd
 import string
+from transformers import AutoTokenizer
+import torch
+import torchvision.transforms as T
+from PIL import Image
+
+from torchvision.transforms.functional import InterpolationMode
+
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def build_transform(input_size):
+    MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
+    transform = T.Compose([
+        T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+        T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+        T.ToTensor(),
+        T.Normalize(mean=MEAN, std=STD)
+    ])
+    return transform
+
+
+def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
+    best_ratio_diff = float('inf')
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        elif ratio_diff == best_ratio_diff:
+            if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                best_ratio = ratio
+    return best_ratio
+
+
+def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnail=False):
+    orig_width, orig_height = image.size
+    aspect_ratio = orig_width / orig_height
+
+    # calculate the existing image aspect ratio
+    target_ratios = set(
+        (i, j) for n in range(min_num, max_num + 1) for i in range(1, n + 1) for j in range(1, n + 1) if
+        i * j <= max_num and i * j >= min_num)
+    target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+    # find the closest aspect ratio to the target
+    target_aspect_ratio = find_closest_aspect_ratio(
+        aspect_ratio, target_ratios, orig_width, orig_height, image_size)
+
+    # calculate the target width and height
+    target_width = image_size * target_aspect_ratio[0]
+    target_height = image_size * target_aspect_ratio[1]
+    blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+
+    # resize the image
+    resized_img = image.resize((target_width, target_height))
+    processed_images = []
+    for i in range(blocks):
+        box = (
+            (i % (target_width // image_size)) * image_size,
+            (i // (target_width // image_size)) * image_size,
+            ((i % (target_width // image_size)) + 1) * image_size,
+            ((i // (target_width // image_size)) + 1) * image_size
+        )
+        # split the image
+        split_img = resized_img.crop(box)
+        processed_images.append(split_img)
+    assert len(processed_images) == blocks
+    if use_thumbnail and len(processed_images) != 1:
+        thumbnail_img = image.resize((image_size, image_size))
+        processed_images.append(thumbnail_img)
+    return processed_images
+
+
+def load_image(image_file, input_size=448, max_num=6):
+    image = Image.open(image_file).convert('RGB')
+    transform = build_transform(input_size=input_size)
+    images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
+    pixel_values = [transform(image) for image in images]
+    pixel_values = torch.stack(pixel_values)
+    return pixel_values
 
 
 class InternVLChat(BaseModel):
@@ -25,24 +110,17 @@ class InternVLChat(BaseModel):
         self.image_size = self.model.config.vision_config.image_size
 
         if 'V1-1' in model_path:
-            kwargs_default = dict(do_sample=False, max_new_tokens=512, top_p=None, num_beams=5)
+            kwargs_default = dict(do_sample=False, max_new_tokens=1024, top_p=None, num_beams=5)
         else:
-            kwargs_default = dict(do_sample=False, max_new_tokens=512, top_p=None, num_beams=1)
+            kwargs_default = dict(do_sample=False, max_new_tokens=1024, top_p=None, num_beams=1)
         kwargs_default.update(kwargs)
         self.kwargs = kwargs_default
         warnings.warn(f'Following kwargs received: {self.kwargs}, will use as generation config. ')
 
     def use_custom_prompt(self, dataset):
-        assert dataset is not None
-        if DATASET_TYPE(dataset) == 'multi-choice':
-            return True
-        return False
+        return True
 
-    def build_prompt(self, line, dataset=None):
-        assert self.use_custom_prompt(dataset)
-        assert dataset is None or isinstance(dataset, str)
-        tgt_path = self.dump_image(line, dataset)
-
+    def build_multi_choice_prompt(self, line, dataset=None):
         question = line['question']
         hint = line['hint'] if ('hint' in line and not pd.isna(line['hint'])) else None
         if hint is not None:
@@ -63,18 +141,67 @@ class InternVLChat(BaseModel):
         else:
             prompt += '\n请直接回答问题。' if cn_string(prompt) else '\nAnswer the question directly.'
 
+        return prompt
+
+    def build_prompt(self, line, dataset=None):
+        assert self.use_custom_prompt(dataset)
+        assert dataset is None or isinstance(dataset, str)
+        tgt_path = self.dump_image(line, dataset)
+
+        if listinstr(['MME'], dataset):
+            question = line['question']
+            prompt = question + ' Answer the question using a single word or phrase.'
+            self.kwargs = dict(do_sample=True, max_new_tokens=5, top_k=50, num_beams=5, top_p=0.9)
+        elif listinstr(['HallusionBench'], dataset):
+            question = line['question']
+            prompt = question + ' Please answer yes or no. Answer the question using a single word or phrase.'
+        elif DATASET_TYPE(dataset) == 'multi-choice':
+            prompt = self.build_multi_choice_prompt(line, dataset)
+        elif DATASET_TYPE(dataset) == 'VQA':
+            if 'MathVista' in dataset:
+                prompt = line['question']
+            elif listinstr(['LLaVABench'], dataset):
+                question = line['question']
+                prompt = question + '\nAnswer this question in detail.'
+            elif listinstr(['MMVet'], dataset):
+                prompt = line['question']
+            else:
+                question = line['question']
+                prompt = question + f'\nAnswer the question using a single word or phrase.'
+
         message = [dict(type='text', value=prompt)]
         message.extend([dict(type='image', value=s) for s in tgt_path])
 
         return message
 
-    def generate_inner(self, message, dataset=None):
+    def generate_v1_5(self, message, dataset=None):
+        prompt, image_path = self.message_to_promptimg(message)
+        if listinstr(['DocVQA_TEST', 'DocVQA_VAL', 'ChartQA_TEST'], dataset):
+            self.max_num = 12
+        elif listinstr(['InfoVQA_VAL', 'InfoVQA_TEST', 'OCRBench'], dataset):
+            self.max_num = 24
+        else:
+            self.max_num = 6
+        pixel_values = load_image(image_path, max_num=self.max_num).cuda().to(torch.bfloat16)
+        with torch.no_grad():
+            response = self.model.chat(self.tokenizer, pixel_values=pixel_values,
+                                       question=prompt, generation_config=self.kwargs)
+        return response
+
+    def generate_v1_2(self, message, dataset=None):
         prompt, image_path = self.message_to_promptimg(message)
         image = Image.open(image_path).convert('RGB')
         image = image.resize((self.image_size, self.image_size))
         image_processor = CLIPImageProcessor.from_pretrained(self.model_path)
         pixel_values = image_processor(images=image, return_tensors='pt').pixel_values
         pixel_values = pixel_values.to(torch.bfloat16).to(self.device)
-        response = self.model.chat(self.tokenizer, pixel_values=pixel_values,
-                                   question=prompt, generation_config=self.kwargs)
+        with torch.no_grad():
+            response = self.model.chat(self.tokenizer, pixel_values=pixel_values,
+                                       question=prompt, generation_config=self.kwargs)
         return response
+
+    def generate(self, message, dataset=None):
+        if "V1-5" in self.model_path:
+            return self.generate_v1_5(message, dataset)
+        else:
+            return self.generate_v1_2(message, dataset)

--- a/vlmeval/vlm/internvl_chat.py
+++ b/vlmeval/vlm/internvl_chat.py
@@ -191,6 +191,7 @@ class InternVLChat(BaseModel):
         with torch.no_grad():
             response = self.model.chat(self.tokenizer, pixel_values=pixel_values,
                                        question=prompt, generation_config=self.kwargs)
+        response = response.split('[UNUSED_TOKEN_145]')[0]
         return response
 
     def generate_v1_2(self, message, dataset=None):

--- a/vlmeval/vlm/internvl_chat.py
+++ b/vlmeval/vlm/internvl_chat.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer, AutoModel, CLIPImageProcessor
+from transformers import AutoTokenizer, AutoModel, CLIPImageProcessor
 import warnings
 from PIL import Image
 from .base import BaseModel

--- a/vlmeval/vlm/internvl_chat.py
+++ b/vlmeval/vlm/internvl_chat.py
@@ -148,10 +148,16 @@ class InternVLChat(BaseModel):
         assert dataset is None or isinstance(dataset, str)
         tgt_path = self.dump_image(line, dataset)
 
+        if 'V1-1' in self.model_path:
+            kwargs_default = dict(do_sample=False, max_new_tokens=1024, top_p=None, num_beams=5)
+        else:
+            kwargs_default = dict(do_sample=False, max_new_tokens=1024, top_p=None, num_beams=1)
+        self.kwargs = kwargs_default
         if listinstr(['MME'], dataset):
             question = line['question']
             prompt = question + ' Answer the question using a single word or phrase.'
-            self.kwargs = dict(do_sample=True, max_new_tokens=5, top_k=50, num_beams=5, top_p=0.9)
+            if "V1-2" not in self.model_path:
+                self.kwargs = dict(do_sample=True, max_new_tokens=5, top_k=50, num_beams=5, top_p=0.9)
         elif listinstr(['HallusionBench'], dataset):
             question = line['question']
             prompt = question + ' Please answer yes or no. Answer the question using a single word or phrase.'


### PR DESCRIPTION
Hi, developers of VLMEvalKit:

Thanks for developing such a good toolkit for multi-modal evaluation!

We recently developed a new InternVL-Chat model ([InternVL-Chat-V1-5](https://huggingface.co/OpenGVLab/InternVL-Chat-V1-5-Preview)) that achieves many SOTA performance on multimodal benchmarks. We apply to add this model to OpenCompass Multi-modal Leaderboard.

There are two major changes in this PR:
1. add a new model, [InternVL-Chat-V1-5](https://huggingface.co/OpenGVLab/InternVL-Chat-V1-5-Preview), the model weights have been open-sourced.
2. fix prompts for old models, including InternVL-Chat-V1-1, InternVL-Chat-V1-2, and InternVL-Chat-V1-2-Plus.

We test this model using transformers==4.36.2, but I think 4.37.0 should work as well.