### PR TITLE
Fix xcomposer error during inference

### DIFF
--- a/vlmeval/vlm/xcomposer/xcomposer.py
+++ b/vlmeval/vlm/xcomposer/xcomposer.py
@@ -103,10 +103,11 @@ class XComposer(BaseModel):
         assert len(prompt_segs) == len(img_embeds) + 1
 
         prompt_seg_tokens = [
-            self.model.tokenizer(seg, return_tensors='pt', add_special_tokens=(i == 0)).to(self.device).input_ids
+            self.model.tokenizer(seg, return_tensors='pt', add_special_tokens=(i == 0)).to(self.device).input_ids.long()
             for i, seg in enumerate(prompt_segs)
         ]
         prompt_seg_embs = [self.model.internlm_model.model.embed_tokens(seg) for seg in prompt_seg_tokens]
+        # prompt_seg_embs = [self.model.internlm_model.model.embed_tokens(torch.tensor(seg).long()) for seg in prompt_seg_tokens]
         all_embeddings = []
         for i in range(len(img_embeds)):
             all_embeddings.extend([prompt_seg_embs[i], img_embeds[i]])

--- a/vlmeval/vlm/xcomposer/xcomposer.py
+++ b/vlmeval/vlm/xcomposer/xcomposer.py
@@ -107,7 +107,6 @@ class XComposer(BaseModel):
             for i, seg in enumerate(prompt_segs)
         ]
         prompt_seg_embs = [self.model.internlm_model.model.embed_tokens(seg) for seg in prompt_seg_tokens]
-        # prompt_seg_embs = [self.model.internlm_model.model.embed_tokens(torch.tensor(seg).long()) for seg in prompt_seg_tokens]
         all_embeddings = []
         for i in range(len(img_embeds)):
             all_embeddings.extend([prompt_seg_embs[i], img_embeds[i]])


### PR DESCRIPTION
Torch Version: 2.1.2+cu121

Traceback (most recent call last):
  File "/mnt/petrelfs/wangjize/VLMEvalKit/run.py", line 152, in <module>
    main()  File "/mnt/petrelfs/wangjize/VLMEvalKit/run.py", line 74, in main    model = infer_data_job(
  File "/mnt/petrelfs/wangjize/VLMEvalKit/vlmeval/inference.py", line 164, in infer_data_job
    model = infer_data(
  File "/mnt/petrelfs/wangjize/VLMEvalKit/vlmeval/inference.py", line 130, in infer_data    response = model.generate(message=struct, dataset=dataset_name)  File "/mnt/petrelfs/wangjize/VLMEvalKit/vlmeval/vlm/base.py", line 135, in generate
    return self.generate_inner(message, dataset)
  File "/mnt/petrelfs/wangjize/VLMEvalKit/vlmeval/vlm/xcomposer/xcomposer.py", line 65, in generate_inner
    prompt_embs = self.message_to_prompt_embs(message, dataset)
  File "/mnt/petrelfs/wangjize/VLMEvalKit/vlmeval/vlm/xcomposer/xcomposer.py", line 109, in message_to_prompt_embs    prompt_seg_embs = [self.model.internlm_model.model.embed_tokens(seg) for seg in prompt_seg_tokens]  File "/mnt/petrelfs/wangjize/VLMEvalKit/vlmeval/vlm/xcomposer/xcomposer.py", line 109, in <listcomp>    prompt_seg_embs = [self.model.internlm_model.model.embed_tokens(seg) for seg in prompt_seg_tokens]  File "/mnt/petrelfs/wangjize/anaconda3/envs/vlmeval/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/mnt/petrelfs/wangjize/anaconda3/envs/vlmeval/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/petrelfs/wangjize/anaconda3/envs/vlmeval/lib/python3.10/site-packages/torch/nn/modules/sparse.py", line 162, in forward
    return F.embedding(
  File "/mnt/petrelfs/wangjize/anaconda3/envs/vlmeval/lib/python3.10/site-packages/torch/nn/functional.py", line 2233, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but got torch.cuda.FloatTensor instead (while checking arguments for embedding)