### PR TITLE
Fix bug regarding azure openai api key

### DIFF
--- a/vlmeval/smp/vlm.py
+++ b/vlmeval/smp/vlm.py
@@ -187,6 +187,9 @@ def read_ok(img_path):
 
 def gpt_key_set():
     openai_key = os.environ.get('OPENAI_API_KEY', None)
+    if openai_key is None:
+        openai_key = os.environ.get('AZURE_OPENAI_API_KEY', None) 
+        return isinstance(openai_key, str)
     return isinstance(openai_key, str) and openai_key.startswith('sk-')
 
 


### PR DESCRIPTION
In `vlmeval/smp/vlm.py`, function `gpt_key_set()`, the processing of `AZURE_OPENAI_API_KEY` is currenntly missing.
It will lead to an error when using the azure key, evaluating on datasets such as `WeMath `and `LogicVista`.

Simply adding 3 lines in the function will fix this problem:
```python
def gpt_key_set():
    openai_key = os.environ.get('OPENAI_API_KEY', None)
    if openai_key is None:
        openai_key = os.environ.get('AZURE_OPENAI_API_KEY', None) 
        return isinstance(openai_key, str)
    return isinstance(openai_key, str) and openai_key.startswith('sk-')
```