### PR TITLE
update internvl_chat.py for InternVL3.5

### DIFF
--- a/vlmeval/vlm/internvl/internvl_chat.py
+++ b/vlmeval/vlm/internvl/internvl_chat.py
@@ -180,7 +180,11 @@ class InternVLChat(BaseModel):
             self.model = pipeline(
                 model_path,
                 vision_config=vision_config,
-                backend_config=engine_type(session_len=max(16384, kwargs.get("max_new_tokens", 16384)), cache_max_entry_count=0.5, tp=num_gpus)
+                backend_config=engine_type(
+                    session_len=max(16384, kwargs.get("max_new_tokens", 16384)),
+                    cache_max_entry_count=0.5,
+                    tp=num_gpus,
+                )
             )
             torch.cuda.set_device(0)
             self.device = 'cuda'

--- a/vlmeval/vlm/internvl/internvl_chat.py
+++ b/vlmeval/vlm/internvl/internvl_chat.py
@@ -173,14 +173,14 @@ class InternVLChat(BaseModel):
         self.screen_parse = screen_parse
 
         if use_lmdeploy:
-            from lmdeploy import TurbomindEngineConfig, VisionConfig, pipeline, ChatTemplateConfig
+            from lmdeploy import TurbomindEngineConfig, PytorchEngineConfig, VisionConfig, pipeline
+            engine_type = PytorchEngineConfig if "internvl3_5" in model_path.lower() else TurbomindEngineConfig
             vision_config = VisionConfig(max_batch_size=4)
             num_gpus = torch.cuda.device_count()
             self.model = pipeline(
                 model_path,
                 vision_config=vision_config,
-                chat_template_config=ChatTemplateConfig(model_name='internvl2_5'),
-                backend_config=TurbomindEngineConfig(session_len=16384, cache_max_entry_count=0.1, tp=num_gpus)
+                backend_config=engine_type(session_len=max(16384, kwargs.get("max_new_tokens", 16384)), cache_max_entry_count=0.5, tp=num_gpus)
             )
             torch.cuda.set_device(0)
             self.device = 'cuda'
@@ -247,7 +247,7 @@ class InternVLChat(BaseModel):
         assert dataset is None or isinstance(dataset, str)
         tgt_path = self.dump_image(line, dataset)
         if dataset is not None and listinstr(['BMMR'], dataset):
-            self.kwargs['max_new_tokens'] = 8196
+            self.kwargs['max_new_tokens'] = max(self.kwargs.get('max_new_tokens', 4096), 8196)
             print(f'[Warning] BMMR dataset requires a larger max_new_tokens, set to {self.kwargs["max_new_tokens"]}')
 
         if dataset is not None and DATASET_TYPE(dataset) == 'Y/N':


### PR DESCRIPTION
Currently, LMDeploy does not support the Turbomind backend for the Qwen3 series, so we need to use PytorchEngine as the backend to initialize InternVL3.5 when using LMDeploy.

Additionally, during Thinking mode, InternVL3.5 is evaluated with `max_new_tokens=65536`. Therefore, we need to increase the session_len accordingly. `cache_max_entry_count` is also increased to ensure better inference efficiency.