### PR TITLE
[Feat] add modelscope download video datasets

### DIFF
--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -123,7 +123,7 @@ class LongVideoBench(VideoBaseDataset):
 
         if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
             repo_id = "AI-ModelScope/LongVideoBench"
-            
+
         cache_path = get_cache_path(repo_id)
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -121,7 +121,7 @@ class LongVideoBench(VideoBaseDataset):
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+        if modelscope_flag_set():
             repo_id = "AI-ModelScope/LongVideoBench"
 
         cache_path = get_cache_path(repo_id)
@@ -140,7 +140,7 @@ class LongVideoBench(VideoBaseDataset):
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -121,7 +121,7 @@ class LongVideoBench(VideoBaseDataset):
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
             repo_id = "AI-ModelScope/LongVideoBench"
 
         cache_path = get_cache_path(repo_id)
@@ -140,7 +140,7 @@ class LongVideoBench(VideoBaseDataset):
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -121,6 +121,9 @@ class LongVideoBench(VideoBaseDataset):
                     return False
             return True
 
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            repo_id = "AI-ModelScope/LongVideoBench"
+            
         cache_path = get_cache_path(repo_id)
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -137,7 +140,11 @@ class LongVideoBench(VideoBaseDataset):
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
 
-            snapshot_download(repo_id=repo_id, repo_type='dataset')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                snapshot_download(repo_id=repo_id, repo_type='dataset')
             print("All videos are downloaded for LongVideoBench")
 
             if not glob(osp.join(cache_path, "videos")):

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -94,7 +94,10 @@ class MLVU_MCQ(VideoBaseDataset):
                 if not osp.exists(osp.join(pth, item['prefix'], item['video'])):
                     return False
             return True
-
+        
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            repo_id = "AI-ModelScope/MLVU"
+            
         cache_path = get_cache_path(repo_id)
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -123,9 +126,14 @@ class MLVU_MCQ(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            hf_token = os.environ.get('HUGGINGFACE_TOKEN')
-            huggingface_hub.login(hf_token)
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                hf_token = os.environ.get('HUGGINGFACE_TOKEN')
+                huggingface_hub.login(hf_token)
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+                
             generate_tsv(dataset_path)
 
         data_file = osp.join(dataset_path, f'{dataset_name}.tsv')
@@ -297,7 +305,10 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 if not osp.exists(osp.join(pth, item['prefix'], item['video'])):
                     return False
             return True
-
+        
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            repo_id = "AI-ModelScope/MLVU"
+            
         cache_path = get_cache_path(repo_id)
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -325,10 +336,15 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 data_df = pd.DataFrame(self.data_list)
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
-
-            hf_token = os.environ.get('HUGGINGFACE_TOKEN')
-            huggingface_hub.login(hf_token)
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+                
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                hf_token = os.environ.get('HUGGINGFACE_TOKEN')
+                huggingface_hub.login(hf_token)
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            
             generate_tsv(dataset_path)
 
         data_file = osp.join(dataset_path, f'{dataset_name}.tsv')

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -94,10 +94,10 @@ class MLVU_MCQ(VideoBaseDataset):
                 if not osp.exists(osp.join(pth, item['prefix'], item['video'])):
                     return False
             return True
-        
+
         if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
             repo_id = "AI-ModelScope/MLVU"
-            
+
         cache_path = get_cache_path(repo_id)
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -133,7 +133,7 @@ class MLVU_MCQ(VideoBaseDataset):
                 hf_token = os.environ.get('HUGGINGFACE_TOKEN')
                 huggingface_hub.login(hf_token)
                 dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
-                
+
             generate_tsv(dataset_path)
 
         data_file = osp.join(dataset_path, f'{dataset_name}.tsv')
@@ -305,10 +305,10 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 if not osp.exists(osp.join(pth, item['prefix'], item['video'])):
                     return False
             return True
-        
+
         if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
             repo_id = "AI-ModelScope/MLVU"
-            
+
         cache_path = get_cache_path(repo_id)
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -336,7 +336,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 data_df = pd.DataFrame(self.data_list)
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
-                
+
             if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
@@ -344,7 +344,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 hf_token = os.environ.get('HUGGINGFACE_TOKEN')
                 huggingface_hub.login(hf_token)
                 dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
-            
+
             generate_tsv(dataset_path)
 
         data_file = osp.join(dataset_path, f'{dataset_name}.tsv')

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -95,7 +95,7 @@ class MLVU_MCQ(VideoBaseDataset):
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+        if modelscope_flag_set():
             repo_id = "AI-ModelScope/MLVU"
 
         cache_path = get_cache_path(repo_id)
@@ -126,7 +126,7 @@ class MLVU_MCQ(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:
@@ -306,7 +306,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+        if modelscope_flag_set():
             repo_id = "AI-ModelScope/MLVU"
 
         cache_path = get_cache_path(repo_id)
@@ -337,7 +337,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -95,7 +95,7 @@ class MLVU_MCQ(VideoBaseDataset):
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
             repo_id = "AI-ModelScope/MLVU"
 
         cache_path = get_cache_path(repo_id)
@@ -126,7 +126,7 @@ class MLVU_MCQ(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:
@@ -306,7 +306,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
             repo_id = "AI-ModelScope/MLVU"
 
         cache_path = get_cache_path(repo_id)
@@ -337,7 +337,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/mmbench_video.py
+++ b/vlmeval/dataset/mmbench_video.py
@@ -81,7 +81,7 @@ Please directly reply with your response to the only question.
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
         else:
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/mmbench_video.py
+++ b/vlmeval/dataset/mmbench_video.py
@@ -81,7 +81,7 @@ Please directly reply with your response to the only question.
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
         else:
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/mmbench_video.py
+++ b/vlmeval/dataset/mmbench_video.py
@@ -81,7 +81,11 @@ Please directly reply with your response to the only question.
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
         else:
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
             unwrap_hf_pkl(dataset_path)
         self.video_path = osp.join(dataset_path, 'video/')
         data_file = osp.join(dataset_path, f'{dataset_name}.tsv')

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -96,7 +96,7 @@ Based on your observations, select the best option that accurately addresses the
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
             repo_id = 'modelscope/MVBench'
 
         cache_path = get_cache_path(repo_id, branch='main')
@@ -171,7 +171,7 @@ Based on your observations, select the best option that accurately addresses the
                                     except Exception as e:
                                         print(f"Error moving {item_path} to {target_path}: {e}")
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id, revision='master')
             else:
@@ -464,7 +464,7 @@ Based on your observations, select the best option that accurately addresses the
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
             repo_id = 'modelscope/MVBench'
 
         cache_path = get_cache_path(repo_id, branch='video')
@@ -493,7 +493,7 @@ Based on your observations, select the best option that accurately addresses the
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id, revision='video')
             else:

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -98,7 +98,7 @@ Based on your observations, select the best option that accurately addresses the
 
         if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
             repo_id = 'modelscope/MVBench'
-            
+
         cache_path = get_cache_path(repo_id, branch='main')
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -466,7 +466,7 @@ Based on your observations, select the best option that accurately addresses the
 
         if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
             repo_id = 'modelscope/MVBench'
-            
+
         cache_path = get_cache_path(repo_id, branch='video')
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -96,7 +96,7 @@ Based on your observations, select the best option that accurately addresses the
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+        if modelscope_flag_set():
             repo_id = 'modelscope/MVBench'
 
         cache_path = get_cache_path(repo_id, branch='main')
@@ -171,7 +171,7 @@ Based on your observations, select the best option that accurately addresses the
                                     except Exception as e:
                                         print(f"Error moving {item_path} to {target_path}: {e}")
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id, revision='master')
             else:
@@ -464,7 +464,7 @@ Based on your observations, select the best option that accurately addresses the
                     return False
             return True
 
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+        if modelscope_flag_set():
             repo_id = 'modelscope/MVBench'
 
         cache_path = get_cache_path(repo_id, branch='video')
@@ -493,7 +493,7 @@ Based on your observations, select the best option that accurately addresses the
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id, revision='video')
             else:

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -96,6 +96,9 @@ Based on your observations, select the best option that accurately addresses the
                     return False
             return True
 
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            repo_id = 'modelscope/MVBench'
+            
         cache_path = get_cache_path(repo_id, branch='main')
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
@@ -148,7 +151,6 @@ Based on your observations, select the best option that accurately addresses the
                 data_df.to_csv(data_file, sep='\t', index=False)
 
             def move_files(pth):
-                # special for mvbench/data0613 supplementary data
                 src_folder = os.path.join(pth, 'video/data0613')
                 if not os.path.exists(src_folder):
                     return
@@ -162,11 +164,20 @@ Based on your observations, select the best option that accurately addresses the
                                     item_path = os.path.join(subsubdir_path, item)
                                     target_folder = os.path.join(pth, 'video', subdir, subsubdir)
                                     if not os.path.exists(target_folder):
-                                        shutil.move(item_path, target_folder)
+                                        os.makedirs(target_folder)
+                                    target_path = os.path.join(target_folder, item)
+                                    try:
+                                        shutil.move(item_path, target_path)
+                                    except Exception as e:
+                                        print(f"Error moving {item_path} to {target_path}: {e}")
 
-            hf_token = os.environ.get('HUGGINGFACE_TOKEN')
-            huggingface_hub.login(hf_token)
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id, revision='master')
+            else:
+                hf_token = os.environ.get('HUGGINGFACE_TOKEN')
+                huggingface_hub.login(hf_token)
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
             unzip_hf_zip(dataset_path)
             move_files(dataset_path)
             generate_tsv(dataset_path)
@@ -423,7 +434,7 @@ Based on your observations, select the best option that accurately addresses the
 
 class MVBench_MP4(VideoBaseDataset):
 
-    MP4_MD5 = '7b4608045347904c28c153015a7a2b6b'
+    MP4_MD5 = '5c8c6f8b7972c2de65a629590f7c42f5'
     SYS = """Carefully watch the video and pay attention to the cause and sequence of events, \
 the detail and movement of objects, and the action and pose of persons. \
 Based on your observations, select the best option that accurately addresses the question.
@@ -453,13 +464,16 @@ Based on your observations, select the best option that accurately addresses the
                     return False
             return True
 
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            repo_id = 'modelscope/MVBench'
+            
         cache_path = get_cache_path(repo_id, branch='video')
         if cache_path is not None and check_integrity(cache_path):
             dataset_path = cache_path
         else:
             def generate_tsv(pth):
                 data_file = osp.join(pth, f'{dataset_name}.tsv')
-                if os.path.exists(data_file) and md5(data_file) == self.MD5:
+                if os.path.exists(data_file) and md5(data_file) == self.MP4_MD5:
                     return
                 json_data_path = os.path.join(dataset_path, 'test.json')
                 json_data = load(json_data_path)
@@ -479,9 +493,13 @@ Based on your observations, select the best option that accurately addresses the
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            hf_token = os.environ.get('HUGGINGFACE_TOKEN')
-            huggingface_hub.login(hf_token)
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset', revision='video')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id, revision='video')
+            else:
+                hf_token = os.environ.get('HUGGINGFACE_TOKEN')
+                huggingface_hub.login(hf_token)
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset', revision='video')
             generate_tsv(dataset_path)
 
         data_file = osp.join(dataset_path, f'{dataset_name}.tsv')

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -130,8 +130,12 @@ class TempCompass_MCQ(VideoBaseDataset):
                 data_df = pd.DataFrame(self.data_list)
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
-
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+                
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
             read_parquet(dataset_path)
             unzip_videos(dataset_path)
             generate_tsv(dataset_path)
@@ -322,7 +326,11 @@ class TempCompass_Captioning(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
             read_parquet(dataset_path)
             unzip_videos(dataset_path)
             generate_tsv(dataset_path)
@@ -510,7 +518,11 @@ class TempCompass_YorN(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
             read_parquet(dataset_path)
             unzip_videos(dataset_path)
             generate_tsv(dataset_path)

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -131,7 +131,7 @@ class TempCompass_MCQ(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:
@@ -326,7 +326,7 @@ class TempCompass_Captioning(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:
@@ -518,7 +518,7 @@ class TempCompass_YorN(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -130,7 +130,7 @@ class TempCompass_MCQ(VideoBaseDataset):
                 data_df = pd.DataFrame(self.data_list)
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
-                
+
             if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -131,7 +131,7 @@ class TempCompass_MCQ(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:
@@ -326,7 +326,7 @@ class TempCompass_Captioning(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:
@@ -518,7 +518,7 @@ class TempCompass_YorN(VideoBaseDataset):
                 data_df = data_df.assign(index=range(len(data_df)))
                 data_df.to_csv(data_file, sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/video_base.py
+++ b/vlmeval/dataset/video_base.py
@@ -76,7 +76,7 @@ class VideoBaseDataset:
             indices = [int(i * step_size) for i in range(required_frames)]
 
             # 提取帧并保存
-            frame_paths = self.frame_paths_fps(video, len(izhendices), fps)
+            frame_paths = self.frame_paths_fps(video, len(indices), fps)
             flag = np.all([osp.exists(p) for p in frame_paths])
             if flag:
                 return frame_paths

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -139,8 +139,12 @@ Respond with only the letter (A, B, C, or D) of the correct option.
                                        'sub_category', 'task_type', 'subtitle_path', 'question', 'answer']]
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
-
-            dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+            
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
             unzip_hf_zip(dataset_path)
             generate_tsv(dataset_path)
 

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -139,7 +139,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
                                        'sub_category', 'task_type', 'subtitle_path', 'question', 'answer']]
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
-            
+
             if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -140,7 +140,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -140,7 +140,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
                 data_file.to_csv(osp.join(pth, f'{dataset_name}.tsv'), sep='\t', index=False)
 
-            if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+            if modelscope_flag_set():
                 from modelscope import dataset_snapshot_download
                 dataset_path = dataset_snapshot_download(dataset_id=repo_id)
             else:

--- a/vlmeval/smp/misc.py
+++ b/vlmeval/smp/misc.py
@@ -74,16 +74,24 @@ def bincount(lst):
 
 def get_cache_path(repo_id, branch='main', repo_type='datasets'):
     try:
-        from .file import HFCacheRoot
-        cache_path = HFCacheRoot()
-        org, repo_name = repo_id.split('/')
-        repo_path = Path(osp.join(cache_path, f'{repo_type}--{org}--{repo_name}/'))
-        hf_cache_info = _scan_cached_repo(repo_path=repo_path)
-        revs = {r.refs: r for r in hf_cache_info.revisions}
-        if branch is not None:
-            revs = {refs: r for refs, r in revs.items() if branch in refs}
-        rev2keep = max(revs.values(), key=lambda r: r.last_modified)
-        return str(rev2keep.snapshot_path)
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+            from modelscope.hub.file_download import create_temporary_directory_and_cache
+            if repo_type == 'datasets':
+                repo_type = 'dataset'
+            _, cache = create_temporary_directory_and_cache(model_id=repo_id, repo_type=repo_type)
+            cache_path = cache.get_root_location()
+            return cache_path
+        else:
+            from .file import HFCacheRoot
+            cache_path = HFCacheRoot()
+            org, repo_name = repo_id.split('/')
+            repo_path = Path(osp.join(cache_path, f'{repo_type}--{org}--{repo_name}/'))
+            hf_cache_info = _scan_cached_repo(repo_path=repo_path)
+            revs = {r.refs: r for r in hf_cache_info.revisions}
+            if branch is not None:
+                revs = {refs: r for refs, r in revs.items() if branch in refs}
+            rev2keep = max(revs.values(), key=lambda r: r.last_modified)
+            return str(rev2keep.snapshot_path)
     except Exception as e:
         import logging
         logging.warning(f'{type(e)}: {e}')

--- a/vlmeval/smp/misc.py
+++ b/vlmeval/smp/misc.py
@@ -24,6 +24,11 @@ from huggingface_hub import scan_cache_dir
 from huggingface_hub.utils._cache_manager import _scan_cached_repo
 from sty import fg, bg, ef, rs
 
+
+def modelscope_flag_set():
+    return os.environ.get('VLMEVALKIT_USE_MODELSCOPE', None) in ['1', 'True']
+
+
 def process_punctuation(inText):
     import re
     outText = inText
@@ -74,7 +79,7 @@ def bincount(lst):
 
 def get_cache_path(repo_id, branch='main', repo_type='datasets'):
     try:
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
+        if modelscope_flag_set():
             from modelscope.hub.file_download import create_temporary_directory_and_cache
             if repo_type == 'datasets':
                 repo_type = 'dataset'

--- a/vlmeval/smp/misc.py
+++ b/vlmeval/smp/misc.py
@@ -74,7 +74,7 @@ def bincount(lst):
 
 def get_cache_path(repo_id, branch='main', repo_type='datasets'):
     try:
-        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False')=='True':
+        if os.environ.get('VLMEVALKIT_USE_MODELSCOPE', 'False') == 'True':
             from modelscope.hub.file_download import create_temporary_directory_and_cache
             if repo_type == 'datasets':
                 repo_type = 'dataset'


### PR DESCRIPTION
Set env `VLMEVALKIT_USE_MODELSCOPE=True` and `pip install modelscope`

you can download video benchmarks from modelscope automatically, which supports:

- [x] MVBench_MP4
- [x] MLVU_OpenEnded
- [x] MLVU_MCQ
- [x] LongVideoBench
- [x] TempCompass_MCQ
- [x] TempCompass_Captioning
- [x] TempCompass_YorN
- [x] Video-MME
- [x] MVBench
- [x] MMBench-Video

all dataset downloads have been tested.