### PR TITLE
Fix all_finished return null

### DIFF
--- a/vlmeval/inference.py
+++ b/vlmeval/inference.py
@@ -101,7 +101,7 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
     if all_finished:
         res = {k: res[k] for k in data_indices}
         dump(res, out_file)
-        return
+        return model
 
     # Data need to be inferred
     data = data[~data['index'].isin(res)]

--- a/vlmeval/inference_mt.py
+++ b/vlmeval/inference_mt.py
@@ -95,7 +95,7 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
     if all_finished:
         res = {k: res[k] for k in data_indices}
         dump(res, out_file)
-        return
+        return model
 
     # Data need to be inferred
     data = data[~data['index'].isin(res)]


### PR DESCRIPTION
In the code, the infer_data function in both vlmeval\inference.py and vlmeval\inference_mt.py returns null when a dataset has already been evaluated. This behavior is problematic because the function is called as model = infer_data(...), meaning we need to pass the model forward. If it returns null, the already loaded model will be lost, leading to unexpected results when processing subsequent datasets (i.e., those that haven't been fully evaluated yet).