### PR TITLE
fix(qwen2.5vl) qwen2.5vl evaluation do not use custom prompt

### DIFF
--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -398,9 +398,12 @@ qwen2vl_series = {
     'Qwen2-VL-2B-Instruct-GPTQ-Int4': partial(Qwen2VLChat, model_path='Qwen/Qwen2-VL-2B-Instruct-GPTQ-Int4', min_pixels=1280*28*28, max_pixels=16384*28*28),
     'Qwen2-VL-2B-Instruct-GPTQ-Int8': partial(Qwen2VLChat, model_path='Qwen/Qwen2-VL-2B-Instruct-GPTQ-Int8', min_pixels=1280*28*28, max_pixels=16384*28*28),
     'XinYuan-VL-2B-Instruct': partial(Qwen2VLChat, model_path='Cylingo/Xinyuan-VL-2B', min_pixels=1280*28*28, max_pixels=16384*28*28),
-    'Qwen2.5-VL-3B': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-3B-Instruct', min_pixels=1280*28*28, max_pixels=16384*28*28),
-    'Qwen2.5-VL-7B': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-7B-Instruct', min_pixels=1280*28*28, max_pixels=16384*28*28),
-    'Qwen2.5-VL-72B': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-72B-Instruct', min_pixels=1280*28*28, max_pixels=16384*28*28),
+    'Qwen2.5-VL-3B-Instruct': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-3B-Instruct', min_pixels=1280*28*28, max_pixels=16384*28*28, use_custom_prompt=False),
+    'Qwen2.5-VL-3B-Instruct-AWQ': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-3B-Instruct-AWQ', min_pixels=1280*28*28, max_pixels=16384*28*28, use_custom_prompt=False),
+    'Qwen2.5-VL-7B-Instruct': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-7B-Instruct', min_pixels=1280*28*28, max_pixels=16384*28*28, use_custom_prompt=False),
+    'Qwen2.5-VL-7B-Instruct-AWQ': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-7B-Instruct-AWQ', min_pixels=1280*28*28, max_pixels=16384*28*28, use_custom_prompt=False),
+    'Qwen2.5-VL-72B-Instruct': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-72B-Instruct', min_pixels=1280*28*28, max_pixels=16384*28*28, use_custom_prompt=False),
+    'Qwen2.5-VL-72B-Instruct-AWQ': partial(Qwen2VLChat, model_path='Qwen/Qwen2.5-VL-72B-Instruct-AWQ', min_pixels=1280*28*28, max_pixels=16384*28*28, use_custom_prompt=False),
 }
 
 slime_series = {


### PR DESCRIPTION
The qwen2.5vl evaluation did not use custom prompts but instead maintained consistency with the ones in the official repository.