### PR TITLE
Fixed the cache_path in pixtral.py

### DIFF
--- a/vlmeval/vlm/pixtral.py
+++ b/vlmeval/vlm/pixtral.py
@@ -26,7 +26,7 @@ class Pixtral(BaseModel):
         else:
             if get_cache_path(model_path) is None:
                 snapshot_download(repo_id=model_path)
-            cache_path = get_cache_path(self.model_path)
+            cache_path = get_cache_path(self.model_path, repo_type='models')
 
         self.tokenizer = MistralTokenizer.from_file(f'{cache_path}/tekken.json')
         model = Transformer.from_folder(cache_path, device='cpu')


### PR DESCRIPTION
Hi,

Running evaluation of "Pixtral-12B" on any dataset throws an error saying:
```bash
File "/VLMEvalKit/vlmeval/vlm/pixtral.py", line 31, in __init__
    self.tokenizer = MistralTokenizer.from_file(f'{cache_path}/tekken.json')
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.11/site-packages/mistral_common/tokens/tokenizers/mistral.py", line 190, in from_file
    raise TokenizerException(f"Unrecognized tokenizer file: {tokenizer_filename}")
mistral_common.exceptions.TokenizerException: Unrecognized tokenizer file: None/tekken.json
ERROR - run.py: main - 411: Unrecognized tokenizer file: None/tekken.json, skipping this combination.
```

The reason is the missing argument `repo_type='models'` when calling `get_cache_path` function