### PR TITLE
Update mlvu.py

### DIFF
--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -24,7 +24,7 @@ class MLVU(ConcatVideoDataset):
     def __init__(self, dataset='MLVU', nframe=0, fps=-1):
         self.DATASET_SETS[dataset] = ['MLVU_MCQ', 'MLVU_OpenEnded']
         self.type_data_dict = {
-            'M-Avg':['plotQA', 'needle', 'ego', 'count', 'anomaly_reco', 'topic_reasoning'],
+            'M-Avg':['plotQA', 'needle', 'ego', 'count', 'anomaly_reco', 'topic_reasoning', 'order'],
             'G-Avg':['sub_scene', 'summary']
         }
         super().__init__(dataset=dataset, nframe=nframe, fps=fps)


### PR DESCRIPTION
Fix missing order items in MCQ task during MLVU Benchmark evaluation.
Previously, the order items were mistakenly omitted, resulting in 259 fewer items being included in the final evaluation results.

修复 MLVU Benchmark 评测过程中 MCQ 任务遗漏 order 项目的问题。
此前在实际计算结果时遗漏了 order 项目，导致最终结果中少了 259 个项目。