### PR TITLE
[Fix] Update prompts for InternVL2

### DIFF
--- a/vlmeval/vlm/internvl_chat.py
+++ b/vlmeval/vlm/internvl_chat.py
@@ -222,7 +222,7 @@ class InternVLChat(BaseModel):
             prompt = prompt.replace('\nAnswer:', '')
             prompt += "\nAnswer with the option's letter from the given choices directly."
         elif listinstr(['MVBench'], dataset):
-            prompt += "\nOnly give the best option."
+            prompt += '\nOnly give the best option.'
 
         return prompt
 

--- a/vlmeval/vlm/internvl_chat.py
+++ b/vlmeval/vlm/internvl_chat.py
@@ -181,6 +181,9 @@ class InternVLChat(BaseModel):
         if listinstr(['MMDU', 'MME-RealWorld', 'MME-RealWorld-CN'], dataset):
             # For Multi-Turn we don't have custom prompt
             return False
+        if listinstr(['MMBench-Video', 'Video-MME', 'MVBench', 'Video'], dataset):
+            # For Video benchmarks we don't have custom prompt at here
+            return False
         else:
             return True
 
@@ -207,18 +210,20 @@ class InternVLChat(BaseModel):
 
         return prompt
 
-    def build_video_prompt(self, prompt, dataset=None, max_nframe=64):
-        for start in range(0, max_nframe, 8):
-            images_to_remove = ''.join([f'<image-{i}>' for i in range(start + 1, start + 9)])
+    def build_video_prompt(self, prompt, dataset=None, max_frames=64):
+        for start in range(0, max_frames, 8):
+            images_to_remove = ''.join([f'<Image-{i}>' for i in range(start + 1, start + 9)])
             prompt = prompt.replace(images_to_remove, '')
-        for i in range(max_nframe):
-            prompt = prompt.replace(f'<image-{i + 1}>', f'Frame{i + 1}')
+        for i in range(max_frames):
+            prompt = prompt.replace(f'Image-{i + 1}', f'Frame-{i + 1}')
         if listinstr(['MMBench-Video'], dataset):
             prompt = prompt.replace('\nAnswer:', '')
-            prompt += '\nAnswer the question using a single word or phrase.'
         elif listinstr(['Video-MME'], dataset):
             prompt = prompt.replace('\nAnswer:', '')
             prompt += "\nAnswer with the option's letter from the given choices directly."
+        elif listinstr(['MVBench'], dataset):
+            prompt += "\nOnly give the best option."
+
         return prompt
 
     def build_prompt(self, line, dataset=None):
@@ -232,24 +237,21 @@ class InternVLChat(BaseModel):
             kwargs_default = dict(do_sample=False, max_new_tokens=1024, top_p=None, num_beams=1)
         self.kwargs = kwargs_default
 
-        if dataset is not None and listinstr(['MME'], dataset):
+        if dataset is not None and DATASET_TYPE(dataset) == 'Y/N':
             question = line['question']
-            prompt = question + ' Answer the question using a single word or phrase.'
-        elif dataset is not None and listinstr(['HallusionBench'], dataset):
-            question = line['question']
-            prompt = question + ' Please answer yes or no. Answer the question using a single word or phrase.'
+            if listinstr(['MME'], dataset):
+                prompt = question + ' Answer the question using a single word or phrase.'
+            elif listinstr(['HallusionBench'], dataset):
+                prompt = question + ' Please answer yes or no. Answer the question using a single word or phrase.'
         elif dataset is not None and DATASET_TYPE(dataset) == 'MCQ':
             prompt = self.build_multi_choice_prompt(line, dataset)
         elif dataset is not None and DATASET_TYPE(dataset) == 'VQA':
-            if listinstr(['MathVista', 'MathVision'], dataset):
-                prompt = line['question']
+            question = line['question']
+            if listinstr(['MathVista', 'MathVision', 'VCR', 'MTVQA', 'MMVet'], dataset):
+                prompt = question
             elif listinstr(['LLaVABench'], dataset):
-                question = line['question']
                 prompt = question + '\nAnswer this question in detail.'
-            elif listinstr(['MMVet'], dataset):
-                prompt = line['question']
             else:
-                question = line['question']
                 prompt = question + '\nAnswer the question using a single word or phrase.'
         else:
             prompt = line['question']
@@ -259,17 +261,19 @@ class InternVLChat(BaseModel):
 
     def set_max_num(self, dataset):
         assert dataset is not None
-        if dataset is not None and listinstr(['ChartQA_TEST', 'MMMU_DEV_VAL'], dataset):
-            self.max_num = 12
-        elif dataset is not None and listinstr(['MME-RealWorld', 'MME-RealWorld-CN'], dataset):
-            self.max_num = 12
-        elif dataset is not None and listinstr(['DocVQA_VAL', 'DocVQA_TEST'], dataset):
-            self.max_num = 18
-        elif dataset is not None and listinstr(['InfoVQA_VAL', 'InfoVQA_TEST', 'OCRBench',
-                                                'HRBench4K', 'HRBench8K'], dataset):
-            self.max_num = 24
-        elif dataset is not None and listinstr(['MMBench-Video', 'Video-MME', 'Video'], dataset):
+        res_1_datasets = ['MMBench-Video', 'Video-MME', 'MVBench', 'Video']
+        res_12_datasets = ['ChartQA_TEST', 'MMMU_DEV_VAL', 'MMMU_TEST', 'MME-RealWorld',
+                           'MME-RealWorld', 'VCR_EN', 'VCR_ZH']
+        res_18_datasets = ['DocVQA_VAL', 'DocVQA_TEST']
+        res_24_datasets = ['InfoVQA_VAL', 'InfoVQA_TEST', 'OCRBench', 'HRBench4K', 'HRBench8K']
+        if listinstr(res_1_datasets, dataset):
             self.max_num = 1
+        elif listinstr(res_12_datasets, dataset):
+            self.max_num = 12
+        elif listinstr(res_18_datasets, dataset):
+            self.max_num = 18
+        elif listinstr(res_24_datasets, dataset):
+            self.max_num = 24
         else:
             self.max_num = 6
 
@@ -297,11 +301,11 @@ class InternVLChat(BaseModel):
             image_path = [x['value'] for x in message if x['type'] == 'image']
             pixel_values_list = []
             for file_name in image_path:
-                pixel_values_list.append(load_image(file_name, max_num=self.max_num).cuda().to(torch.bfloat16))
+                pixel_values_list.append(load_image(file_name, max_num=self.max_num).to(self.device).to(torch.bfloat16))
             pixel_values = torch.cat(pixel_values_list, dim=0)
         elif image_num == 1:
             image_path = [x['value'] for x in message if x['type'] == 'image'][0]
-            pixel_values = load_image(image_path, max_num=self.max_num).cuda().to(torch.bfloat16)
+            pixel_values = load_image(image_path, max_num=self.max_num).to(self.device).to(torch.bfloat16)
         else:
             pixel_values = None
         with torch.no_grad():
@@ -323,9 +327,9 @@ class InternVLChat(BaseModel):
                 if x['type'] == 'text':
                     prompt += x['value']
                 elif x['type'] == 'image':
-                    prompt += f'<image-{image_idx}>'
+                    prompt += f'<Image-{image_idx}>'
                     image_idx += 1
-            prompt = ' '.join([f'<image-{i + 1}>: <image>' for i in range(image_num)]) + '\n' + prompt
+            prompt = '\n'.join([f'Image-{i + 1}: <image>' for i in range(image_num)]) + '\n' + prompt
 
         if listinstr(['Video'], dataset):
             prompt = self.build_video_prompt(prompt, dataset)
@@ -337,7 +341,7 @@ class InternVLChat(BaseModel):
             for image_idx, file_name in enumerate(image_path):
                 upscale_flag = image_idx == 0 and dataset is not None and listinstr(['MMMU_DEV_VAL'], dataset)
                 curr_pixel_values = load_image(
-                    file_name, max_num=self.max_num, upscale=upscale_flag).cuda().to(torch.bfloat16)
+                    file_name, max_num=self.max_num, upscale=upscale_flag).to(self.device).to(torch.bfloat16)
                 num_patches_list.append(curr_pixel_values.size(0))
                 pixel_values_list.append(curr_pixel_values)
             pixel_values = torch.cat(pixel_values_list, dim=0)
@@ -345,7 +349,7 @@ class InternVLChat(BaseModel):
             image_path = [x['value'] for x in message if x['type'] == 'image'][0]
             upscale_flag = listinstr(['MMMU_DEV_VAL'], dataset)
             pixel_values = load_image(
-                image_path, max_num=self.max_num, upscale=upscale_flag).cuda().to(torch.bfloat16)
+                image_path, max_num=self.max_num, upscale=upscale_flag).to(self.device).to(torch.bfloat16)
             num_patches_list = [pixel_values.size(0)]
         else:
             pixel_values = None
@@ -431,14 +435,14 @@ class InternVLChat(BaseModel):
             for image_idx, file_name in enumerate(image_path):
                 upscale_flag = image_idx == 0 and dataset is not None and listinstr(['MMMU_DEV_VAL'], dataset)
                 curr_pixel_values = load_image(
-                    file_name, max_num=self.max_num, upscale=upscale_flag).cuda().to(torch.bfloat16)
+                    file_name, max_num=self.max_num, upscale=upscale_flag).to(self.device).to(torch.bfloat16)
                 num_patches_list.append(curr_pixel_values.size(0))
                 pixel_values_list.append(curr_pixel_values)
             pixel_values = torch.cat(pixel_values_list, dim=0)
         elif image_cnt == 1:
             upscale_flag = listinstr(['MMMU_DEV_VAL'], dataset)
             pixel_values = load_image(
-                image_path, max_num=self.max_num, upscale=upscale_flag).cuda().to(torch.bfloat16)
+                image_path, max_num=self.max_num, upscale=upscale_flag).to(self.device).to(torch.bfloat16)
             num_patches_list = [pixel_values.size(0)]
         else:
             pixel_values = None


### PR DESCRIPTION
以下是本次修改的说明：

1. 由于video数据集没有dump_image函数，在use_custom_prompt对遇到的所有Video数据集都返回False；

2. 修改了一下image数据集的prompt，把MME和HallusionBench都归类到了Y/N下面；

3. 在set_max_num中根据max_num做了数据集名称的list，方便之后拓展新的数据集；

4. cuda()的硬编码全部改成to(self.device)；

5. 图片的指代词改成了Image-{idx}，不同图像用`\n`区分；

6. 增加了MVBench的prompt；

经过测试，图像benchmark的点数没有变化，视频benchmark中Video-MME的点数没有变化，MMBench-Video的点数有轻微提升，MVBench的点数还需要进一步测试。

---

Here is an explanation of the changes made:

1. The dump_image function was not available for the video dataset, so use_custom_prompt returned False for all Video datasets encountered.

2. The prompt for image datasets was modified to categorize MME and HallusionBench under Y/N.

3. A list of dataset names based on max_num was created in set_max_num for future expansion of new datasets.

4. All hard-coded .cuda() calls were changed to .to(self.device).

5. The referential term for images was changed to Image-{idx}, with different images separated by `\n`.

6. The prompt for MVBench was added.

After testing, it was found that the number of points for both image and video benchmarks remained unchanged except for a slight increase in points for MMBench-Video. Further testing is needed for MVBench's point count.