### PR TITLE
[API] Allow setting model name for `LMDeployWrapper`

### DIFF
--- a/vlmeval/api/lmdeploy.py
+++ b/vlmeval/api/lmdeploy.py
@@ -165,6 +165,7 @@ class LMDeployWrapper(BaseAPI):
     }
 
     def __init__(self,
+                 model: str = None,
                  retry: int = 5,
                  wait: int = 5,
                  key: str = 'sk-123456',
@@ -189,7 +190,8 @@ class LMDeployWrapper(BaseAPI):
 
         model_url = ''.join([api_base.split('v1')[0], 'v1/models'])
         resp = requests.get(model_url)
-        self.model = resp.json()['data'][0]['id']
+        model_id_list = [str(data['id']) for data in resp.json()['data']]
+        self.model = model if model in model_id_list else model_id_list[0]
         self.logger.info(f'lmdeploy evaluate model: {self.model}')
         self.set_prompt_pattern(self.model)
         if hasattr(self, 'custom_prompt'):


### PR DESCRIPTION
- Some VLMs like Phi-4-multimodal use [vision LoRA adapter](https://huggingface.co/microsoft/Phi-4-multimodal-instruct/tree/main/vision-lora) for vision tasks. However, current `LMDeployWrapper` can only always set `model` as base model automatically, causing incorrect evaluation results.
- This PR exposes `model` for `LMDeployWrapper` so that users can configure model name and send LoRA requests during evaluation to get correct responses.