### PR TITLE
README: Pin exact transformers for LLaVA-Next to avoid “Got USER: <image>” error

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note that some VLMs may not be able to run under certain transformer versions, w
 - **Please use** `transformers==4.42.0` **for**: `AKI`.
 - **Please use** `transformers==4.44.0` **for**: `Moondream2`, `H2OVL series`.
 - **Please use** `transformers==4.45.0` **for**: `Aria`.
-- **Please use** `transformers==4.48.0` *(or* `4.46.0`*) **for**: `LLaVA-Next series` (e.g., `llava-hf/llava-v1.6-vicuna-7b-hf`).
+- **Please use** `transformers==4.48.0` (or `4.46.0`) **for**: `LLaVA-Next series` (e.g., `llava-hf/llava-v1.6-vicuna-7b-hf`).
 - **Please use** `transformers==latest` **for**: `PaliGemma-3B`, `Chameleon series`, `Video-LLaVA-7B-HF`, `Ovis series`, `Mantis series`, `MiniCPM-V2.6`, `OmChat-v2.0-13B-sinlge-beta`, `Idefics-3`, `GLM-4v-9B`, `VideoChat2-HD`, `RBDash_72b`, `Llama-3.2 series`, `Kosmos series`.
 
 **Torchvision Version Recommendation:**


### PR DESCRIPTION
Refs https://github.com/DrishtiShrrrma/VLMEvalKit/issues/2

### Summary
This PR updates the Transformers Version Recommendation so that LLaVA-Next models don’t default to “latest”. We pin to tested, working versions. This prevents a reproducible crash where the image processor receives the literal <image> placeholder.

### What changed
* Replace the bullet that says **“`transformers==latest` for LLaVA-Next”** with:
* **Use `transformers==4.48.0` (recommended) or `transformers==4.46.0`** for **LLaVA-Next series** (e.g., `llava-hf/llava-v1.6-vicuna-7b-hf`).
* Keep “`transformers==latest`” for the other model families listed in the README.

**Why**
Newer `transformers` builds change image handling and, in our testing, cause LLaVA-Next evaluation to pass the literal placeholder to the processor, leading to:

```
ValueError: Incorrect image source. Must be a valid URL starting with `http://`/ or `https://`/, a valid path to an image file, or a base64 encoded string. Got USER: <image>
```

### Observations (tested)
| `transformers` | Result  | Error / Notes                                              |
| -------------- | ------- | ---------------------------------------------------------- |
| **4.46.0**     | ✅ Works | Stable across tested benchmarks                            |
| **4.48.0**     | ✅ Works | Stable across tested benchmarks                                             |
| **4.57.1**     | ❌ Fails | `ValueError: Incorrect image source. Must be a valid URL starting with `http://` or `https://`, a valid path to an image file, or a base64 encoded string. Got USER: <image>` |
| **5.0.0.dev0** | ❌ Fails | `ValueError: Incorrect image source. Must be a valid URL starting with `http://` or `https://`, a valid path to an image file, or a base64 encoded string. Got USER: <image>`                                           |

### Benchmarks tested
`CountBenchQA`, `MMBench_DEV_EN`, `MME`, `SEEDBench_IMG`

### Model tested
`llava-hf/llava-v1.6-vicuna-7b-hf` (key: `llava_next_vicuna_7b`)

### Minimal repro
```bash
# Failing case (example)
pip install "transformers==4.57.1"
python run.py --data CountBenchQA --model llava_next_vicuna_7b --verbose
# -> ValueError: Incorrect image source ... Got USER: <image>

# Working case (example)
pip install "transformers==4.48.0"
python run.py --data CountBenchQA --model llava_next_vicuna_7b --verbose
# -> runs successfully
```

### Environment
* Platform: Google Colab (Python 3.12.12)
* PyTorch: 2.8.0+cu126 | CUDA: 12.6
* GPU: NVIDIA L4

