### PR TITLE
[bug-fix] Fix bug in extracting dataset name from eval file name

### DIFF
--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -353,9 +353,8 @@ def fetch_aux_files(eval_file):
         model_name = osp.basename(osp.dirname(file_root))
     else:
         model_name = eval_id
-
-    suffix = file_name.split('.')[-1]
-    dataset_name = file_name.split('.')[0][len(model_name) + 1:]
+    
+    dataset_name = osp.splitext(file_name)[0][len(model_name) + 1:]
     from vlmeval.dataset import SUPPORTED_DATASETS
     to_handle = []
     for d in SUPPORTED_DATASETS:


### PR DESCRIPTION
The original code failed to extract the dataset name correctly when the model name contains a period (e.g., "Qwen2.5-VL-3B"). This issue has been fixed by using the standard method to extract the file name without the extension.

The `suffix` variable isn't used and it's removed.