### PR TITLE
Integrate 2860 VQA Image Cases from VLM2Bench

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -22,6 +22,7 @@ from .mmlongbench import MMLongBench
 from .dude import DUDE
 from .slidevqa import SlideVQA
 from .vl_rewardbench import VLRewardBench
+from .vlm2bench import VLM2Bench
 
 from .mmbench_video import MMBenchVideo
 from .videomme import VideoMME
@@ -142,7 +143,7 @@ IMAGE_DATASET = [
     GMAIMMBenchDataset, MMERealWorld, HRBenchDataset, CRPE, MathVerse, NaturalBenchDataset,
     MIABench, OlympiadBench, WildVision, MMMath, QSpatial, Dynamath, MMGenBench, VizWiz, MMNIAH,
     CMMMU, VLRewardBench, WeMath, LogicVista, MMMUProDataset, CreationMMBenchDataset,
-    ImageShortQADataset, MMAlignBench, OmniDocBench
+    ImageShortQADataset, MMAlignBench, OmniDocBench, VLM2Bench
 ]
 
 

--- a/vlmeval/dataset/utils/vlm2bench.py
+++ b/vlmeval/dataset/utils/vlm2bench.py
@@ -1,0 +1,227 @@
+"""
+vlm2bench utils for eval
+
+Input sample format: contains the following fields:
+  - index        (original q_id)
+  - question
+  - answer       (correct answer, i.e., gt_answer)
+  - category
+  - prediction   (model output, i.e., model answer)
+
+The categories of each sub-task include:
+  gc-mat, gc-trk, oc-cpr, pc-cpr   --> tf pair task (the last character of the same index distinguishes positive or negative with _p or _n)
+  oc-cnt, pc-cnt                  --> cnt type
+  oc-grp, pc-grp                  --> grp (MCQ) type
+"""
+
+import os
+import re
+import json
+from collections import defaultdict
+from PIL import Image
+
+##########################################
+# 1. General Functions
+##########################################
+def common_doc_to_text(sample, **kwargs):
+    """
+    General: directly return the "question" field from the sample.
+    """
+    return sample.get("question", "")
+
+def common_doc_to_target(sample, **kwargs):
+    """
+    General: return the "answer" field from the sample as the correct answer.
+    """
+    return sample.get("answer", "")
+
+def common_process_results(results):
+    """
+    Since the input file fields are already index, question, answer, category, prediction,
+    directly return the original results without field mapping conversion.
+    """
+    return results
+
+##########################################
+# 2. TF Pair Task Evaluation (suitable for gc-mat, gc-trk, oc-cpr, pc-cpr)
+##########################################
+def parse_tf_answer(model_answer):
+    """
+    Extract 'T' or 'F' from the tf type model_answer.
+    Supports formats like 'T', 'F', 'True', 'False'; returns an error flag if multiple matches are found.
+    """
+    pattern = re.compile(r'\b(t|f|true|false)\b', re.IGNORECASE)
+    matches = pattern.findall(model_answer)
+    extracted = [match.upper()[0] for match in matches]
+    if len(extracted) == 1:
+        return extracted[0], None
+    elif len(extracted) > 1:
+        return None, 'multiple_answers_found'
+    else:
+        return None, 'no_answer_found'
+
+def tf_pair_aggregate_accuracy(results):
+    """
+    Aggregate evaluation results for the tf pair task.
+    Group by index, where the index format is like "pc-cpr_1_p" and "pc-cpr_1_n",
+    taking the prefix (removing the last _p or _n) as the identifier for the same group.
+    If all records in the group have predictions that match the answer ("T" or "F"), the group is considered correct,
+    returning the ratio of correct groups to total groups.
+    """
+    groups = defaultdict(list)
+    for item in results:
+        idx = item.get("index", "")
+        if "_" not in idx:
+            continue
+        base_id = "_".join(idx.split("_")[:-1])
+        groups[base_id].append(item)
+    total_groups = len(groups)
+    correct_groups = 0
+    for base_id, items in groups.items():
+        # At least two records are required in the group
+        if len(items) < 2:
+            continue
+        group_correct = True
+        for item in items:
+            gt = item.get("answer", "").strip().upper()
+            pred = item.get("prediction", "").strip().upper()
+            parsed, err = parse_tf_answer(pred)
+            if parsed != gt:
+                group_correct = False
+                break
+        if group_correct:
+            correct_groups += 1
+    return (correct_groups / total_groups) * 100 if total_groups > 0 else 0
+
+##########################################
+# 3. CNT Task Evaluation (suitable for oc-cnt, pc-cnt)
+##########################################
+NUM_WORDS = {
+    "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+    "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
+    "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18,
+    "nineteen": 19, "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+    "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90, "hundred": 100, "thousand": 1000,
+}
+PENALTY_FACTOR = 10
+L_MAX = 4
+
+def words_to_num(s):
+    s = s.lower().replace('-', ' ').replace('and', ' ')
+    tokens = s.split()
+    total = 0
+    current = 0
+    for token in tokens:
+        if token in NUM_WORDS:
+            scale = NUM_WORDS[token]
+            if scale in (100, 1000):
+                if current == 0:
+                    current = 1
+                current *= scale
+                total += current
+                current = 0
+            else:
+                current += scale
+        else:
+            return None
+    total += current
+    return total if total != 0 else None
+
+def extract_numbers(text):
+    text = text.lower()
+    digit_numbers = re.findall(r'\d+', text)
+    digit_numbers = [int(num) for num in digit_numbers]
+    word_numbers = []
+    pattern = re.compile(
+        r'\b(zero|one|two|three|four|five|six|seven|eight|nine|ten|'
+        r'eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|'
+        r'eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|'
+        r'eighty|ninety|hundred|thousand)\b', re.IGNORECASE)
+    matches = pattern.findall(text)
+    if matches:
+        word_phrase = ' '.join(matches)
+        num = words_to_num(word_phrase)
+        if num is not None:
+            word_numbers.append(num)
+    return digit_numbers + word_numbers
+
+def parse_model_answer(model_answer):
+    numbers = extract_numbers(model_answer)
+    if len(numbers) == 1:
+        return numbers[0]
+    else:
+        return None
+
+def cnt_aggregate_metric(results):
+    """
+    Aggregate evaluation results for the CNT task.
+    For each sample, parse the numbers in the prediction and compare them with the answer (which should be an integer),
+    calculate the score based on the error, and return the average score of all samples.
+    """
+    total_count = 0
+    total_norm_score = 0.0
+    for item in results:
+        try:
+            gt = int(item.get("answer", None))
+        except:
+            gt = None
+        if gt is None:
+            continue
+        total_count += 1
+        model_ans_str = str(item.get("prediction", "")).strip()
+        # Try to use the image_seq_len provided in the record; if not, default to 2
+        image_seq_len = item.get("image_seq_len", 2)
+        try:
+            image_seq_len = int(image_seq_len)
+        except:
+            image_seq_len = 2
+
+        parsed = parse_model_answer(model_ans_str)
+        if parsed is None:
+            norm_score = 0.0
+        else:
+            raw_diff = abs(parsed - gt)
+            if raw_diff == 0:
+                norm_score = 100.0
+            else:
+                max_error = max(gt - 1, image_seq_len - gt)
+                if max_error <= 0:
+                    max_error = 1
+                relative_error = raw_diff / max_error
+                weight = L_MAX / image_seq_len
+                penalty = weight * (relative_error ** (1.0 / PENALTY_FACTOR))
+                norm_score = 100 * (1 - penalty) if penalty < 1 else 0.0
+        total_norm_score += norm_score
+    return total_norm_score / total_count if total_count > 0 else 0
+
+
+##########################################
+# 4. GRP Task Evaluation (suitable for oc-grp, pc-grp)
+##########################################
+def grp_clean_answer(answer):
+    if ")" in answer:
+        return answer.split(")")[0].strip()
+    return answer.strip()
+
+def grp_count_options(answer):
+    return len(re.findall(r'\([A-Z]\)', answer))
+
+def grp_aggregate_accuracy(results):
+    """
+    Aggregate evaluation results for the GRP task (MCQ).
+    For each sample, if multiple options appear in the prediction, it is considered incorrect; otherwise, compare the cleaned answer letters.
+    Return the accuracy.
+    """
+    total = 0
+    correct = 0
+    for item in results:
+        total += 1
+        model_ans = item.get("prediction", "")
+        gt_ans = item.get("answer", "")
+        if grp_count_options(model_ans) > 1:
+            continue
+        if grp_clean_answer(model_ans) == grp_clean_answer(gt_ans):
+            correct += 1
+    return (correct / total * 100) if total > 0 else 0
+

--- a/vlmeval/dataset/vlm2bench.py
+++ b/vlmeval/dataset/vlm2bench.py
@@ -1,0 +1,122 @@
+import os
+import pandas as pd
+from .image_base import ImageBaseDataset
+from .utils.vlm2bench import (
+    common_process_results,
+    tf_pair_aggregate_accuracy,
+    cnt_aggregate_metric,
+    grp_aggregate_accuracy,
+)
+
+
+class VLM2Bench(ImageBaseDataset):
+    TYPE = "VQA"
+
+    DATASET_URL = {
+        "VLM2Bench": 'https://huggingface.co/datasets/Sterzhang/vlm2-bench/resolve/main/VLM2Bench_img.tsv' # all 2860 image cases from VLM2Bench huggingface repo
+    }
+    # DATASET_MD5
+    DATASET_MD5 = {'VLM2Bench': '587b658f297aaed0b1be8d519399b3f3'}
+
+    def build_prompt(self, line):
+        """
+        Build multimodal input:
+        - If the record does not have "image_path", generate the image_path list based on the "image" field (stored as a regular list of image encodings),
+          and update the "image" field to contain a list of multiple image paths.
+        - Call dump_image to process the image and image_path fields to obtain all local paths of the images.
+        - Construct the text prompt in the format "Question: {question}".
+        - Encapsulate all image paths as image messages and append the text message, returning the final multimodal message list.
+        """
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        # If there is no image_path, generate the image_path list based on the image field
+        if "image_path" not in line:
+            img_field = line.get("image")
+            # Assume the image field is already a regular list of image encodings, not a JSON-encoded string
+            image_paths = [f"{line['index']}_{i}.jpg" for i in range(len(img_field))]
+            line["image_path"] = image_paths
+            # Also update the image field to the list of image encodings
+            line["image"] = img_field
+
+        # Call dump_image (implemented in the parent class) to process the image and image_path fields, returning the list of local image paths
+        img_paths = self.dump_image(line)
+        if not isinstance(img_paths, list):
+            img_paths = [img_paths]
+
+        # Construct the text prompt (only containing the question)
+        prompt = f"Question: {line['question']}\n"
+
+        # Encapsulate all image paths as image messages and append the text message
+        msgs = [{"type": "image", "value": p} for p in img_paths]
+        msgs.append({"type": "text", "value": prompt})
+        return msgs
+
+    @classmethod
+    def evaluate(cls, eval_file, **judge_kwargs):
+        """
+        Evaluation function:
+        - Automatically read the model prediction result file (xlsx or TSV), which contains fields: index, question, answer, category, prediction
+        - Directly use the original fields for evaluation without additional conversion;
+        - For categories "oc-cnt" or "pc-cnt", calculate image_seq_len based on the "image" field (stored as a regular multi-image encoding) 
+          and write it into each record;
+        - Group by category and use different evaluation functions to calculate metrics for each sub-task:
+                • tf pair: suitable for gc-mat, gc-trk, oc-cpr, pc-cpr
+                • cnt: suitable for oc-cnt, pc-cnt
+                • grp: suitable for oc-grp, pc-grp
+        - Write the scores of each sub-task to a CSV file and return a DataFrame.
+        """
+        model = judge_kwargs.get("model")
+        if model:
+            suffix = eval_file.split('.')[-1]
+            storage = eval_file.replace(f'.{suffix}', f'_{model}.xlsx')
+            score_file = eval_file.replace(f'.{suffix}', f'_{model}_score.csv')
+            tmp_file = eval_file.replace(f'.{suffix}', f'_{model}.pkl')
+            if os.path.exists(storage):
+                if storage.lower().endswith(".xlsx"):
+                    data = pd.read_excel(storage)
+                else:
+                    data = pd.read_csv(storage, sep="\t", encoding="latin1", engine="python")
+            else:
+                if eval_file.lower().endswith(".xlsx"):
+                    data = pd.read_excel(eval_file)
+                else:
+                    data = pd.read_csv(eval_file, sep="\t", encoding="latin1", engine="python")
+        else:
+            if eval_file.lower().endswith(".xlsx"):
+                data = pd.read_excel(eval_file)
+            else:
+                data = pd.read_csv(eval_file, sep="\t", encoding="latin1", engine="python")
+        
+        results = data.to_dict(orient="records")
+        processed = common_process_results(results)
+        
+        # For cnt category, calculate image_seq_len (i.e., number of images) based on the list of image encodings stored in the image field
+        for rec in processed:
+            if rec.get("category", "").lower() in ["oc-cnt", "pc-cnt"]:
+                try:
+                    rec["image_seq_len"] = len(rec["image"])
+                except Exception as e:
+                    rec["image_seq_len"] = 2
+
+        eval_scores = {}
+        for cat in sorted(set([r["category"] for r in processed])):
+            sub_results = [r for r in processed if r["category"] == cat]
+            if cat in ["gc-mat", "gc-trk", "oc-cpr", "pc-cpr"]:
+                score = tf_pair_aggregate_accuracy(sub_results)
+            elif cat in ["oc-cnt", "pc-cnt"]:
+                score = cnt_aggregate_metric(sub_results)
+            elif cat in ["oc-grp", "pc-grp"]:
+                score = grp_aggregate_accuracy(sub_results)
+            else:
+                score = None
+            eval_scores[cat] = score
+
+        score_df = pd.DataFrame({k: [v] for k, v in eval_scores.items()})
+        if model:
+            final_score_file = score_file
+        else:
+            suffix = os.path.splitext(eval_file)[1]
+            final_score_file = eval_file.replace(suffix, "_score.csv")
+        score_df.to_csv(final_score_file, index=False)
+        return score_df


### PR DESCRIPTION
## Add [VLM2Bench](https://github.com/vlm2-bench/VLM2-Bench) Image Cases

This PR introduces **2860 image VQA pairs** from [VLM2Bench](https://github.com/vlm2-bench/VLM2-Bench) to enhance the evaluation set.

### Verification
I am **Dongyu (Rain) Yao**, the **co-first author** of the [VLM2Bench paper](https://arxiv.org/abs/2502.12084).  
I have thoroughly **checked all cases**, ensuring that they can be **inferred** and **evaluated** using the **Qwen2.5-VL-7B-Instruct** model, producing results **comparable** to those reported in the paper.

### Additional Resources
- **Project Page**: [VLM2Bench](https://vlm2-bench.github.io/)
- **Paper**: [arXiv](https://arxiv.org/abs/2502.12084)

This addition aims to further benchmark **vision-language models** under diverse real-world scenarios.