### PR TITLE
[Benchmark] Support CVQA

### DIFF
--- a/run.py
+++ b/run.py
@@ -388,6 +388,8 @@ def main():
                         judge_kwargs['model'] = 'qwen-72b'
                     elif listinstr(['MMVMBench'], dataset_name):
                         judge_kwargs['model'] = 'gpt-4o'
+                    elif listinstr(['CVQA_EN', 'CVQA_LOC'], dataset_name):
+                        judge_kwargs['model'] = 'gpt-4.1'
 
                 if args.use_verifier:
                     judge_kwargs['use_verifier'] = True

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -205,6 +205,7 @@ IMAGE_DATASET = [
     ZEROBench, SCAM, Omni3DBench, TallyQA, _3DSRBench, BMMR, AffordanceDataset,
     MMEReasoning, GOBenchDataset, SFE, ChartMimic, MMVMBench, XLRSBench,
     OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench, CVQA, M4Bench
+]
 
 VIDEO_DATASET = [
     MMBenchVideo, VideoMME, MVBench, MVBench_MP4, MVTamperBench,

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -7,7 +7,7 @@ from .image_mcq import (
     ImageMCQDataset, MMMUDataset, CustomMCQDataset, MUIRDataset, GMAIMMBenchDataset, MMERealWorld, HRBenchDataset,
     NaturalBenchDataset, WeMath, MMMUProDataset, VMCBenchDataset, MedXpertQA_MM_test, LEGO, VisuLogic, CVBench, TDBench,
     MicroBench, OmniMedVQA, MSEarthMCQ, VLMBlind, SCAM, _3DSRBench, AffordanceDataset, OmniEarthMCQBench, XLRSBench,
-    TreeBench
+    TreeBench, CVQA
 )
 from .image_mt import MMDUDataset
 from .image_vqa import (
@@ -202,7 +202,7 @@ IMAGE_DATASET = [
     WildDocBenchmark, MSEarthMCQ, OCR_Reasoning, PhyX, VLMBlind, CountBenchQA,
     ZEROBench, SCAM, Omni3DBench, TallyQA, _3DSRBench, BMMR, AffordanceDataset,
     MMEReasoning, GOBenchDataset, SFE, ChartMimic, MMVMBench, XLRSBench,
-    OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench
+    OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench, CVQA
 ]
 
 

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -2680,16 +2680,17 @@ class TreeBench(ImageMCQDataset):
 
         return calculate_average_iou(all_boxes, target_boxes)
 
+
 class CVQA(ImageMCQDataset):
-    
+
     @classmethod
     def supported_datasets(cls):
         return ['CVQA']
-    
-    DATASET_URL = {"CVQA": "https://huggingface.co/datasets/timothycdc/VLMEvalKit_CVQA_GT/resolve/main/CVQA.tsv",}
+
+    DATASET_URL = {"CVQA": "https://huggingface.co/datasets/timothycdc/VLMEvalKit_CVQA_GT/resolve/main/CVQA.tsv"}
     DATASET_MD5 = {"CVQA": "b51dcf2820cb292aa5cb3430dd7d5049"}
     SYSPROMPT = (
-                'Select the best answer to the above multiple-choice question based on the image. ' 
-                 'Respond with only the number of the correct answer (A, B, C, or D) of the correct option. \n'
-                 'The best answser is:'
+        'Select the best answer to the above multiple-choice question based on the image. '
+        'Respond with only the number of the correct answer (A, B, C, or D) of the correct option. \n'
+        'The best answser is:'
     )

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -2679,3 +2679,17 @@ class TreeBench(ImageMCQDataset):
             return total_iou / num_targets
 
         return calculate_average_iou(all_boxes, target_boxes)
+
+class CVQA(ImageMCQDataset):
+    
+    @classmethod
+    def supported_datasets(cls):
+        return ['CVQA']
+    
+    DATASET_URL = {"CVQA": "https://huggingface.co/datasets/timothycdc/VLMEvalKit_CVQA_GT/resolve/main/CVQA.tsv",}
+    DATASET_MD5 = {"CVQA": "b51dcf2820cb292aa5cb3430dd7d5049"}
+    SYSPROMPT = (
+                'Select the best answer to the above multiple-choice question based on the image. ' 
+                 'Respond with only the number of the correct answer (A, B, C, or D) of the correct option. \n'
+                 'The best answser is:'
+    )

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -2685,12 +2685,58 @@ class CVQA(ImageMCQDataset):
 
     @classmethod
     def supported_datasets(cls):
-        return ['CVQA']
+        return ['CVQA_LOC', 'CVQA_EN']
 
-    DATASET_URL = {"CVQA": "https://huggingface.co/datasets/timothycdc/VLMEvalKit_CVQA_GT/resolve/main/CVQA.tsv"}
-    DATASET_MD5 = {"CVQA": "b51dcf2820cb292aa5cb3430dd7d5049"}
-    SYSPROMPT = (
-        'Select the best answer to the above multiple-choice question based on the image. '
-        'Respond with only the number of the correct answer (A, B, C, or D) of the correct option. \n'
-        'The best answser is:'
-    )
+    DATASET_URL = {
+        "CVQA_EN": (
+            "https://huggingface.co/datasets/timothycdc/"
+            "VLMEvalKit_CVQA/resolve/main/CVQA_ENG.tsv"
+        ),
+        "CVQA_LOC": (
+            "https://huggingface.co/datasets/timothycdc/"
+            "VLMEvalKit_CVQA/resolve/main/CVQA_LOC.tsv"
+        ),
+    }
+
+    DATASET_MD5 = {
+        "CVQA_EN": "f49ad8ad39dbc4208ea8985a3ca00804",
+        "CVQA_LOC": "b51dcf2820cb292aa5cb3430dd7d5049",
+    }
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        question = line['question']
+        options = {
+            cand: line[cand]
+            for cand in string.ascii_uppercase
+            if cand in line and not pd.isna(line[cand])
+        }
+        options_prompt = 'Options:\n'
+        for key, item in options.items():
+            options_prompt += f'{key}. {item}\n'
+
+        prompt = f'Question: {question}\n'
+        if len(options):
+            prompt += options_prompt
+            prompt += (
+                'Select the best answer to the above multiple-choice question '
+                'based on the image. Respond with only the letter of the '
+                'correct option (A, B, C, or D).\n'
+                'The best answer is: '
+            )
+
+        msgs = []
+        if isinstance(tgt_path, list):
+            msgs.extend([dict(type='image', value=p) for p in tgt_path])
+        else:
+            msgs = [dict(type='image', value=tgt_path)]
+        msgs.append(dict(type='text', value=prompt))
+
+        return msgs


### PR DESCRIPTION
Adds support for the [Cultural VQA (CVQA)](https://arxiv.org/pdf/2406.05967) benchmark.
Despite 'VQA' being in the name, CVQA is actually multiple-choice. 

<img width="662" height="246" alt="Screenshot 2025-07-25 at 12 01 12 AM" src="https://github.com/user-attachments/assets/b639007a-391d-46f9-aacc-62ab94d7ddeb" />


I used the dataset's region+language column (e.g. Japan, Japanese) as `l2-category split`.


[Original dataset link](https://huggingface.co/datasets/afaji/cvqa)
[TSV converted version](https://huggingface.co/datasets/timothycdc/VLMEvalKit_CVQA_GT/blob/main/CVQA.tsv)

