### PR TITLE
fix relative import for run_script_safe from eval_configs

### DIFF
--- a/vlmeval/dataset/utils/chartmimic/evaluator/chart_type_evaluator.py
+++ b/vlmeval/dataset/utils/chartmimic/evaluator/chart_type_evaluator.py
@@ -4,7 +4,7 @@ from typing import Dict
 # load_dotenv()
 
 import os
-from eval_configs.global_config import run_script_safe
+from ..eval_configs.global_config import run_script_safe
 
 
 class ChartTypeEvaluator:

--- a/vlmeval/dataset/utils/chartmimic/evaluator/color_evaluator.py
+++ b/vlmeval/dataset/utils/chartmimic/evaluator/color_evaluator.py
@@ -8,7 +8,7 @@ import os
 
 # sys.path.insert(0, os.environ["PROJECT_PATH"])
 
-from eval_configs.global_config import run_script_safe
+from ..eval_configs.global_config import run_script_safe
 
 
 # from skimage.color import deltaE_cie76

--- a/vlmeval/dataset/utils/chartmimic/evaluator/grid_evaluator.py
+++ b/vlmeval/dataset/utils/chartmimic/evaluator/grid_evaluator.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 import os
 # sys.path.insert(0, os.environ["PROJECT_PATH"])
 
-from eval_configs.global_config import run_script_safe
+from ..eval_configs.global_config import run_script_safe
 
 
 

--- a/vlmeval/dataset/utils/chartmimic/evaluator/layout_evaluator.py
+++ b/vlmeval/dataset/utils/chartmimic/evaluator/layout_evaluator.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 import os
 # sys.path.insert(0, os.environ["PROJECT_PATH"])
 
-from eval_configs.global_config import run_script_safe
+from ..eval_configs.global_config import run_script_safe
 
 
 class LayoutEvaluator:

--- a/vlmeval/dataset/utils/chartmimic/evaluator/legend_evaluator.py
+++ b/vlmeval/dataset/utils/chartmimic/evaluator/legend_evaluator.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 import os
 # sys.path.insert(0, os.environ["PROJECT_PATH"])
 
-from eval_configs.global_config import run_script_safe
+from ..eval_configs.global_config import run_script_safe
 
 
 

--- a/vlmeval/dataset/utils/chartmimic/evaluator/text_evaluator.py
+++ b/vlmeval/dataset/utils/chartmimic/evaluator/text_evaluator.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 # load_dotenv()
 
 import os
-from eval_configs.global_config import run_script_safe
+from ..eval_configs.global_config import run_script_safe
 
 
 


### PR DESCRIPTION
the existing import breaks module loading due to incorrect relative path usage