### PR TITLE
Update eos_token for HF converted xgen-mm

### DIFF
--- a/vlmeval/vlm/xgen_mm.py
+++ b/vlmeval/vlm/xgen_mm.py
@@ -10,9 +10,9 @@ class XGenMM(BaseModel):
     INSTALL_REQ = False
     INTERLEAVE = True
 
-    def __init__(self, model_path='Salesforce/xgen-mm-phi3-mini-instruct-dpo-r-v1.5', **kwargs):
+    def __init__(self, model_path='Salesforce/xgen-mm-phi3-mini-instruct-interleave-r-v1.5', **kwargs):
         try:
-            from transformers import AutoModelForVision2Seq, AutoTokenizer, AutoImageProcessor, StoppingCriteria
+            from transformers import AutoModelForVision2Seq, AutoTokenizer, AutoImageProcessor
         except:
             warnings.warn('Please install the latest version transformers.')
             sys.exit(-1)
@@ -25,7 +25,9 @@ class XGenMM(BaseModel):
             model_path, trust_remote_code=True, use_fast=False, legacy=False
         )
         tokenizer = model.update_special_tokens(tokenizer)
+        tokenizer.eos_token = '<|end|>'
         tokenizer.padding_side = 'left'
+        
         image_processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
         self.model = model
         self.image_processor = image_processor
@@ -70,6 +72,7 @@ class XGenMM(BaseModel):
         generate_ids = self.model.generate(
             **inputs, image_size=[image_sizes],
             pad_token_id=self.tokenizer.pad_token_id,
+            eos_token_id=self.tokenizer.eos_token_id,
             **generation_args
         )
 

--- a/vlmeval/vlm/xgen_mm.py
+++ b/vlmeval/vlm/xgen_mm.py
@@ -27,7 +27,7 @@ class XGenMM(BaseModel):
         tokenizer = model.update_special_tokens(tokenizer)
         tokenizer.eos_token = '<|end|>'
         tokenizer.padding_side = 'left'
-        
+
         image_processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
         self.model = model
         self.image_processor = image_processor

--- a/vlmeval/vlm/xgen_mm.py
+++ b/vlmeval/vlm/xgen_mm.py
@@ -27,7 +27,6 @@ class XGenMM(BaseModel):
         tokenizer = model.update_special_tokens(tokenizer)
         tokenizer.eos_token = '<|end|>'
         tokenizer.padding_side = 'left'
-
         image_processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
         self.model = model
         self.image_processor = image_processor


### PR DESCRIPTION
Hi team,

This is Manli, one of the original authors of XGen-MM (BLIP3). Thank you all for contributing to support xGen-MM in your awesome eval toolkit. 

I was working on fixing some small issues with our Huggingface converted models. This PR is to update the `eos_token` for our tokenizer so the model knows to stop at `<|end|>`. 

(To clarify, in my local evaluation, I directly ran your toolkit using the model defined in the training code, which differs from the Huggingface converted one, so we don't have this `eos_token` issue with our local models.)