### PR TITLE
[Fix] Fix duplicate logging by disabling propagation

### DIFF
--- a/vlmeval/smp/log.py
+++ b/vlmeval/smp/log.py
@@ -32,10 +32,12 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
         handlers.append(file_handler)
 
     formatter = logging.Formatter(
-        '[%(asctime)s] %(levelname)s - %(name)s - %(filename)s: %(funcName)s - %(lineno)d: %(message)s')
+        '[%(asctime)s] %(levelname)s - %(name)s - %(filename)s: %(funcName)s - %(lineno)d: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S')
     for handler in handlers:
         handler.setFormatter(formatter)
         handler.setLevel(log_level)
+        logger.propagate = False
         logger.addHandler(handler)
 
     if rank == 0:


### PR DESCRIPTION
## Previous situation

Logging messages were duplicated because module-level loggers propagated messages to the root logger, causing each log entry to appear twice in the output.
![image](https://github.com/user-attachments/assets/af379659-fa14-425d-bc33-aac21ddf2a14)


## Fix

This PR sets  **`logger.propagate = False`** in module-level loggers. This ensures that logs handled by module-level loggers are not propagated to the root logger, thereby eliminating duplicate log entries.

## After Fix

Logs now correctly appear once per event, clearly indicating their source without duplication.
![image](https://github.com/user-attachments/assets/cb4e50af-847c-4e56-85e5-3d52d08cf9b7)






