### PR TITLE
[Model] Add SmolVLM-256M and SmolVLM-500M and fix prompts for benchmarks

### DIFF
--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -294,9 +294,11 @@ idefics_series = {
 }
 
 smolvlm_series = {
+    'SmolVLM-256M': partial(SmolVLM, model_path='HuggingFaceTB/SmolVLM-256M-Instruct'),
+    'SmolVLM-500M': partial(SmolVLM, model_path='HuggingFaceTB/SmolVLM-500M-Instruct'),
     'SmolVLM': partial(SmolVLM, model_path='HuggingFaceTB/SmolVLM-Instruct'),
     'SmolVLM-DPO': partial(SmolVLM, model_path='HuggingFaceTB/SmolVLM-Instruct-DPO'),
-    'SmolVLM-Synthetic': partial(SmolVLM, model_path='HuggingFaceTB/SmolVLM-Instruct'),
+    'SmolVLM-Synthetic': partial(SmolVLM, model_path='HuggingFaceTB/SmolVLM-Synthetic'),
 }
 
 instructblip_series = {


### PR DESCRIPTION
I added the paths for SmolVLM-256M and SmolVLM-500M. Additionally, I worked on the prompts for different benchmarks to match our internal evaluations. In particular, ChartQA went from 27% to 72% when we prompt the model to follow certain formatting rules. 