### PR TITLE
[Fix] Fix errors when `vlmeval check` ovis2 models

### DIFF
--- a/vlmeval/vlm/ovis/ovis.py
+++ b/vlmeval/vlm/ovis/ovis.py
@@ -490,7 +490,7 @@ class Ovis2(BaseModel):
         # preprocess inputs
         if DATASET_MODALITY(dataset) == 'VIDEO':
             max_partition = 1
-        elif any(
+        elif (dataset != None) and any(
             dataset.startswith(prefix) for prefix in
             ('HallusionBench', 'TextVQA', 'ChartQA', 'OCRBench', 'InfoVQA', 'DocVQA', 'MTVQA')):
             max_partition = 12


### PR DESCRIPTION
Since `vlmeval check` doesn't pass the dataset param to the ovis2's prepare_inputs function, then dataset=None. Thus, when in [line 494](https://github.com/open-compass/VLMEvalKit/blob/66a76843f260a57e2236150bcf0b7df9c2d82f88/vlmeval/vlm/ovis/ovis.py#L494), it will raise error:

```
user@host $ vlmutil check Ovis2-8B
......
  File "/data/XXX/Item/VLMEvalKit/vlmeval/vlm/ovis/ovis.py", line 494, in <genexpr>
    dataset.startswith(prefix) for prefix in
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'
```

After fix:
```
user@host $ vlmutil check Ovis2-8B
......
Test 1: The image shows a single, ripe red apple with a glossy surface and a small green leaf attached to its stem. The apple is positioned against a plain white background, which highlights its vibrant red color and shiny texture. The apple appears fresh and appetizing, with a smooth, round shape and a slight shine that suggests it's juicy and ripe.
Test 2: The image shows a single, ripe red apple with a glossy surface and a small green leaf attached to its stem. The apple is positioned against a plain white background, which highlights its vibrant red color and shiny texture. The apple appears fresh and appetizing, with a smooth, round shape and a slight shine that suggests it's juicy and ripe.
Test 3: There is one apple in each of the images provided.
Test 4: There is one apple in each of the images provided.
```