### PR TITLE
Correct the configuration of LLaVA-CoT

### DIFF
--- a/vlmeval/vlm/llama_vision.py
+++ b/vlmeval/vlm/llama_vision.py
@@ -79,7 +79,7 @@ class llama_vision(BaseModel):
 
         self.device = 'cuda'
         self.processor = AutoProcessor.from_pretrained(model_path)
-        if 'Instruct' in model_path:
+        if 'Instruct' in model_path or 'cot' in model_path or 'CoT' in model_path:
             kwargs_default = dict(do_sample=True, temperature=0.6, top_p=0.9)
         else:
             kwargs_default = dict(do_sample=False, max_new_tokens=512, temperature=0.0, top_p=None, num_beams=1)
@@ -200,5 +200,7 @@ class llama_vision(BaseModel):
                 self.kwargs['max_new_tokens'] = 128
             else:
                 self.kwargs['max_new_tokens'] = 512
+        if "cot" in self.model_name or "CoT" in self.model_name:
+            self.kwargs['max_new_tokens'] = 2048
         output = self.model.generate(**inputs, **self.kwargs)
         return self.processor.decode(output[0][inputs['input_ids'].shape[1]:]).replace('<|eot_id|>', '')


### PR DESCRIPTION
First of all, we sincerely appreciate the work of VLMEvalKit and the tremendous contributions it has made to the entire VLM community! However, the current configuration of LLaVA-CoT (e.g., max_new_tokens) is incorrect, leading to significant deviations in the benchmark test results. This PR aims to correct the configuration of LLaVA-CoT.