### PR TITLE
Fix mathvista Idefics2

### DIFF
--- a/vlmeval/vlm/idefics.py
+++ b/vlmeval/vlm/idefics.py
@@ -221,6 +221,8 @@ class IDEFICS2(BaseModel):
                 for k, v in replace_mapping.items():
                     instruction = instruction.replace(k, v)
                 prompt += instruction.strip()
+        if 'A.' in prompt and 'B.' in prompt:
+            prompt += "\nAnswer with the letter."
         prompt += '<end_of_utterance>\nAssistant:'
         if 'A.' in prompt and 'B.' in prompt:
             prompt += ' Answer:'


### PR DESCRIPTION
A very small change in the prompting of MathVista.
This can change a bit the performance (up to 1 point).

Idefics2 was fine-tuned with a specific prompt for MCQ.
In this PR, I add a sentence that was always seen during the fine-tuning when the model is expected to answer with a letter for MCQ.

Feel free to directly merge if you think this modification makes sense.