### PR TITLE
[Fix] Remove Decord Dependancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ run_g.sh
 tmp/
 InternVL*
 Qwen*
+CongRong*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 accelerate
-decord; platform_machine != 'arm64'
 dotenv
 einops
-eva-decord; platform_machine == 'arm64'
 # for gemini api
 google-genai
 gradio

--- a/vlmeval/api/cloudwalk.py
+++ b/vlmeval/api/cloudwalk.py
@@ -68,7 +68,7 @@ class CWWrapper(BaseAPI):
             input_msgs.append(dict(role='user', content=text))
         return input_msgs
 
-    def generate_inner(self, inputs, **kwargs) :
+    def generate_inner(self, inputs, **kwargs):
         input_msgs = self.prepare_inputs(inputs)
         temperature = kwargs.pop('temperature', self.temperature)
         max_tokens = kwargs.pop('max_tokens', self.max_tokens)

--- a/vlmeval/dataset/cgbench.py
+++ b/vlmeval/dataset/cgbench.py
@@ -350,7 +350,7 @@ class CGBench_MCQ_Grounding_Mini(VideoBaseDataset):
 
         if type(uid) is not str:
             uid = str(uid)
-
+        import decord
         vid_path = osp.join(self.data_root, video)
         vid = decord.VideoReader(vid_path)
         vid_fps = vid.get_avg_fps()
@@ -677,7 +677,7 @@ class CGBench_OpenEnded_Mini(VideoBaseDataset):
 
         if type(uid) is not str:
             uid = str(uid)
-
+        import decord
         vid_path = osp.join(self.data_root, video)
         vid = decord.VideoReader(vid_path)
         vid_fps = vid.get_avg_fps()
@@ -1230,7 +1230,7 @@ class CGBench_MCQ_Grounding(VideoBaseDataset):
 
         if type(uid) is not str:
             uid = str(uid)
-
+        import decord
         vid_path = osp.join(self.data_root, video)
         vid = decord.VideoReader(vid_path)
         vid_fps = vid.get_avg_fps()
@@ -1556,7 +1556,7 @@ class CGBench_OpenEnded(VideoBaseDataset):
 
         if type(uid) is not str:
             uid = str(uid)
-
+        import decord
         vid_path = osp.join(self.data_root, video)
         vid = decord.VideoReader(vid_path)
         vid_fps = vid.get_avg_fps()

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -201,6 +201,7 @@ class LongVideoBench(VideoBaseDataset):
     def save_video_frames(self, video_path, video_llm=False):
 
         vid_path = osp.join(self.data_root, video_path)
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -8,7 +8,6 @@ from ..utils import track_progress_rich
 import torchvision.transforms as T
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
-from decord import VideoReader, cpu
 import pandas as pd
 import imageio
 import cv2
@@ -156,6 +155,7 @@ class MLVU_MCQ(VideoBaseDataset):
         suffix = line['video'].split('.')[-1]
         video = line['video'].replace(f'.{suffix}','')
         vid_path = osp.join(self.data_root, line['prefix'], line['video'])
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),
@@ -359,6 +359,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
         suffix = line['video'].split('.')[-1]
         video = line['video'].replace(f'.{suffix}','')
         vid_path = osp.join(self.data_root, line['prefix'], line['video'])
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -7,7 +7,6 @@ from ..utils import track_progress_rich
 import torchvision.transforms as T
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
-from decord import VideoReader, cpu
 import imageio
 import cv2
 import zipfile
@@ -213,6 +212,7 @@ Based on your observations, select the best option that accurately addresses the
         return frame_indices
 
     def read_video(self, video_path, bound=None):
+        from decord import VideoReader, cpu
         vr = VideoReader(video_path, ctx=cpu(0), num_threads=1)
         max_frame = len(vr) - 1
         fps = float(vr.get_avg_fps())
@@ -535,6 +535,7 @@ Based on your observations, select the best option that accurately addresses the
         return frame_indices
 
     def read_video(self, video_path):
+        from decord import VideoReader, cpu
         vr = VideoReader(video_path, ctx=cpu(0), num_threads=1)
         max_frame = len(vr) - 1
 

--- a/vlmeval/dataset/qbench_video.py
+++ b/vlmeval/dataset/qbench_video.py
@@ -9,7 +9,6 @@ from ..utils import track_progress_rich
 import torchvision.transforms as T
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
-from decord import VideoReader, cpu
 import pandas as pd
 import imageio
 import cv2
@@ -102,6 +101,7 @@ Please do not add any other answers beyond this.
     def save_video_frames(self, line):
         video = line['video']
         vid_path = os.path.normpath(os.path.join(self.data_root, line['video_path']))
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),
@@ -256,6 +256,7 @@ Please analyze these frames and provide a detailed and accurate answer from the 
     def save_video_frames(self, line):
         video = line['video']
         vid_path = os.path.normpath(os.path.join(self.data_root, line['video_path']))
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),

--- a/vlmeval/dataset/tamperbench.py
+++ b/vlmeval/dataset/tamperbench.py
@@ -5,7 +5,6 @@ from .video_base import VideoBaseDataset
 from .utils import build_judge, DEBUG_MESSAGE
 import torchvision.transforms as T
 from torchvision import transforms
-from decord import VideoReader, cpu
 import imageio
 import cv2
 import zipfile
@@ -231,6 +230,7 @@ Based on your observations, select the best option that accurately addresses the
         return frame_indices.astype(int)
 
     def read_video(self, video_path, bound=None):
+        from decord import VideoReader, cpu
         vr = VideoReader(video_path, ctx=cpu(0), num_threads=1)
         max_frame = len(vr) - 1
         fps = float(vr.get_avg_fps())

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -8,7 +8,6 @@ from ..utils import track_progress_rich
 import torchvision.transforms as T
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
-from decord import VideoReader, cpu
 from .utils.tempcompass import *
 
 
@@ -150,6 +149,7 @@ class TempCompass_MCQ(VideoBaseDataset):
 
     def save_video_frames(self, line):
         vid_path = osp.join(self.data_root, line['prefix'], line['video'] + line['suffix'])
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),
@@ -345,6 +345,7 @@ class TempCompass_Captioning(VideoBaseDataset):
 
     def save_video_frames(self, line):
         vid_path = osp.join(self.data_root, line['prefix'], line['video'] + line['suffix'])
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),
@@ -537,6 +538,7 @@ class TempCompass_YorN(VideoBaseDataset):
 
     def save_video_frames(self, line):
         vid_path = osp.join(self.data_root, line['prefix'], line['video'] + line['suffix'])
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),

--- a/vlmeval/dataset/utils/cgbench.py
+++ b/vlmeval/dataset/utils/cgbench.py
@@ -551,6 +551,7 @@ def save_clue_video_frames(data_root, clue_frame_root, video, uid, clue_interval
         uid = str(uid)
 
     vid_path = osp.join(data_root, video)
+    import decord
     vid = decord.VideoReader(vid_path)
     vid_fps = vid.get_avg_fps()
 

--- a/vlmeval/dataset/video_base.py
+++ b/vlmeval/dataset/video_base.py
@@ -68,6 +68,7 @@ class VideoBaseDataset:
                          self.frame_tmpl_fps.format(i, num_frames, self.fps)) for i in range(1, num_frames + 1)]
 
     def save_video_frames(self, video):
+        import decord
         if self.fps > 0:
             vid_path = osp.join(self.data_root, video + '.mp4')
             vid = decord.VideoReader(vid_path)

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -155,6 +155,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
     def save_video_frames(self, video, video_llm=False):
 
         vid_path = osp.join(self.data_root, 'video', video + '.mp4')
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),

--- a/vlmeval/dataset/worldsense.py
+++ b/vlmeval/dataset/worldsense.py
@@ -195,6 +195,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
     def save_video_frames(self, video, video_llm=False):
 
         vid_path = osp.join(self.data_root, 'videos', video + '.mp4')
+        import decord
         vid = decord.VideoReader(vid_path)
         video_info = {
             'fps': vid.get_avg_fps(),

--- a/vlmeval/smp/misc.py
+++ b/vlmeval/smp/misc.py
@@ -138,11 +138,6 @@ def cn_string(s):
         return True
     return False
 
-try:
-    import decord
-except ImportError:
-    pass
-
 def timestr(granularity='second'):
     s = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
     assert granularity in ['second', 'minute', 'hour', 'day']

--- a/vlmeval/vlm/long_vita.py
+++ b/vlmeval/vlm/long_vita.py
@@ -3,7 +3,6 @@ import os
 import math
 import numpy as np
 from PIL import Image
-import decord
 from ..smp import *
 from .base import BaseModel
 from ..dataset import DATASET_TYPE
@@ -469,6 +468,7 @@ class ImageProcessor:
         ]
 
     def save_video_frames(self, vid_path, max_fps=1, num_frames=8):
+        import decord
         vid = decord.VideoReader(vid_path, num_threads=1)
 
         step_size = len(vid) / (num_frames + 1)
@@ -493,6 +493,7 @@ class ImageProcessor:
         return frame_paths
 
     def get_video_frames(self, vid_path, max_fps=1, num_frames=8):
+        import decord
         vid = decord.VideoReader(vid_path, num_threads=1)
 
         step_size = len(vid) / (num_frames + 1)

--- a/vlmeval/vlm/valley/requirements_valley.txt
+++ b/vlmeval/vlm/valley/requirements_valley.txt
@@ -2,7 +2,6 @@ accelerate==0.34.2
 bert-score==0.3.13
 byted-wandb==0.13.72
 datasets==2.21.0
-decord==0.6.0
 einops==0.8.0
 evaluate==0.4.3
 fastapi==0.115.0

--- a/vlmeval/vlm/video_llm/chat_uni_vi.py
+++ b/vlmeval/vlm/video_llm/chat_uni_vi.py
@@ -8,7 +8,6 @@ import logging
 from ..base import BaseModel
 from ...smp import isimg, listinstr
 from ...dataset import DATASET_TYPE
-from decord import VideoReader, cpu
 from PIL import Image
 
 
@@ -41,6 +40,7 @@ def _get_rawvideo_dec(
             end_time = start_time + 1
 
     if os.path.exists(video_path):
+        from decord import VideoReader, cpu
         vreader = VideoReader(video_path, ctx=cpu(0))
     else:
         print(video_path)

--- a/vlmeval/vlm/video_llm/llama_vid.py
+++ b/vlmeval/vlm/video_llm/llama_vid.py
@@ -8,11 +8,11 @@ import logging
 from ..base import BaseModel
 from ...smp import isimg, listinstr, load, dump, download_file
 from ...dataset import DATASET_TYPE
-from decord import VideoReader, cpu
 from huggingface_hub import snapshot_download
 
 
 def load_video(video_path, setting_fps):
+    from decord import VideoReader, cpu
     vr = VideoReader(video_path, ctx=cpu(0))
     total_frame_num = len(vr)
     fps = round(vr.get_avg_fps())


### PR DESCRIPTION
Remove Decord Dependancy:
1. decord is only used by video LMMs and benchmarks
2. it's difficult to install decord on linux arm machines 