### PR TITLE
Fix wrong md5 of WorldMedQA-V

### DIFF
--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -143,7 +143,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MLLMGuard_DS': '975fc0dd7119386e198c37d71e274b3f',
         'BLINK': '3b6649b6a662184ea046908e5506260e',
         'TaskMeAnything_v1_imageqa_random': '023fef69e2ca21827afb77c5ec3bc889',
-        'WorldMedQA-V': 'db504a238ac8b708f3a678882c23c3d5'
+        'WorldMedQA-V': '441e63875e30c87f5750528b57b41285'
     }
 
     DATASET_URL.update(MMMB_URLS)


### PR DESCRIPTION
An incorrect md5 will cause the dataset to be downloaded repeatedly for each test