### PR TITLE
[Benchmark] Support Aya Vision Bench

### DIFF
--- a/run.py
+++ b/run.py
@@ -393,6 +393,8 @@ def main():
                         judge_kwargs['model'] = 'gpt-4o'
                     elif listinstr(['M4Bench'], dataset_name):
                         judge_kwargs['model'] = 'gpt-4o'
+                    elif listinstr(['AyaVisionBench'], dataset_name):
+                        judge_kwargs['model'] = 'gpt-4.1'
 
                 if args.use_verifier:
                     judge_kwargs['use_verifier'] = True

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -14,7 +14,7 @@ from .image_vqa import (
     ImageVQADataset, MathVision, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet, MTVQADataset,
     TableVQABench, CustomVQADataset, CRPE, MathVerse, OlympiadBench, SeePhys, QSpatial, VizWiz, MMNIAH, LogicVista,
     MME_CoT, MMSci_Captioning, Physics_yale, TDBenchGrounding, WildDocBenchmark, OCR_Reasoning, PhyX, CountBenchQA,
-    ZEROBench, Omni3DBench, TallyQA, MMEReasoning, MMVMBench, BMMR, OCRBench_v2
+    ZEROBench, Omni3DBench, TallyQA, MMEReasoning, MMVMBench, BMMR, OCRBench_v2, AyaVisionBench
 )
 
 from .image_ccocr import CCOCRDataset
@@ -204,7 +204,7 @@ IMAGE_DATASET = [
     WildDocBenchmark, MSEarthMCQ, OCR_Reasoning, PhyX, VLMBlind, CountBenchQA,
     ZEROBench, SCAM, Omni3DBench, TallyQA, _3DSRBench, BMMR, AffordanceDataset,
     MMEReasoning, GOBenchDataset, SFE, ChartMimic, MMVMBench, XLRSBench,
-    OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench, M4Bench
+    OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench, M4Bench, AyaVisionBench
 ]
 
 

--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -3487,3 +3487,84 @@ class OCRBench_v2(ImageBaseDataset):
         score_pth = eval_file.replace('.xlsx', '_score.json')
         dump(final_score_dict, score_pth)
         return final_score_dict
+
+
+class AyaVisionBench(ImageVQADataset):
+    TYPE = 'VQA'
+    DATASET_URL = {
+        "AyaVisionBench":
+            "https://huggingface.co/datasets/timothycdc/"
+            "VLMEvalKit_AyaVisionBench/resolve/main/aya_vision_bench.tsv"
+    }
+
+    DATASET_MD5 = {
+        "AyaVisionBench": "2bc7f64c767421ba86cf7c035ca74f95"
+    }
+
+    def build_prompt(self, line):
+        msgs = super().build_prompt(line)
+        assert msgs[-1]['type'] == 'text'
+        msgs[-1][
+            'value'] += '\nAnswer the question using a single word or phrase.'
+        return msgs
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        model_name = judge_kwargs.get('model', None)
+        if not model_name:
+            raise ValueError("A model must be specified for "
+                             "AyaVisionBench evaluation. Please use --judge <model_name>.")
+
+        from .utils.ayavision import AyaVision_auxeval
+        model = build_judge(**judge_kwargs)
+        if not model.working():
+            raise RuntimeError("OPENAI API is not working properly. Please check your API key and configuration.")
+
+        suffix = eval_file.split('.')[-1]
+        storage = eval_file.replace(f'.{suffix}', f'_{model_name}.xlsx')
+        tmp_file = eval_file.replace(f'.{suffix}', f'_{model_name}.pkl')
+        nproc = judge_kwargs.pop('nproc', 4)
+
+        data = load(eval_file)
+        lt = len(data)
+        lines = [data.iloc[i] for i in range(lt)]
+        tups = [(model, line) for line in lines]
+        indices = [line['index'] for line in lines]
+
+        ans = {}
+        if osp.exists(tmp_file):
+            ans = load(tmp_file)
+
+        tups = [x for x, i in zip(tups, indices) if i not in ans]
+        indices = [i for i in indices if i not in ans]
+
+        if len(indices):
+            new_results = track_progress_rich(
+                AyaVision_auxeval,
+                tups,
+                nproc=nproc,
+                chunksize=nproc,
+                keys=indices,
+                save=tmp_file,
+            )
+            tmp_results = load(tmp_file)
+            for k, v in zip(indices, new_results):
+                assert k in tmp_results and tmp_results[k] == v
+            ans.update(tmp_results)
+
+        data['hit'] = [ans[idx]['hit'] for idx in data['index']]
+        data['res'] = [ans[idx]['res'] for idx in data['index']]
+        data['log'] = [ans[idx]['log'] for idx in data['index']]
+
+        # Rename 'hit' to 'acc' for compatibility with report_acc
+        data['acc'] = data['hit']
+
+        dump(data, storage)
+
+        from .utils.multiple_choice import report_acc
+        ret = report_acc(data)
+
+        ret.round(2)
+
+        result_file = eval_file.replace(f'.{suffix}', '_acc.csv')
+        dump(ret, result_file)
+        return ret

--- a/vlmeval/dataset/utils/ayavision.py
+++ b/vlmeval/dataset/utils/ayavision.py
@@ -1,0 +1,50 @@
+import pandas as pd
+from ...smp import *
+
+
+FAIL_MSG = "Failed to obtain answer via API."
+
+
+def build_prompt_ayavision(line):
+    question = line["question"]
+    prediction = str(line["prediction"])
+    answer = str(line["answer"])
+
+    tmpl = (
+        "You are an expert evaluator. Your task is to determine if the predicted answer "
+        "is a correct response to the given question, using the ground truth answer as a reference. "
+        "The predicted answer does not need to be a verbatim match of the ground truth, "
+        "but it must be semantically equivalent and accurately answer the question.\n"
+        "Respond with '[[CORRECT]]' if the prediction is correct, and '[[WRONG]]' if it is incorrect. "
+        "Do not provide any explanation.\n\n"
+        "Question: {question}\n"
+        "Ground Truth Answer: {answer}\n"
+        "Predicted Answer: {prediction}\n\n"
+        "Is the prediction correct? "
+    )
+    return tmpl.format(question=question, answer=answer, prediction=prediction)
+
+
+def AyaVision_auxeval(model, line):
+    prompt = build_prompt_ayavision(line)
+    log = ""
+    retry = 5
+
+    for i in range(retry):
+        res = model.generate(prompt, temperature=i * 0.5)
+
+        if FAIL_MSG in res:
+            log += f"Try {i}: output is {res}, failed to parse.\\n"
+        elif "[[CORRECT]]" in res:
+            log += "Succeed"
+            hit = 1
+            return dict(log=log, res=res, hit=hit)
+        elif "[[WRONG]]" in res:
+            log += "Succeed"
+            hit = 0
+            return dict(log=log, res=res, hit=hit)
+        else:
+            log += f"Try {i}: output is {res}, failed to parse.\\n"
+
+    log += "All 5 retries failed.\\n"
+    return dict(log=log, res="", hit=0)


### PR DESCRIPTION
<img width="921" height="352" alt="image" src="https://github.com/user-attachments/assets/f152559c-8273-4201-9990-aaa09c4e6fde" />

Adds support for the [Aya Vision Benchmark](https://huggingface.co/datasets/CohereLabs/AyaVisionBench) by Cohere Labs.

From the Hugging Face Page:
> The Aya Vision Benchmark is designed to evaluate vision-language models in real-world multilingual scenarios. It spans 23 languages and 9 distinct task categories, with 15 samples per category, resulting in 135 image-question pairs per language. 


Implementation details:
1. The dataset has the ground truth in a column called 'reference'. My implementation uses GPT4.1 as a judge-evaluator since the responses can be open-ended.
2. The TSV file can be found [here](https://huggingface.co/datasets/timothycdc/VLMEvalKit_AyaVisionBench). Note that I have removed image-question pairs where the ground truth was missing in the dataset.

This benchmark is meant for multilingual models, so testing with primarily-English-trained LLMs will yield poorer results.