### PR TITLE
[benchmark][MOAT] Shuffle choices for MOAT

### DIFF
--- a/vlmeval/dataset/moat.py
+++ b/vlmeval/dataset/moat.py
@@ -6,8 +6,10 @@ from ..smp import load, dump, decode_base64_to_image
 from .utils import DEBUG_MESSAGE
 
 import zipfile
-from random import shuffle
+from random import shuffle, seed
 
+
+RANDOM_SEED = 0
 
 VQA_SYSTEM_PROMPT = json.dumps({
     'task': 'Answer the question presented to you truthfully.',
@@ -42,6 +44,10 @@ class MOAT(ImageBaseDataset):
     DATASET_MD5 = {
         'MOAT': '803b5a176a5b01aa1b8094fae73532a2',
     }
+
+    def __init__(self, dataset, **kwargs):
+        super().__init__(dataset, **kwargs)
+        seed(RANDOM_SEED) # seed the random number generator to ensure reproducibility
 
     def post_build(self, dataset):
         assert dataset == "MOAT", f"Wrong dataset name {dataset}"


### PR DESCRIPTION
Sorry to bother again.

I check the code for MOAT and find some minor differences from our original settings.
1. shuffle the choices if given
2. for outside knowledge text, LMMs should be told this is a hint

Theoretically, these should not cause significant performance changes. But setting so will make the implementation more consistent. We conduct a test ourselves with GPT4o_HIGH and the result is similar to ours in the paper.
(It is reasonable for results changing minorly every time, since the shuffle and the uncertainty of model itself)

Sorry again and thank you for your help.