### PR TITLE
[Benchmark] Support V* Benchmark

### DIFF
--- a/vlmeval/api/cloudwalk.py
+++ b/vlmeval/api/cloudwalk.py
@@ -68,7 +68,7 @@ class CWWrapper(BaseAPI):
             input_msgs.append(dict(role='user', content=text))
         return input_msgs
 
-    def generate_inner(self, inputs, **kwargs) :
+    def generate_inner(self, inputs, **kwargs):
         input_msgs = self.prepare_inputs(inputs)
         temperature = kwargs.pop('temperature', self.temperature)
         max_tokens = kwargs.pop('max_tokens', self.max_tokens)

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -6,7 +6,7 @@ from .image_yorn import ImageYORNDataset
 from .image_mcq import (
     ImageMCQDataset, MMMUDataset, CustomMCQDataset, MUIRDataset, GMAIMMBenchDataset, MMERealWorld, HRBenchDataset,
     NaturalBenchDataset, WeMath, MMMUProDataset, VMCBenchDataset, MedXpertQA_MM_test, LEGO, VisuLogic, CVBench, TDBench,
-    CMMU_MCQ, PathMMU_VAL, PathMMU_TEST, MicroVQA, MicroBench, OmniMedVQA, MSEarthMCQ
+    CMMU_MCQ, PathMMU_VAL, PathMMU_TEST, MicroVQA, MicroBench, OmniMedVQA, MSEarthMCQ, VStarBench
 )
 from .image_mt import MMDUDataset
 from .image_vqa import (

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -1080,6 +1080,16 @@ class HRBenchDataset(ImageMCQDataset):
         return acc
 
 
+class VStarBench(ImageMCQDataset):
+    DATASET_URL = {
+        "VStarBench": "https://huggingface.co/datasets/xjtupanda/VStar_Bench/resolve/main/VStarBench.tsv",
+    }
+
+    DATASET_MD5 = {
+        "VStarBench": "b18854d7075574be06b631cd5f7d2d6a",
+    }
+
+
 class CustomMCQDataset(ImageMCQDataset):
 
     def load_data(self, dataset):


### PR DESCRIPTION
The V* benchmark (CVPR-2024) features high-res images and active visual search.
[Original project site](https://github.com/penghao-wu/vstar)
[Original data page](https://huggingface.co/datasets/craigwu/vstar_bench)
I refactored the benchmark for VLMEvalKit and tested using GPT-4o-mini. A pre-commit test has been done.
Test command:
`python run.py --data VStarBench --model GPT4o_MINI --verbose`
Results are as shown below:
```
-----------------  -------------------
split              none
Overall            0.39790575916230364
direct_attributes  0.41739130434782606
relative_position  0.3684210526315789
-----------------  -------------------
```