### PR TITLE
VLM2Bench UPDATE: .tsv file for image cases and new md5 value

### DIFF
--- a/vlmeval/dataset/vlm2bench.py
+++ b/vlmeval/dataset/vlm2bench.py
@@ -16,7 +16,7 @@ class VLM2Bench(ImageBaseDataset):
         "VLM2Bench": 'https://huggingface.co/datasets/Sterzhang/vlm2-bench/resolve/main/VLM2Bench_img.tsv' # all 2860 image cases from VLM2Bench huggingface repo
     }
     # DATASET_MD5
-    DATASET_MD5 = {'VLM2Bench': '587b658f297aaed0b1be8d519399b3f3'}
+    DATASET_MD5 = {'VLM2Bench': '16f474bfc4e269c583468bf89139da8f'}
 
     def build_prompt(self, line):
         """


### PR DESCRIPTION
We corrected some cases in the .tsv file and uploaded the new version to our huggingface repo.

The link to our .tsv file has not changed, but we updated the new MD5 value for our .tsv file in the code.

We also rerun the following two models using this Evalkit (on RXT6000 GPUs):
**Qwen2.5-VL-7B-Instruct**
gc-mat: 41.6988416988417
gc-trk: 44.29223744292237
oc-cnt: 58.333333333333336
oc-cpr: 62
oc-grp: 54.5
pc-cnt: 67.5
pc-cpr: 79.5
pc-grp: 77


**InternVL2_5-8B**
gc-mat:  28.9575
gc-trk:  37.8995
oc-cnt:  58.8889
oc-cpr:  53.0556
oc-grp:  53
pc-cnt:  48.3333
pc-cpr:  44
pc-grp:  56



These results may differ slightly from those reported in the paper. This could be because the results in our paper were obtained using our inference script, and differences in parameter settings and the computing environment may have led to variations in the outcomes.
