### PR TITLE
[Fix] Align LLAVA-OneVision Model Loading with Official Implementation

### DIFF
--- a/vlmeval/vlm/llava/llava.py
+++ b/vlmeval/vlm/llava/llava.py
@@ -400,9 +400,8 @@ class LLaVA_OneVision(BaseModel):
             warnings.warn('Please `pip install git+https://github.com/LLaVA-VL/LLaVA-NeXT.git`')
 
         model_name = get_model_name_from_path(model_path)
-        tokenizer, model, image_processor, _ = load_pretrained_model(model_path, None, model_name, device_map=None)
-        model.cuda().eval()
-        model.tie_weights()
+        tokenizer, model, image_processor, _ = load_pretrained_model(model_path, None, model_name, device_map='auto')
+        model.eval()
 
         if 'llava' in model_path.lower():
             conv_mode = 'qwen_1_5'


### PR DESCRIPTION
This pull request updates the model loading process in the `llava-onevision` implementation to match the official method provided by Hugging Face. The key changes include setting the `device_map` to 'auto' during model loading and removing the manual tying of model weights. This ensures compatibility and consistency with the official loading procedure, as outlined [here](https://huggingface.co/lmms-lab/llava-onevision-qwen2-7b-si#:~:text=tokenizer%2C%20model%2C%20image_processor%2C%20max_length%20%3D%20load_pretrained_model(pretrained%2C%20None%2C%20model_name%2C%20device_map%3Ddevice_map)).