### PR TITLE
fix encoding issue in setup.py (set readme.md encoding to utf-8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def parse_requirements(fname='requirements.txt', with_version=True):
     return packages
 
 
-with open('README.md') as f:
+with open('README.md', encoding="utf-8") as f:
     readme = f.read()
 
 


### PR DESCRIPTION
this fixes the UnicodeDecodeError occurring when installing on windows by explicitly setting readme.md encoding to utf-8
