### PR TITLE
[bug-fix] move barrier to the beginning of the for-loop

### DIFF
--- a/run.py
+++ b/run.py
@@ -211,6 +211,9 @@ def main():
             model = build_model_from_config(cfg['model'], model_name)
 
         for _, dataset_name in enumerate(args.data):
+            if world_size > 1:
+                dist.barrier()
+
             try:
                 result_file_base = f'{model_name}_{dataset_name}.xlsx'
 
@@ -428,9 +431,6 @@ def main():
                 logger.exception(f'Model {model_name} x Dataset {dataset_name} combination failed: {e}, '
                                  'skipping this combination.')
                 continue
-
-            if world_size > 1:
-                dist.barrier()
 
     if world_size > 1:
         dist.destroy_process_group()


### PR DESCRIPTION
current implementation will not work if user use infer only mode under multiple processes