### PR TITLE
[Benchmark] Add MMBench_DEV_KO, SEEDBench_IMG_KO, MMStar_KO, K-DTCBench, LLaVABench_KO

### DIFF
--- a/run.py
+++ b/run.py
@@ -373,7 +373,10 @@ def main():
                         else:
                             judge_kwargs['model'] = 'chatgpt-0125'
                     elif listinstr(['MMVet', 'LLaVABench', 'MMBench_Video'], dataset_name):
-                        judge_kwargs['model'] = 'gpt-4-turbo'
+                        if listinstr(['LLaVABench_KO'], dataset_name):
+                            judge_kwargs['model'] = 'gpt-4o-2024-08-06'
+                        else:
+                            judge_kwargs['model'] = 'gpt-4-turbo'
                     elif listinstr(['VGRPBench'], dataset_name):
                         judge_kwargs['model'] = 'gpt-4o'
                     elif listinstr(['MathVista', 'MathVerse', 'MathVision', 'DynaMath', 'VL-RewardBench', 'LogicVista', 'MOAT', 'OCR_Reasoning'], dataset_name):  # noqa: E501

--- a/run.py
+++ b/run.py
@@ -374,7 +374,7 @@ def main():
                             judge_kwargs['model'] = 'chatgpt-0125'
                     elif listinstr(['MMVet', 'LLaVABench', 'MMBench_Video'], dataset_name):
                         if listinstr(['LLaVABench_KO'], dataset_name):
-                            judge_kwargs['model'] = 'gpt-4o-2024-08-06'
+                            judge_kwargs['model'] = 'gpt-4o-0806'
                         else:
                             judge_kwargs['model'] = 'gpt-4-turbo'
                     elif listinstr(['VGRPBench'], dataset_name):

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -11,9 +11,9 @@ from .image_mcq import (
 )
 from .image_mt import MMDUDataset
 from .image_vqa import (
-    ImageVQADataset, MathVision, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet, MTVQADataset, TableVQABench,
-    CustomVQADataset, CRPE, MathVerse, OlympiadBench, SeePhys, QSpatial, VizWiz, MMNIAH, LogicVista, MME_CoT,
-    MMSci_Captioning, Physics_yale, TDBenchGrounding, WildDocBenchmark, OCR_Reasoning, PhyX, CountBenchQA,
+    ImageVQADataset, MathVision, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet, MTVQADataset,
+    TableVQABench, CustomVQADataset, CRPE, MathVerse, OlympiadBench, SeePhys, QSpatial, VizWiz, MMNIAH, LogicVista,
+    MME_CoT, MMSci_Captioning, Physics_yale, TDBenchGrounding, WildDocBenchmark, OCR_Reasoning, PhyX, CountBenchQA,
     ZEROBench, Omni3DBench, TallyQA, MMEReasoning, MMVMBench, BMMR, OCRBench_v2
 )
 

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -11,7 +11,7 @@ from .image_mcq import (
 )
 from .image_mt import MMDUDataset
 from .image_vqa import (
-    ImageVQADataset, MathVision, OCRBench, MathVista, LLaVABench, VGRPBench, MMVet, MTVQADataset, TableVQABench,
+    ImageVQADataset, MathVision, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet, MTVQADataset, TableVQABench,
     CustomVQADataset, CRPE, MathVerse, OlympiadBench, SeePhys, QSpatial, VizWiz, MMNIAH, LogicVista, MME_CoT,
     MMSci_Captioning, Physics_yale, TDBenchGrounding, WildDocBenchmark, OCR_Reasoning, PhyX, CountBenchQA,
     ZEROBench, Omni3DBench, TallyQA, MMEReasoning, MMVMBench, BMMR, OCRBench_v2
@@ -188,7 +188,7 @@ class ConcatDataset(ImageBaseDataset):
 # Add new supported dataset class here
 IMAGE_DATASET = [
     ImageCaptionDataset, ImageYORNDataset, ImageMCQDataset, ImageVQADataset,
-    MathVision, MMMUDataset, OCRBench, MathVista, LLaVABench, VGRPBench, MMVet,
+    MathVision, MMMUDataset, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet,
     MTVQADataset, TableVQABench, MMLongBench, VCRDataset, MMDUDataset, DUDE,
     SlideVQA, MUIRDataset, CCOCRDataset, GMAIMMBenchDataset, MMERealWorld,
     HRBenchDataset, CRPE, MathVerse, NaturalBenchDataset, MIABench,

--- a/vlmeval/dataset/image_base.py
+++ b/vlmeval/dataset/image_base.py
@@ -20,6 +20,7 @@ def img_root_map(dataset):
     mmbench_root_map = {
         'MMBench_DEV_EN': 'MMBench', 'MMBench_TEST_EN': 'MMBench',
         'MMBench_DEV_CN': 'MMBench', 'MMBench_TEST_CN': 'MMBench',
+        'MMBench_DEV_KO': 'MMBench',
         'MMBench': 'MMBench', 'MMBench_CN': 'MMBench',
         'MMBench_DEV_EN_V11': 'MMBench_V11', 'MMBench_TEST_EN_V11': 'MMBench_V11',
         'MMBench_DEV_CN_V11': 'MMBench_V11', 'MMBench_TEST_CN_V11': 'MMBench_V11',

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -49,6 +49,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MMBench_TEST_EN': 'https://opencompass.openxlab.space/utils/benchmarks/MMBench/MMBench_TEST_EN.tsv',
         'MMBench_DEV_CN': 'https://opencompass.openxlab.space/utils/benchmarks/MMBench/MMBench_DEV_CN.tsv',
         'MMBench_TEST_CN': 'https://opencompass.openxlab.space/utils/benchmarks/MMBench/MMBench_TEST_CN.tsv',
+        'MMBench_DEV_KO': 'https://huggingface.co/datasets/NCSOFT/K-MMBench/resolve/main/MMBench_DEV_KO.tsv',
         'MMBench': 'https://opencompass.openxlab.space/utils/benchmarks/MMBench/MMBench.tsv',  # Internal
         'MMBench_CN': 'https://opencompass.openxlab.space/utils/benchmarks/MMBench/MMBench_CN.tsv',  # Internal
         # MMBench v1.1
@@ -60,6 +61,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MMBench_CN_V11': 'https://opencompass.openxlab.space/utils/benchmarks/MMBench/MMBench_CN_V11.tsv',  # Internal
         # SEEDBench Series
         'SEEDBench_IMG': 'https://opencompass.openxlab.space/utils/benchmarks/SEEDBench/SEEDBench_IMG.tsv',
+        'SEEDBench_IMG_KO': 'https://huggingface.co/datasets/NCSOFT/K-SEED/resolve/main/SEEDBench_IMG_KO.tsv',
         'SEEDBench2': 'https://huggingface.co/datasets/VLMEval/SEEDBench2/resolve/main/SEEDBench2.tsv',
         'SEEDBench2_Plus': 'https://opencompass.openxlab.space/utils/benchmarks/SEEDBench/SEEDBench2_Plus.tsv',
         # ScienceQA Series
@@ -87,6 +89,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'AI2D_TEST': 'https://opencompass.openxlab.space/utils/VLMEval/AI2D_TEST.tsv',
         'AI2D_TEST_NO_MASK': 'https://opencompass.openxlab.space/utils/VLMEval/AI2D_TEST_NO_MASK.tsv',
         'MMStar': 'https://opencompass.openxlab.space/utils/VLMEval/MMStar.tsv',
+        'MMStar_KO': 'https://huggingface.co/datasets/NCSOFT/K-MMStar/resolve/main/MMStar_KO.tsv',
         'RealWorldQA': 'https://opencompass.openxlab.space/utils/VLMEval/RealWorldQA.tsv',
         'MLLMGuard_DS': 'https://opencompass.openxlab.space/utils/VLMEval/MLLMGuard_DS.tsv',
         'BLINK': 'https://opencompass.openxlab.space/utils/VLMEval/BLINK.tsv',
@@ -104,6 +107,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MMCR': 'http://opencompass.openxlab.space/utils/VLMEval/MMCR.tsv',
         'MMSci_DEV_MCQ': 'https://opencompass.openxlab.space/utils/VLMEval/MMSci_DEV_MCQ.tsv',
         "MMVP": "http://opencompass.openxlab.space/utils/VLMEval/MMVP.tsv",
+        "K-DTCBench": "https://huggingface.co/datasets/NCSOFT/K-DTCBench/resolve/main/K-DTCBench.tsv",
         # For Internal Use Only
         'MMBench_V11_MINI': 'https://opencompass.openxlab.space/utils/TEST/MMBench_V11_MINI.tsv',
         'MMStar_MINI': 'https://opencompass.openxlab.space/utils/TEST/MMStar_MINI.tsv',
@@ -125,6 +129,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MMBench_TEST_EN': '6939fadb0ce626fefc0bdc9c64efc528',
         'MMBench_DEV_CN': '08b8fc3324a5ed74155350f57be69fbd',
         'MMBench_TEST_CN': '7e1239baf0ee4c8b513e19705a0f317e',
+        'MMBench_DEV_KO': '72e1cde9124b5015be6d0dd5c9b5500d',
         'MMBench': '4115aea3383f3dd0083be6a633e0f820',  # Internal Only
         'MMBench_CN': '2e053ffc90ea598b1feae13c36dc13ee',    # Internal Only
         # MMBench v1.1
@@ -136,6 +141,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MMBench_CN_V11': '95f6980dd1b4de38e3cbffe0305a3f25',    # Internal Only
         # SEEDBench
         'SEEDBench_IMG': '68017231464752261a2526d6ca3a10c0',
+        'SEEDBench_IMG_KO': 'b354a9ac3493f3ccf294e69b216bfab3',
         'SEEDBench2': '4ec15cf864c4f16274112284f531813e',
         'SEEDBench2_Plus': 'e32d3216dc4f452b0fe497a52015d1fd',
         # ScienceQA
@@ -163,6 +169,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'AI2D_TEST': '0f593e0d1c7df9a3d69bf1f947e71975',
         'AI2D_TEST_NO_MASK': 'fd8f463634d4fe9fbd23b876e8eea5be',
         'MMStar': 'e1ecd2140806c1b1bbf54b43372efb9e',
+        'MMStar_KO': 'cc6049c7314bb54b9ac5e247a2bfb357',
         'RealWorldQA': '4de008f55dc4fd008ca9e15321dc44b7',
         'MLLMGuard_DS': '975fc0dd7119386e198c37d71e274b3f',
         'BLINK': '3b6649b6a662184ea046908e5506260e',
@@ -173,6 +180,7 @@ class ImageMCQDataset(ImageBaseDataset):
         'MMCR': '9052635f2c3835bdb87755ef73564f5e',
         'MMSci_DEV_MCQ': '865144aa866e29b251bdc7d63a735b6b',
         "MMVP": "8cb732b141a0cba5b42159df2839e557",
+        "K-DTCBench": "fe72a85b010513d3840b5f3be2de6ed3",
         "VStarBench": "b18854d7075574be06b631cd5f7d2d6a",
         'MicroVQA': 'd7506438701a2076ec277f8bb3586c1a',
         'MMSIBench_circular': '7be2b9e8a280863272e89fab5ba40807',

--- a/vlmeval/dataset/utils/llavabench.py
+++ b/vlmeval/dataset/utils/llavabench.py
@@ -58,7 +58,7 @@ def build_prompt_ko(line):
     ans1 = line['gpt4_ans']
     ans2 = line['prediction']
     category = 'llava_bench_' + line['category']
-    rule = rule_dict[category]
+    rule = rule_dict_ko[category]
     role, prompt = rule['role'], rule['prompt']
 
     content = (f'[설명]\n{cap_str}\n\n'

--- a/vlmeval/dataset/utils/llavabench.py
+++ b/vlmeval/dataset/utils/llavabench.py
@@ -8,6 +8,12 @@ rule_dict = {
     'llava_bench_complex': {'role': 'Assistant', 'prompt': 'We would like to request your feedback on the performance of two AI assistants in response to the user question displayed above. The user asks the question on observing an image. For your reference, the visual content in the image is represented with a few sentences describing the image. \nPlease rate the helpfulness, relevance, accuracy, level of details of their responses. Each assistant receives an overall score on a scale of 1 to 10, where a higher score indicates better overall performance.\nPlease first output a single line containing only two values indicating the scores for Assistant 1 and 2, respectively. The two scores are separated by a space.\nIn the subsequent line, please provide a comprehensive explanation of your evaluation, avoiding any potential bias and ensuring that the order in which the responses were presented does not affect your judgment.'}  # noqa: E501
 }
 
+rule_dict_ko = {
+    'llava_bench_conv': {'role': '어시스턴트', 'prompt': '두 인공지능 어시스턴트의 성능을 [질문]에 대한 응답에 기반하여 평가하세요. 해당 [질문]은 특정 이미지를 보고 생성되었습니다. `유용성`, `관련성`, `정확성`, `세부 수준`, `한국어 생성능력`을 기준으로 응답을 평가하세요. 각각의 어시스턴트에게 1에서 10까지의 전반적인 점수를 부여하며, 높은 점수일수록 더 나은 전반적인 성능을 나타냅니다.\n\n# 단계\n1. 제공된 이미지 [설명]을 검토하세요.\n2. 각 어시스턴트의 응답을 다음 기준으로 분석하세요:\n   - `유용성`: 응답이 사용자의 질문을 얼마나 잘 해결하는가?\n   - `관련성`: 응답이 사용자의 질문에 얼마나 적절한가?\n   - `정확성`: 응답에서 제공한 정보가 얼마나 정확한가?\n   - `세부 수준`: 응답이 과하지 않게 충분히 자세한가?\n   - `한국어 생성능력`: 생성된 한국어 문장이 자연스럽고 문법적으로 올바른가?\n3. 분석에 기반하여 각 어시스턴트에게 1에서 10까지의 점수를 부여하세요.\n4. 두 점수를 공백으로 구분하여 한 줄로 제공하세요.\n5. 점수에 대한 이유를 강조하면서 포괄적인 평가를 제공하고, 편견을 피하며 응답의 순서가 판단에 영향을 미치지 않도록 하세요.\n\n# 출력 형식\n- 첫 번째 줄: `어시스턴트1_점수 어시스턴트2_점수` (예: `8 9`)\n- 두 번째 줄: `유용성`, `관련성`, `정확성`, `세부 수준`, `한국어 생성능력` 기준으로 점수를 설명하는 자세한 문단을 제공합니다.\n\n# 주의사항\n- 평가 시 잠재적 편견을 방지하여 객관성을 확보하세요.\n- 분석과 설명에서 일관성과 명확성을 유지하세요.'},  # noqa: E501
+    'llava_bench_detail': {'role': '어시스턴트', 'prompt': '두 인공지능 어시스턴트의 성능을 [질문]에 대한 응답에 기반하여 평가하세요. 해당 [질문]은 특정 이미지를 보고 생성되었습니다. `유용성`, `관련성`, `정확성`, `세부 수준`, `한국어 생성능력`을 기준으로 응답을 평가하세요. 각각의 어시스턴트에게 1에서 10까지의 전반적인 점수를 부여하며, 높은 점수일수록 더 나은 전반적인 성능을 나타냅니다.\n\n# 단계\n1. 제공된 이미지 [설명]을 검토하세요.\n2. 각 어시스턴트의 응답을 다음 기준으로 분석하세요:\n   - `유용성`: 응답이 사용자의 질문을 얼마나 잘 해결하는가?\n   - `관련성`: 응답이 사용자의 질문에 얼마나 적절한가?\n   - `정확성`: 응답에서 제공한 정보가 얼마나 정확한가?\n   - `세부 수준`: 응답이 과하지 않게 충분히 자세한가?\n   - `한국어 생성능력`: 생성된 한국어 문장이 자연스럽고 문법적으로 올바른가?\n3. 분석에 기반하여 각 어시스턴트에게 1에서 10까지의 점수를 부여하세요.\n4. 두 점수를 공백으로 구분하여 한 줄로 제공하세요.\n5. 점수에 대한 이유를 강조하면서 포괄적인 평가를 제공하고, 편견을 피하며 응답의 순서가 판단에 영향을 미치지 않도록 하세요.\n\n# 출력 형식\n- 첫 번째 줄: `어시스턴트1_점수 어시스턴트2_점수` (예: `8 9`)\n- 두 번째 줄: `유용성`, `관련성`, `정확성`, `세부 수준`, `한국어 생성능력` 기준으로 점수를 설명하는 자세한 문단을 제공합니다.\n\n# 주의사항\n- 평가 시 잠재적 편견을 방지하여 객관성을 확보하세요.\n- 분석과 설명에서 일관성과 명확성을 유지하세요.'},  # noqa: E501
+    'llava_bench_complex': {'role': '어시스턴트', 'prompt': '두 인공지능 어시스턴트의 성능을 [질문]에 대한 응답에 기반하여 평가하세요. 해당 [질문]은 특정 이미지를 보고 생성되었습니다. `유용성`, `관련성`, `정확성`, `세부 수준`, `한국어 생성능력`을 기준으로 응답을 평가하세요. 각각의 어시스턴트에게 1에서 10까지의 전반적인 점수를 부여하며, 높은 점수일수록 더 나은 전반적인 성능을 나타냅니다.\n\n# 단계\n1. 제공된 이미지 [설명]을 검토하세요.\n2. 각 어시스턴트의 응답을 다음 기준으로 분석하세요:\n   - `유용성`: 응답이 사용자의 질문을 얼마나 잘 해결하는가?\n   - `관련성`: 응답이 사용자의 질문에 얼마나 적절한가?\n   - `정확성`: 응답에서 제공한 정보가 얼마나 정확한가?\n   - `세부 수준`: 응답이 과하지 않게 충분히 자세한가?\n   - `한국어 생성능력`: 생성된 한국어 문장이 자연스럽고 문법적으로 올바른가?\n3. 분석에 기반하여 각 어시스턴트에게 1에서 10까지의 점수를 부여하세요.\n4. 두 점수를 공백으로 구분하여 한 줄로 제공하세요.\n5. 점수에 대한 이유를 강조하면서 포괄적인 평가를 제공하고, 편견을 피하며 응답의 순서가 판단에 영향을 미치지 않도록 하세요.\n\n# 출력 형식\n- 첫 번째 줄: `어시스턴트1_점수 어시스턴트2_점수` (예: `8 9`)\n- 두 번째 줄: `유용성`, `관련성`, `정확성`, `세부 수준`, `한국어 생성능력` 기준으로 점수를 설명하는 자세한 문단을 제공합니다.\n\n# 주의사항\n- 평가 시 잠재적 편견을 방지하여 객관성을 확보하세요.\n- 분석과 설명에서 일관성과 명확성을 유지하세요.'}  # noqa: E501
+}
+
 
 def get_eval(judge, content):
     return judge.generate(content)
@@ -42,6 +48,23 @@ def build_prompt(line):
                f'[Question]\n{question}\n\n'
                f'[{role} 1]\n{ans1}\n\n[End of {role} 1]\n\n'
                f'[{role} 2]\n{ans2}\n\n[End of {role} 2]\n\n'
+               f'[System]\n{prompt}\n\n')
+    return content
+
+
+def build_prompt_ko(line):
+    cap_str = line['caption']
+    question = line['question']
+    ans1 = line['gpt4_ans']
+    ans2 = line['prediction']
+    category = 'llava_bench_' + line['category']
+    rule = rule_dict[category]
+    role, prompt = rule['role'], rule['prompt']
+
+    content = (f'[설명]\n{cap_str}\n\n'
+               f'[질문]\n{question}\n\n'
+               f'[{role} 1]\n{ans1}\n\n[{role} 1 끝]\n\n'
+               f'[{role} 2]\n{ans2}\n\n[{role} 2 끝]\n\n'
                f'[System]\n{prompt}\n\n')
     return content
 


### PR DESCRIPTION
[MMBench_DEV_KO](https://huggingface.co/datasets/NCSOFT/K-MMBench), [SEEDBench_IMG_KO](https://huggingface.co/datasets/NCSOFT/K-SEED), [MMStar_KO](https://huggingface.co/datasets/NCSOFT/K-MMStar), [LLaVABench_KO](https://huggingface.co/datasets/NCSOFT/K-LLaVA-W) are new benchmarks created in Korean based on MMBench, SEEDBench_IMG, MMStar and LLaVABench respectively.

Also, [K-DTCBench](https://huggingface.co/datasets/NCSOFT/K-DTCBench) is a newly developed benchmark featuring both computer-generated and handwritten images of three different types (documents, tables, and charts), all written in Korean.

The paper is here: https://arxiv.org/pdf/2411.19103

Thank you :)