### PR TITLE
Add StaticEmbodiedBench and StaticEmbodiedBench_circular

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -71,6 +71,8 @@ from .GUI.screenspot import ScreenSpot
 from .GUI.screenspot_pro import ScreenSpot_Pro
 from .mmifeval import MMIFEval
 from .chartmimic import ChartMimic
+from .static_embodied_bench import StaticEmbodiedBench
+from .static_embodied_bench_circular import StaticEmbodiedBench_circular
 
 
 class ConcatDataset(ImageBaseDataset):
@@ -197,7 +199,7 @@ IMAGE_DATASET = [
     WildDocBenchmark, MSEarthMCQ, OCR_Reasoning, PhyX, VLMBlind, CountBenchQA,
     ZEROBench, SCAM, Omni3DBench, TallyQA, _3DSRBench, AffordanceDataset,
     MMEReasoning, GOBenchDataset, SFE, ChartMimic, MMVMBench, XLRSBench,
-    OmniEarthMCQBench, VisFactor
+    OmniEarthMCQBench, VisFactor,StaticEmbodiedBench, StaticEmbodiedBench_circular
 ]
 
 

--- a/vlmeval/dataset/static_embodied_bench.py
+++ b/vlmeval/dataset/static_embodied_bench.py
@@ -1,0 +1,28 @@
+# vlmeval/dataset/static_embodied_bench.py
+from vlmeval.dataset.image_mcq import ImageMCQDataset
+import string
+import pandas as pd
+from vlmeval.smp import *
+
+
+class StaticEmbodiedBench(ImageMCQDataset):
+    TYPE = "MCQ"
+    DATASET_NAME = "StaticEmbodiedBench"
+    DATASET_URL = {
+        "StaticEmbodiedBench": (
+            "https://huggingface.co/datasets/xiaojiahao/StaticEmbodiedBench/resolve/main/StaticEmbodiedBench.tsv"
+        )
+    }
+    DATASET_MD5 = {
+        "StaticEmbodiedBench": "5c50611650ca966970180a80d49429f0"
+    }
+
+    @classmethod
+    def supported_datasets(cls):
+        return [cls.DATASET_NAME]
+
+    def build_prompt(self, line):
+        return super().build_prompt(line)
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        return super().evaluate(eval_file, **judge_kwargs)

--- a/vlmeval/dataset/static_embodied_bench_circular.py
+++ b/vlmeval/dataset/static_embodied_bench_circular.py
@@ -1,0 +1,29 @@
+# vlmeval/dataset/static_embodied_bench_circular.py
+from vlmeval.dataset.image_mcq import ImageMCQDataset
+import string
+import pandas as pd
+from vlmeval.smp import *
+
+
+class StaticEmbodiedBench_circular(ImageMCQDataset):
+    TYPE = "MCQ"
+    DATASET_NAME = "StaticEmbodiedBench_circular"
+    DATASET_URL = {
+        "StaticEmbodiedBench_circular": (
+            "https://huggingface.co/datasets/xiaojiahao/StaticEmbodiedBench/"
+            "resolve/main/StaticEmbodiedBench_circular.tsv"
+        )
+    }
+    DATASET_MD5 = {
+        "StaticEmbodiedBench_circular": "034cf398a3c7d848d966e1081e4baf68"
+    }
+
+    @classmethod
+    def supported_datasets(cls):
+        return [cls.DATASET_NAME]
+
+    def build_prompt(self, line):
+        return super().build_prompt(line)
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        return super().evaluate(eval_file, **judge_kwargs)


### PR DESCRIPTION
This PR adds support for the **StaticEmbodiedBench** dataset, along with its **circular variant**.

### 🔍 About StaticEmbodiedBench
- StaticEmbodiedBench is a dataset for evaluating vision-language models on embodied intelligence tasks, as featured in the OpenCompass Leaderboard(https://staging.opencompass.org.cn/embodied-intelligence/rank/brain).

- This release includes **200 open-source samples** from the full dataset, made available for public research and benchmarking purposes.
- Dataset format follows the standard `ImageMCQDataset` format.

### 📁 Added Files
- `vlmeval/dataset/static_embodied_bench.py`: dataset class for StaticEmbodiedBench.
- `vlmeval/dataset/static_embodied_bench_circular.py`: dataset class for circular evaluation.
- Register the datasets in vlmeval/dataset/__init__.py for automatic discovery and loading
- Corresponding TSV files are hosted at [Hugging Face Datasets](https://huggingface.co/datasets/xiaojiahao/StaticEmbodiedBench).

### ✅ Features
- Supports circular evaluation via `g_index`.
- Passed all pre-commit checks (flake8, yapf, etc.)

Let me know if there are additional changes or integration steps needed!
