### PR TITLE
Updated the generate in LLaVA-OneVision-HF

### DIFF
--- a/vlmeval/vlm/llava/llava.py
+++ b/vlmeval/vlm/llava/llava.py
@@ -820,7 +820,6 @@ class LLaVA_OneVision_HF(BaseModel):
             }
         ]
         prompt = self.processor.apply_chat_template(conversation, add_generation_prompt=True)
-        print(prompt)
         inputs = self.processor(images=images, text=prompt, return_tensors="pt").to('cuda', torch.float16)
 
         output = self.model.generate(**inputs, max_new_tokens=512)

--- a/vlmeval/vlm/llava/llava.py
+++ b/vlmeval/vlm/llava/llava.py
@@ -824,9 +824,7 @@ class LLaVA_OneVision_HF(BaseModel):
         inputs = self.processor(images=images, text=prompt, return_tensors="pt").to('cuda', torch.float16)
 
         output = self.model.generate(**inputs, max_new_tokens=512)
-        if self.model_path == "NCSOFT/VARCO-VISION-14B-HF":
-            return self.processor.decode(output[0][inputs.input_ids.shape[1]:], skip_special_tokens=True)
-        return self.processor.decode(output[0], skip_special_tokens=True)
+        return self.processor.decode(output[0][inputs.input_ids.shape[1]:], skip_special_tokens=True)
 
     def generate_inner_video(self, message, dataset=None):
         content, text_content, visual_content, videos = "", "", "", []
@@ -863,7 +861,7 @@ class LLaVA_OneVision_HF(BaseModel):
 
         inputs = self.processor(videos=video_frames, text=prompt, return_tensors="pt").to('cuda', torch.float16)
         output = self.model.generate(**inputs, max_new_tokens=512)
-        return self.processor.decode(output[0], skip_special_tokens=True)
+        return self.processor.decode(output[0][inputs.input_ids.shape[1]:], skip_special_tokens=True)
 
     def load_video(self, video_path, max_frames_num, fps=1, force_sample=False):
         from decord import VideoReader, cpu

--- a/vlmeval/vlm/pixtral.py
+++ b/vlmeval/vlm/pixtral.py
@@ -26,7 +26,7 @@ class Pixtral(BaseModel):
         else:
             if get_cache_path(model_path) is None:
                 snapshot_download(repo_id=model_path)
-            cache_path = get_cache_path(self.model_path)
+            cache_path = get_cache_path(self.model_path, repo_type='models')
 
         self.tokenizer = MistralTokenizer.from_file(f'{cache_path}/tekken.json')
         model = Transformer.from_folder(cache_path, device='cpu')


### PR DESCRIPTION
Hi again,

I noticed that the LLaVA-OneVision-HF returns the whole prompt + model's generated tokens, so I just truncated the output to only new generated tokens for all models with this class (previously it was just for `NCSOFT/VARCO-VISION-14B-HF`).

This is necessary for correct evaluation of stored predictions.