### PR TITLE
Fix Gemini backend routing and remove unsupported config kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+environment.yml
 
 # Spyder project settings
 .spyderproject

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -302,10 +302,10 @@ api_models = {
         Gemini, model="gemini-2.0-flash-lite", temperature=0, retry=10
     ),
     "GeminiFlash2-5": partial(
-        Gemini, model="gemini-2.5-flash", temperature=0, retry=10, timeout=1800
+        Gemini, model="gemini-2.5-flash", temperature=0, retry=10
     ),
     "GeminiPro2-5": partial(
-        Gemini, model="gemini-2.5-pro", temperature=0, retry=10, timeout=1800
+        Gemini, model="gemini-2.5-pro", temperature=0, retry=10
     ),
     
     # Qwen-VL

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -302,10 +302,10 @@ api_models = {
         Gemini, model="gemini-2.0-flash-lite", temperature=0, retry=10
     ),
     "GeminiFlash2-5": partial(
-        GPT4V, model="gemini-2.5-flash", temperature=0, retry=10, timeout=1800
+        Gemini, model="gemini-2.5-flash", temperature=0, retry=10, timeout=1800
     ),
     "GeminiPro2-5": partial(
-        GPT4V, model="gemini-2.5-pro", temperature=0, retry=10, timeout=1800
+        Gemini, model="gemini-2.5-pro", temperature=0, retry=10, timeout=1800
     ),
     
     # Qwen-VL


### PR DESCRIPTION
Routes Gemini 2.5 models to the native backend and removes an unsupported `timeout` kwarg from config to prevent runtime errors and improve stability.