### PR TITLE
fix: correct relaxed_correctness parameter order

### DIFF
--- a/vlmeval/dataset/utils/vqa_eval.py
+++ b/vlmeval/dataset/utils/vqa_eval.py
@@ -272,7 +272,7 @@ def process_line(line, method='vqa_score'):
     elif method == 'relaxed_accuracy':
         ret['gt'] = answers
         ret['pred'] = line['prediction'].strip()
-        ret['match'] = [relaxed_correctness(ret['pred'], x) for x in ret['gt']]
+        ret['match'] = [relaxed_correctness(x, ret['pred']) for x in ret['gt']]
     elif method == 'accuracy':
         ret['gt'] = answers
         ret['pred'] = line['prediction'].strip()
@@ -314,7 +314,7 @@ def process_line_WildDoc(line, method='vqa_score'):
     elif method == 'relaxed_accuracy':
         ret['gt'] = answers
         ret['pred'] = line['prediction'].strip()
-        ret['match'] = [relaxed_correctness(ret['pred'], x) for x in ret['gt']]
+        ret['match'] = [relaxed_correctness(x, ret['pred']) for x in ret['gt']]
     elif method == 'accuracy':
         ret['gt'] = answers
         ret['pred'] = line['prediction'].strip()


### PR DESCRIPTION
There was a bug in the call to the relaxed_correctness function, where the order of the target and prediction parameters was reversed.