### PR TITLE
Add support for H2OVL Mississippi model series

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ VLMEvalKit will use a **judge LLM** to extract answer from the output if you set
 | [**Chat-UniVi-7B[-v1.5]**](https://github.com/PKU-YuanGroup/Chat-UniVi) 🎬 | [**LLaMA-VID-7B**](https://github.com/dvlab-research/LLaMA-VID) 🎬 | [**VideoChat2-HD**](https://huggingface.co/OpenGVLab/VideoChat2_HD_stage4_Mistral_7B) 🎬 | [**PLLaVA-[7B/13B/34B]**](https://huggingface.co/ermu2001/pllava-7b) 🎬 |
 | [**RBDash_72b**](https://github.com/RBDash-Team/RBDash) 🚅🎞️   |  [**xgen-mm-phi3-[interleave/dpo]-r-v1.5**](https://huggingface.co/Salesforce/xgen-mm-phi3-mini-instruct-interleave-r-v1.5) 🚅🎞️    | [**Qwen2-VL-[2B/7B]**](https://github.com/QwenLM/Qwen2-VL)🚅🎞️   |[**slime_[7b/8b/13b]**](https://github.com/yfzhang114/SliME)🎞️     |
 | [**Eagle-X4-[8B/13B]**](https://github.com/NVlabs/EAGLE)🚅🎞️, <br>[**Eagle-X5-[7B/13B/34B]**](https://github.com/NVlabs/EAGLE)🚅🎞️  | [**Moondream1-1.8B**](https://github.com/vikhyat/moondream)🚅, <br>[**Moondream2-1.8B**](https://github.com/vikhyat/moondream)🚅 |[**XinYuan-VL-2B-Instruct**](https://huggingface.co/Cylingo/Xinyuan-VL-2B)🚅🎞️ |[**Llama-3.2-[11B/90B]-Vision-Instruct**](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct)🚅 |
-| [**Kosmos2**](https://huggingface.co/microsoft/kosmos-2-patch14-224)🚅 | [**H2OVL-Mississippi-[0.8B/2B]**](https://huggingface.co/h2oai/h2ovl-mississippi-2b)🚅🎞️ | 
+| [**Kosmos2**](https://huggingface.co/microsoft/kosmos-2-patch14-224)🚅 | [**H2OVL-Mississippi-[0.8B/2B]**](https://huggingface.co/h2oai/h2ovl-mississippi-2b)🚅🎞️ |
 
 
 🎞️: Support multiple images as inputs.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ VLMEvalKit will use a **judge LLM** to extract answer from the output if you set
 | [**Chat-UniVi-7B[-v1.5]**](https://github.com/PKU-YuanGroup/Chat-UniVi) 🎬 | [**LLaMA-VID-7B**](https://github.com/dvlab-research/LLaMA-VID) 🎬 | [**VideoChat2-HD**](https://huggingface.co/OpenGVLab/VideoChat2_HD_stage4_Mistral_7B) 🎬 | [**PLLaVA-[7B/13B/34B]**](https://huggingface.co/ermu2001/pllava-7b) 🎬 |
 | [**RBDash_72b**](https://github.com/RBDash-Team/RBDash) 🚅🎞️   |  [**xgen-mm-phi3-[interleave/dpo]-r-v1.5**](https://huggingface.co/Salesforce/xgen-mm-phi3-mini-instruct-interleave-r-v1.5) 🚅🎞️    | [**Qwen2-VL-[2B/7B]**](https://github.com/QwenLM/Qwen2-VL)🚅🎞️   |[**slime_[7b/8b/13b]**](https://github.com/yfzhang114/SliME)🎞️     |
 | [**Eagle-X4-[8B/13B]**](https://github.com/NVlabs/EAGLE)🚅🎞️, <br>[**Eagle-X5-[7B/13B/34B]**](https://github.com/NVlabs/EAGLE)🚅🎞️  | [**Moondream1-1.8B**](https://github.com/vikhyat/moondream)🚅, <br>[**Moondream2-1.8B**](https://github.com/vikhyat/moondream)🚅 |[**XinYuan-VL-2B-Instruct**](https://huggingface.co/Cylingo/Xinyuan-VL-2B)🚅🎞️ |[**Llama-3.2-[11B/90B]-Vision-Instruct**](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct)🚅 |
-| [**Kosmos2**](https://huggingface.co/microsoft/kosmos-2-patch14-224)🚅 |
+| [**Kosmos2**](https://huggingface.co/microsoft/kosmos-2-patch14-224)🚅 | [**H2OVL-Mississippi-[0.8B/2B]**](https://huggingface.co/h2oai/h2ovl-mississippi-2b)🚅🎞️ | 
 
 
 🎞️: Support multiple images as inputs.
@@ -139,7 +139,7 @@ Note that some VLMs may not be able to run under certain transformer versions, w
 - **Please use** `transformers==4.36.2` **for**: `Moondream1`.
 - **Please use** `transformers==4.37.0` **for**: `LLaVA series`, `ShareGPT4V series`, `TransCore-M`, `LLaVA (XTuner)`, `CogVLM Series`, `EMU2 Series`, `Yi-VL Series`, `MiniCPM-[V1/V2]`, `OmniLMM-12B`, `DeepSeek-VL series`, `InternVL series`, `Cambrian Series`, `VILA Series`, `Llama-3-MixSenseV1_1`, `Parrot-7B`, `PLLaVA Series`.
 - **Please use** `transformers==4.40.0` **for**: `IDEFICS2`, `Bunny-Llama3`, `MiniCPM-Llama3-V2.5`, `360VL-70B`, `Phi-3-Vision`, `WeMM`.
-- **Please use** `transformers==4.44.0` **for**: `Moondream2`.
+- **Please use** `transformers==4.44.0` **for**: `Moondream2`, `H2OVL series`.
 - **Please use** `transformers==latest` **for**: `LLaVA-Next series`, `PaliGemma-3B`, `Chameleon series`, `Video-LLaVA-7B-HF`, `Ovis series`, `Mantis series`, `MiniCPM-V2.6`, `OmChat-v2.0-13B-sinlge-beta`, `Idefics-3`, `GLM-4v-9B`, `VideoChat2-HD`, `RBDash_72b`, `Llama-3.2 series`, `Kosmos series`.
 
 **Torchvision Version Recommendation:**

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -331,6 +331,11 @@ vintern_series = {
     'Vintern-3B-beta': partial(VinternChat, model_path='5CD-AI/Vintern-3B-beta'),
 }
 
+h2ovl_series = {
+    'h2ovl-mississippi-2b': partial(H2OVLChat, model_path='h2oai/h2ovl-mississippi-2b'),
+    'h2ovl-mississippi-1b': partial(H2OVLChat, model_path='h2oai/h2ovl-mississippi-800m'),
+}
+
 supported_VLM = {}
 
 model_groups = [
@@ -341,8 +346,9 @@ model_groups = [
     cambrian_series, chameleon_series, video_models, ovis_series, vila_series,
     mantis_series, mmalaya_series, phi3_series, xgen_mm_series, qwen2vl_series, 
     slime_series, eagle_series, moondream_series, llama_series, molmo_series, 
-    kosmos_series, points_series, nvlm_series, vintern_series
+    kosmos_series, points_series, nvlm_series, vintern_series, h2ovl_series
 ]
 
 for grp in model_groups:
     supported_VLM.update(grp)
+

--- a/vlmeval/vlm/__init__.py
+++ b/vlmeval/vlm/__init__.py
@@ -55,3 +55,4 @@ from .molmo import molmo
 from .points import POINTS
 from .nvlm import NVLM
 from .vintern_chat import VinternChat
+from .h2ovl_mississippi import H2OVLChat

--- a/vlmeval/vlm/h2ovl_mississippi.py
+++ b/vlmeval/vlm/h2ovl_mississippi.py
@@ -1,0 +1,123 @@
+import torch
+from transformers import AutoTokenizer, AutoModel
+import warnings
+from .base import BaseModel
+from ..smp import *
+from ..dataset import DATASET_TYPE
+import pandas as pd
+import string
+
+
+
+class H2OVLChat(BaseModel):
+
+    INSTALL_REQ = False
+    INTERLEAVE = True
+
+    def __init__(self, model_path='h2oai/h2ovl-mississippi-2b', **kwargs):
+        assert model_path is not None
+
+        self.model_path = model_path
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True, use_fast=False)
+
+        device = torch.cuda.current_device()
+        self.device = device
+        self.model = AutoModel.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            trust_remote_code=True,
+            ).eval()
+        self.model = self.model.to(device)
+        self.image_size = self.model.config.vision_config.image_size
+        self.kwargs = kwargs
+        warnings.warn(f'Following kwargs received: {self.kwargs}, will use as generation config. ')
+
+    def use_custom_prompt(self, dataset):
+        return True
+
+    def build_multi_choice_prompt(self, line, dataset=None):
+        question = line['question']
+        hint = line['hint'] if ('hint' in line and not pd.isna(line['hint'])) else None
+        if hint is not None:
+            question = hint + '\n' + question
+
+        options = {
+            cand: line[cand]
+            for cand in string.ascii_uppercase
+            if cand in line and not pd.isna(line[cand])
+        }
+        for key, item in options.items():
+            question += f'\n{key}. {item}'
+        prompt = question
+
+        if len(options):
+            prompt += '\n请直接回答选项字母。' if cn_string(
+                prompt) else "\nAnswer with the option's letter from the given choices directly."
+        else:
+            prompt += '\n请直接回答问题。' if cn_string(prompt) else '\nAnswer the question directly.'
+
+        return prompt
+
+    def build_prompt(self, line, dataset=None):
+        assert self.use_custom_prompt(dataset)
+        assert dataset is None or isinstance(dataset, str)
+        tgt_path = self.dump_image(line, dataset)
+        kwargs_default = dict(do_sample=False, max_new_tokens=1024, top_p=None, num_beams=1)
+        self.kwargs = kwargs_default
+
+        if dataset is not None and listinstr(['MME'], dataset):
+            question = line['question']
+            prompt = question + ' Answer the question using a single word or phrase.'
+        elif dataset is not None and listinstr(['HallusionBench'], dataset):
+            question = line['question']
+            prompt = question + ' Please answer yes or no. Answer the question using a single word or phrase.'
+        elif dataset is not None and DATASET_TYPE(dataset) == 'MCQ':
+            prompt = self.build_multi_choice_prompt(line, dataset)
+        elif dataset is not None and DATASET_TYPE(dataset) == 'VQA':
+            if 'MathVista' in dataset:
+                prompt = line['question']
+            elif listinstr(['LLaVABench'], dataset):
+                question = line['question']
+                prompt = question + '\nAnswer this question in detail.'
+            elif listinstr(['MMVet'], dataset):
+                prompt = line['question']
+            else:
+                question = line['question']
+                prompt = question + '\nAnswer the question using a single word or phrase.'
+        else:
+            prompt = line['question']
+        message = [dict(type='text', value=prompt)]
+        message.extend([dict(type='image', value=s) for s in tgt_path])
+        return message
+
+    def generate(self, message, dataset=None):
+        image_num = len([x for x in message if x['type'] == 'image'])
+        question = ''
+        image_files = [x['value'] for x in message if x['type'] == 'image']
+        
+        if image_num == 1:
+            question = '<image>\n' + '\n'.join([x['value'] for x in message if x['type'] == 'text'])
+        
+        elif image_num > 1:
+            text_part = ' '.join([x['value'] for x in message if x['type'] == 'text'])
+            image_part = ' '.join([f'<image-{i + 1}>: <image>' for i in range(image_num)])
+            question = image_part + '\n' + text_part
+
+        else:
+            question = '\n'.join([x['value'] for x in message if x['type'] == 'text'])
+            image_files = None 
+
+        response, history = self.model.chat(
+            self.tokenizer,
+            image_files=image_files,
+            question=question,
+            generation_config=self.kwargs,
+            max_tiles=6, 
+            history=None, 
+            return_history=True
+        )
+        
+        return response
+
+    def generate_inner(self, message, dataset=None):
+            return self.generate(message, dataset)

--- a/vlmeval/vlm/h2ovl_mississippi.py
+++ b/vlmeval/vlm/h2ovl_mississippi.py
@@ -8,7 +8,6 @@ import pandas as pd
 import string
 
 
-
 class H2OVLChat(BaseModel):
 
     INSTALL_REQ = False
@@ -25,8 +24,7 @@ class H2OVLChat(BaseModel):
         self.model = AutoModel.from_pretrained(
             model_path,
             torch_dtype=torch.bfloat16,
-            trust_remote_code=True,
-            ).eval()
+            trust_remote_code=True).eval()
         self.model = self.model.to(device)
         self.image_size = self.model.config.vision_config.image_size
         self.kwargs = kwargs
@@ -94,10 +92,10 @@ class H2OVLChat(BaseModel):
         image_num = len([x for x in message if x['type'] == 'image'])
         question = ''
         image_files = [x['value'] for x in message if x['type'] == 'image']
-        
+
         if image_num == 1:
             question = '<image>\n' + '\n'.join([x['value'] for x in message if x['type'] == 'text'])
-        
+
         elif image_num > 1:
             text_part = ' '.join([x['value'] for x in message if x['type'] == 'text'])
             image_part = ' '.join([f'<image-{i + 1}>: <image>' for i in range(image_num)])
@@ -105,19 +103,17 @@ class H2OVLChat(BaseModel):
 
         else:
             question = '\n'.join([x['value'] for x in message if x['type'] == 'text'])
-            image_files = None 
+            image_files = None
 
         response, history = self.model.chat(
             self.tokenizer,
             image_files=image_files,
             question=question,
             generation_config=self.kwargs,
-            max_tiles=6, 
-            history=None, 
-            return_history=True
-        )
-        
+            max_tiles=6,
+            history=None,
+            return_history=True)
         return response
 
     def generate_inner(self, message, dataset=None):
-            return self.generate(message, dataset)
+        return self.generate(message, dataset)


### PR DESCRIPTION
Adding evaluation code for H2OVL Mississippi models. It supports both single and multi-image scenarios, but not videos. 

The PR is lint checked. Following instructions from here: [advanced_guides](https://github.com/open-compass/VLMEvalKit/blob/main/docs/en/advanced_guides/Development.md)