### PR TITLE
Add VMCBench (CVPR 2025)

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -5,7 +5,7 @@ from .image_caption import ImageCaptionDataset
 from .image_yorn import ImageYORNDataset
 from .image_mcq import (
     ImageMCQDataset, MMMUDataset, CustomMCQDataset, MUIRDataset, GMAIMMBenchDataset, MMERealWorld, HRBenchDataset,
-    NaturalBenchDataset, WeMath, MMMUProDataset
+    NaturalBenchDataset, WeMath, MMMUProDataset, VMCBenchDataset
 )
 from .image_mt import MMDUDataset
 from .image_vqa import (
@@ -142,7 +142,7 @@ IMAGE_DATASET = [
     GMAIMMBenchDataset, MMERealWorld, HRBenchDataset, CRPE, MathVerse, NaturalBenchDataset,
     MIABench, OlympiadBench, WildVision, MMMath, QSpatial, Dynamath, MMGenBench, VizWiz, MMNIAH,
     CMMMU, VLRewardBench, WeMath, LogicVista, MMMUProDataset, CreationMMBenchDataset,
-    ImageShortQADataset, MMAlignBench, OmniDocBench
+    ImageShortQADataset, MMAlignBench, OmniDocBench, VMCBenchDataset
 ]
 
 

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -1158,7 +1158,6 @@ class VMCBenchDataset(ImageBaseDataset):
         prompt += f'Question: {question}\n'
         if len(options):
             prompt += options_prompt
-            # prompt += 'Please select the correct answer from the options above. \n'
             prompt += "Answer with the option's letter from the given choices directly. \n"
             
         msgs = []

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -1177,14 +1177,10 @@ class VMCBenchDataset(ImageBaseDataset):
         data = data.sort_values(by='index')
         data['prediction'] = [str(x) for x in data['prediction']]
         data['hit'] = data.apply(get_mc_score, axis=1)
-        # import pdb; pdb.set_trace()
         result_file = eval_file.replace(f'.{suffix}', f'_result.{suffix}')
         dump(data, result_file)
         acc = report_vmc_acc(data)
         score_file = eval_file.replace(f'.{suffix}', '_acc.csv')
         dump(acc, score_file)
 
-        # warnings.warn('Note that VMCBench is just a toy version of AesBench TEST. For full results, \
-        #                    please evaluate on AesBench TEST. The AesBench TEST dataset is more than 20 times \
-        #                    larger than the VAL dataset and the leaderboard results are based on AesBench TEST.')
         return acc

--- a/vlmeval/dataset/utils/vmcbench.py
+++ b/vlmeval/dataset/utils/vmcbench.py
@@ -1,0 +1,97 @@
+import pandas as pd
+import numpy as np
+import random
+
+
+def parse_multi_choice_response(response, all_choices, index2ans):
+    """
+    Parse the prediction from the generated response.
+    Return the predicted index e.g., A, B, C, D.
+    """
+    response = str(response)
+    for char in [',', '.', '!', '?', ';', ':', "'"]:
+        response = response.strip(char)
+    response = " " + response + " " # add space to avoid partial match
+
+    index_ans = True
+    ans_with_brack = False
+    candidates = []
+    for choice in all_choices:  # e.g., (A) (B) (C) (D)
+        if f'({choice})' in response or f'{choice}. ' in response:
+            candidates.append(choice)
+            ans_with_brack = True
+
+    if len(candidates) == 0:
+        for choice in all_choices: # e.g., A B C D
+            if f' {choice} ' in response:
+                candidates.append(choice)
+
+    # if all above doesn't get candidates, check if the content is larger than 5 tokens and try to parse the example
+    if len(candidates) == 0 and len(response.split()) > 5:
+        for index, ans in index2ans.items():
+            if ans.lower() in response.lower():
+                candidates.append(index)
+                index_ans = False # it's content ans.
+
+    if len(candidates) == 0:  # still not get answer, randomly choose one.
+        pred_index = random.choice(all_choices)
+    elif len(candidates) > 1:
+        start_indexes = []
+        if index_ans:
+            if ans_with_brack: 
+                for can in candidates:
+                    index = response.rfind(f'({can})')
+                    start_indexes.append(index) # -1 will be ignored anyway
+                # start_indexes = [generated_response.index(f'({can})') for can in candidates]
+            else:
+                for can in candidates:
+                    index = response.rfind(f" {can} ")
+                    start_indexes.append(index)
+        else:
+            for can in candidates:
+                index = response.lower().rfind(index2ans[can].lower())
+                start_indexes.append(index)
+        # get the last one
+        pred_index = candidates[np.argmax(start_indexes)]
+    else: # if only one candidate, use it.
+        pred_index = candidates[0]
+
+    return pred_index
+
+def get_mc_score(row, use_parse = True):
+    if use_parse:
+        if pd.isna(row["A"]):
+            return False
+        response = row["prediction"]
+        all_choices = []
+        for i in range(9):
+            if chr(65+i) in row and pd.isna(row[chr(65+i)])== False:
+                all_choices.append(chr(65+i))
+        index2ans = {index: row[index] for index in all_choices}
+        pred_index = parse_multi_choice_response(response, all_choices, index2ans)
+    else:
+        pred_index = row["output"]
+    return int(pred_index == row["answer"])
+
+def report_vmc_acc(data):
+    general_datasets = ["SEEDBench", "MMStar", "A-OKVQA", "VizWiz", "MMVet", 
+                      "VQAv2", "OKVQA"]
+    reason_datasets = ["MMMU", "MathVista", "ScienceQA", "RealWorldQA",  "GQA", "MathVision"]
+    ocr_datasets = ["TextVQA", "OCRVQA"]
+    doc_datasets = ["AI2D", "ChartQA","DocVQA", "InfoVQA",  "TableVQABench"]
+    results = {}
+    for category in data['category'].unique():
+        results[category] = data[data['category'] == category]['hit'].mean()
+    results = pd.DataFrame(results, index=[0])
+    results["Overall"] = data['hit'].mean()
+    results['General'] = results[general_datasets].mean(axis=1)
+    results['Reasoning'] = results[reason_datasets].mean(axis=1)
+    results['OCR'] = results[ocr_datasets].mean(axis=1)
+    results['Doc & Chart'] = results[doc_datasets].mean(axis=1)
+    # import pdb; pdb.set_trace()
+    for key in results:
+        results[key] = round(results[key]*100, 2)
+    results = results[['Overall', 'General', 'Reasoning', 'OCR', 'Doc & Chart'] 
+                      + general_datasets + reason_datasets + ocr_datasets + doc_datasets]
+    return results
+    

--- a/vlmeval/dataset/utils/vmcbench.py
+++ b/vlmeval/dataset/utils/vmcbench.py
@@ -88,7 +88,6 @@ def report_vmc_acc(data):
     results['Reasoning'] = results[reason_datasets].mean(axis=1)
     results['OCR'] = results[ocr_datasets].mean(axis=1)
     results['Doc & Chart'] = results[doc_datasets].mean(axis=1)
-    # import pdb; pdb.set_trace()
     for key in results:
         results[key] = round(results[key]*100, 2)
     results = results[['Overall', 'General', 'Reasoning', 'OCR', 'Doc & Chart'] 


### PR DESCRIPTION
Add VMCBench to image_mcq datasets. VMCBench is from "Automated Generation of Challenging Multiple-Choice Questions for Vision Language Model Evaluation" (CVPR 2025) [https://yuhui-zh15.github.io/AutoConverter-Website/](url). VMCBench is created by transforming 20 existing VQA datasets into a unified multiple-choice format, totaling 9,018 questions. Using VLMEvalKit, we comprehensively evaluate 28 state-of-the-art VLMs on VMCBench, setting a new standard for scalable, consistent, and reproducible VLM evaluation.

