### PR TITLE
Add support for reasoning MLLM URSA-8B-PS-GRPO

### DIFF
--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -1295,7 +1295,10 @@ ross_series = {
     "ross-qwen2-7b": partial(Ross, model_path="HaochenWang/ross-qwen2-7b"),
 }
 
-ursa_series = {"URSA-8B": partial(UrsaChat, model_path="URSA-MATH/URSA-8B")}
+ursa_series = {
+    "URSA-8B": partial(UrsaChat, model_path="URSA-MATH/URSA-8B"),
+    "URSA-8B-PS-GRPO": partial(UrsaChat, model_path="URSA-MATH/URSA-8B-PS-GRPO")    
+}
 
 gemma_series = {
     "paligemma-3b-mix-448": partial(

--- a/vlmeval/vlm/ursa/ursa_chat.py
+++ b/vlmeval/vlm/ursa/ursa_chat.py
@@ -165,6 +165,6 @@ class UrsaChat(BaseModel):
         )
         outputs = self.model.generate(**inputs, **generation_config)
         response = self.image_processor.decode(outputs[0], skip_special_tokens=True).split('assistant\n')[-1]
-        if dataset in ['MathVista_MINI', 'MathVista', 'DynaMath', 'MathVision']:
+        if dataset in ['MathVista_MINI', 'MathVista', 'DynaMath', 'MathVision', 'LogicVista', 'WeMath', 'MathVerse_MINI_Vision_Only', 'MathVerse']:
             response = 'Answer: {}'.format(self.extract_answer(response))
         return response


### PR DESCRIPTION
This PR adds support for a new RL version of the previous MLLM, URSA-8B. We implement a new RL method based on the URSA-8B-RM. Arxiv address: https://arxiv.org/abs/2501.04686.