### PR TITLE
[Fix] Remove judge model restriction and add proxy support for GPT4V.

### DIFF
--- a/vlmeval/dataset/EgoExoBench/egoexobench.py
+++ b/vlmeval/dataset/EgoExoBench/egoexobench.py
@@ -19,6 +19,7 @@ FAIL_MSG = 'Failed to obtain answer via API.'
 class EgoExoBench_MCQ(VideoBaseDataset):
     MD5 = '9c0aa8da235d766d02dd7e9a19182719'
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='EgoExoBench_MCQ', nframe=64, skip_EgoExo4D=False):
         super().__init__(dataset=dataset, nframe=nframe)
@@ -253,7 +254,6 @@ class EgoExoBench_MCQ(VideoBaseDataset):
 
         if not osp.exists(score_file):
             model = judge_kwargs.get('model', 'exact_matching')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -194,6 +194,7 @@ class ImageMCQDataset(ImageBaseDataset):
     DATASET_URL.update(MTL_MMBench_URLS)
     DATASET_MD5.update(MMMB_MD5)
     DATASET_MD5.update(MTL_MMBench_MD5)
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def build_prompt(self, line):
 
@@ -260,7 +261,6 @@ class ImageMCQDataset(ImageBaseDataset):
             circular = True
 
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -736,6 +736,7 @@ class GMAIMMBenchDataset(ImageMCQDataset):
         'GMAI_mm_bench_TEST_part_10': '3dae94627b9ac0fe00180d4780fbf6dc',
         'GMAI_mm_bench_TEST_part_11': 'd08dc813f0eb6bbab63cae2a9d113c4b',
     }
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     @classmethod
     def supported_datasets(cls):
@@ -807,7 +808,6 @@ class GMAIMMBenchDataset(ImageMCQDataset):
 
         suffix = eval_file.split('.')[-1]
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -1271,6 +1271,7 @@ class CVBench(ImageMCQDataset):
 
 
 class HRBenchDataset(ImageMCQDataset):
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     DATASET_URL = {
         'HRBench4K': 'https://huggingface.co/datasets/DreamMr/HR-Bench/resolve/main/hr_bench_4k.tsv',
@@ -1289,7 +1290,6 @@ class HRBenchDataset(ImageMCQDataset):
         nproc = judge_kwargs.pop('nproc', 4)
 
         model = judge_kwargs.get('model', 'extract_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -1426,6 +1426,7 @@ class WeMath(ImageBaseDataset):
     }
     DATASET_MD5 = {'WeMath': 'b5e969a075f01290a542411fb7766388',
                    'WeMath_COT': 'b5e969a075f01290a542411fb7766388'}
+    DEFAULT_JUDGE = ['gpt-4-0125', 'gpt-4-turbo', 'gpt-4o-mini']
 
     def build_prompt(self, line):
         if isinstance(line, int):
@@ -1473,7 +1474,6 @@ class WeMath(ImageBaseDataset):
 
         # model = judge_kwargs['model']
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['exact_matching', 'gpt-4-0125', 'gpt-4-turbo', 'gpt-4o-mini'], model
         name_str_map = {'gpt-4-0125': 'gpt4', 'gpt-4-turbo': 'gpt4-turbo', 'gpt-4o-mini': 'gpt4o-mini'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -1676,6 +1676,7 @@ class VisuLogic(ImageMCQDataset):
     DATASET_MD5 = {
         'VisuLogic': 'b0820b5ec1e01dfe3951927f0def73b6',
     }
+    DEFAULT_JUDGE = ['gpt-4-0125', 'gpt-4-turbo', 'gpt-4o-mini']
 
     def build_prompt(self, line):
         if isinstance(line, int):
@@ -1708,7 +1709,6 @@ class VisuLogic(ImageMCQDataset):
 
         # model = judge_kwargs['model']
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['exact_matching', 'gpt-4-0125', 'gpt-4-turbo', 'gpt-4o-mini'], model
         name_str_map = {'gpt-4-0125': 'gpt4', 'gpt-4-turbo': 'gpt4-turbo', 'gpt-4o-mini': 'gpt4o-mini'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -1759,6 +1759,7 @@ class TDBench(ImageMCQDataset):
         'tdbench_cs_integrity': '05b2045cae2016f6edc400da48e2df4b',
         'tdbench_cs_depth': '449dbe4b24a43a06a9f680811deae517',
     }
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125', 'gpt-4o-mini']
 
     def evaluate(self, eval_file, **judge_kwargs):
         acc, result_file = self.do_evaluate(eval_file, **judge_kwargs)
@@ -1784,7 +1785,6 @@ class TDBench(ImageMCQDataset):
         nproc = judge_kwargs.pop('nproc', 4)
 
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125', 'gpt-4o-mini']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4', 'gpt-4o-mini': 'gpt4omini'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -2434,6 +2434,7 @@ class _3DSRBench(ImageMCQDataset):
 class AffordanceDataset(ImageMCQDataset):
     DATASET_URL = {'A4Bench': "http://opencompass.openxlab.space/utils/VLMEval/A4Bench.tsv"}
     DATASET_MD5 = {'A4Bench': "7c0dc90e8c03e67ff937f3abb4a3fffb"}
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def build_prompt(self, line):
         if isinstance(line, int):
@@ -2529,7 +2530,6 @@ class AffordanceDataset(ImageMCQDataset):
 
         suffix = eval_file.split('.')[-1]
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4'}
         name_str = name_str_map[model] if model in name_str_map else model
 
@@ -2822,6 +2822,7 @@ class TopViewRS(ImageMCQDataset):
     DATASET_MD5 = {
         'TopViewRS': '5669bc122457979dd2ac3b69b5dc1622'
     }
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def evaluate(self, eval_file, **judge_kwargs):
         from .utils.multiple_choice import eval_vanilla, report_topviewrs_acc
@@ -2906,7 +2907,6 @@ class TopViewRS(ImageMCQDataset):
         nproc = judge_kwargs.pop('nproc', 4)
         suffix = eval_file.split('.')[-1]
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4'}
         name_str = name_str_map[model] if model in name_str_map else model
 

--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -1271,15 +1271,13 @@ class LogicVista(ImageBaseDataset):
         'https://opencompass.openxlab.space/utils/VLMEval/LogicVista.tsv'
     }
     DATASET_MD5 = {'LogicVista': '41c5d33adf33765c399e0e6ae588c061'}
+    DEFAULT_JUDGE = ['gpt-4-0125', 'gpt-4-turbo', 'gpt-4o-mini']
 
     def evaluate(self, eval_file, **judge_kwargs):
         from .utils.logicvista import LogicVista_auxeval, evaluate_logicvista
 
         # model = judge_kwargs['model']
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in [
-            'exact_matching', 'gpt-4-0125', 'gpt-4-turbo', 'gpt-4o-mini'
-        ], model
         name_str_map = {
             'gpt-4-0125': 'gpt4',
             'gpt-4-turbo': 'gpt4-turbo',
@@ -2541,6 +2539,7 @@ class MMSci_Captioning(ImageBaseDataset):
         'MMSci_DEV_Captioning_image_only': '0f5f0fd7ff383699fbd2203a4659d3e8',
         'MMSci_DEV_Captioning_with_abs': 'ae4a9b88166153efd74e28c989e4a484'
     }
+    DEFAULT_JUDGE = ['gpt-4o-0806', 'gemini-1.5-pro-exp-0801']
 
     def evaluate(self, eval_file, **judge_kwargs):
         from .utils.mmsci import (get_all_metrics_for_g_eval_score,
@@ -2618,7 +2617,6 @@ class MMSci_Captioning(ImageBaseDataset):
             model = judge_kwargs.pop('model', 'gpt-4o-0806')
             nproc = judge_kwargs.pop('nproc', 4)
             # not supported gemini-1.5-pro-exp-0801 as judge model yet、
-            assert model in ['gpt-4o-0806', 'gemini-1.5-pro-exp-0801']
             judge_model = build_judge(model=model, **judge_kwargs)
 
             assert judge_model.working(), (

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -94,6 +94,7 @@ class LongVideoBench(VideoBaseDataset):
     SYS = ''
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='LongVideoBench', use_subtitle=False, nframe=0, fps=-1):
         super().__init__(dataset=dataset, nframe=nframe, fps=fps)
@@ -286,7 +287,6 @@ class LongVideoBench(VideoBaseDataset):
 
         if not osp.exists(score_file):
             model = judge_kwargs.get('model', 'exact_matching')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -61,6 +61,7 @@ class MLVU_MCQ(VideoBaseDataset):
     BASE_SYS = 'Carefully watch this video and pay attention to every detail. '
     SYS = BASE_SYS + 'Based on your observations, select the best option that accurately addresses the question.'
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='MLVU_MCQ', nframe=0, fps=-1):
         self.type_data_list = {
@@ -218,7 +219,6 @@ class MLVU_MCQ(VideoBaseDataset):
 
         if not osp.exists(score_file):
             model = judge_kwargs.setdefault('model', 'chatgpt-0125')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -26,6 +26,7 @@ Based on your observations, select the best option that accurately addresses the
 """
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='MVBench', nframe=0, fps=-1):
         self.type_data_list = {
@@ -370,7 +371,6 @@ Based on your observations, select the best option that accurately addresses the
 
         if not osp.exists(score_file):
             model = judge_kwargs.setdefault('model', 'chatgpt-0125')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None
@@ -429,6 +429,7 @@ Based on your observations, select the best option that accurately addresses the
 
 
 class MVBench_MP4(VideoBaseDataset):
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     MP4_MD5 = '5c8c6f8b7972c2de65a629590f7c42f5'
     SYS = """Carefully watch the video and pay attention to the cause and sequence of events, \
@@ -617,7 +618,6 @@ Based on your observations, select the best option that accurately addresses the
 
         if not osp.exists(score_file):
             model = judge_kwargs.setdefault('model', 'chatgpt-0125')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/qbench_video.py
+++ b/vlmeval/dataset/qbench_video.py
@@ -166,7 +166,6 @@ Please do not add any other answers beyond this.
 
         if not osp.exists(score_file):
             model = judge_kwargs.setdefault('model', 'exact_matching')
-            assert model in ['exact_matching']
 
             res = {} if not osp.exists(tmp_file) else load(tmp_file)
             res = {k: v for k, v in res.items() if FAIL_MSG not in v}
@@ -216,6 +215,7 @@ Please analyze these frames and provide a detailed and accurate answer from the 
 """
 
     TYPE = 'Video-VQA'
+    DEFAULT_JUDGE = ['gpt-4o-0806', 'gpt-4o']
 
     def __init__(self, dataset='qbenchvideo_single_VQA', nframe=0, fps=-1):
         dataset_tsv_name = 'qbenchvideo_single_VQA'
@@ -316,7 +316,6 @@ Please analyze these frames and provide a detailed and accurate answer from the 
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
         model = judge_kwargs.setdefault('model', 'gpt-4o-0806')
-        assert model in ['gpt-4o-0806', 'gpt-4o']
 
         score_file = get_intermediate_file_path(eval_file, f'_{model}_score')
         tmp_file = get_intermediate_file_path(eval_file, f'_{model}', 'pkl')

--- a/vlmeval/dataset/tamperbench.py
+++ b/vlmeval/dataset/tamperbench.py
@@ -30,6 +30,7 @@ class MVTamperBench(VideoBaseDataset):
 """
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='MVTamperBench', nframe=0, fps=-1):
         self.dataset_name = dataset
@@ -466,7 +467,6 @@ class MVTamperBench(VideoBaseDataset):
 
         if not osp.exists(score_file):
             model = judge_kwargs.setdefault('model', 'chatgpt-0125')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -59,6 +59,7 @@ class TempCompass_MCQ(VideoBaseDataset):
 
     MD5 = '7efbb9e6d9dabacd22daf274852691dd'
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-1106']
 
     def __init__(self, dataset='TempCompass_MCQ', nframe=0, fps=-1):
         self.type_data_list = {
@@ -205,7 +206,6 @@ class TempCompass_MCQ(VideoBaseDataset):
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-1106', 'exact_matching']
         judge_kwargs.update({
             "max_tokens": 128,
             "temperature": 1.0,
@@ -257,6 +257,7 @@ class TempCompass_Captioning(VideoBaseDataset):
 
     MD5 = '35be9bf2581ea7767f02e9a8f37ae1ab'
     TYPE = 'Video-VQA'
+    DEFAULT_JUDGE = ['chatgpt-1106']
 
     def __init__(self, dataset='TempCompass_Captioning', nframe=0, fps=-1):
         self.type_data_list = {
@@ -402,7 +403,6 @@ class TempCompass_Captioning(VideoBaseDataset):
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
         model = judge_kwargs.setdefault('model', 'chatgpt-1106')
-        assert model in ['chatgpt-1106']
         judge_kwargs.update({
             "max_tokens": 128,
             "temperature": 1.0,
@@ -454,6 +454,7 @@ class TempCompass_YorN(VideoBaseDataset):
 
     MD5 = 'c72c046d7fa0e82c8cd7462f2e844ea8'
     TYPE = 'Video-Y/N'
+    DEFAULT_JUDGE = ['chatgpt-1106']
 
     def __init__(self, dataset='TempCompass_YorN', nframe=0, fps=-1):
         self.type_data_list = {
@@ -598,7 +599,6 @@ class TempCompass_YorN(VideoBaseDataset):
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-1106', 'exact_matching']
         judge_kwargs.update({
             "max_tokens": 128,
             "temperature": 1.0,

--- a/vlmeval/dataset/text_mcq.py
+++ b/vlmeval/dataset/text_mcq.py
@@ -11,6 +11,8 @@ class TextMCQDataset(TextBaseDataset):
 
     DATASET_MD5 = {}
 
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
+
     def build_prompt(self, line):
 
         if isinstance(line, int):
@@ -54,7 +56,6 @@ class TextMCQDataset(TextBaseDataset):
 
         circular = False
         model = judge_kwargs.get('model', 'exact_matching')
-        assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
         name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4'}
         name_str = name_str_map[model] if model in name_str_map else model
 

--- a/vlmeval/dataset/video_holmes.py
+++ b/vlmeval/dataset/video_holmes.py
@@ -40,6 +40,7 @@ class Video_Holmes(VideoBaseDataset):
     """  # noqa: E501
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='Video_Holmes', nframe=32, fps=-1):
         super().__init__(dataset=dataset, nframe=nframe, fps=fps)
@@ -213,7 +214,6 @@ class Video_Holmes(VideoBaseDataset):
 
         if not osp.exists(score_file):
             model = judge_kwargs.get('model', 'exact_matching')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -48,6 +48,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 """
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='Video-MME', use_subtitle=False, nframe=0, fps=-1):
         super().__init__(dataset=dataset, nframe=nframe, fps=fps)
@@ -240,7 +241,6 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         if not osp.exists(score_file):
             model = judge_kwargs.get('model', 'exact_matching')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/videott.py
+++ b/vlmeval/dataset/videott.py
@@ -41,6 +41,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 """
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='Video-TT', nframe=0, fps=-1):
         super().__init__(dataset=dataset, nframe=nframe, fps=fps)
@@ -194,7 +195,6 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         if not osp.exists(score_file):
             model = judge_kwargs.get('model', 'exact_matching')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None

--- a/vlmeval/dataset/worldsense.py
+++ b/vlmeval/dataset/worldsense.py
@@ -36,6 +36,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 """
 
     TYPE = 'Video-MCQ'
+    DEFAULT_JUDGE = ['chatgpt-0125', 'gpt-4-0125']
 
     def __init__(self, dataset='WorldSense', use_subtitle=False, use_audio=False, nframe=0, fps=-1):
         super().__init__(dataset=dataset, nframe=nframe, fps=fps)
@@ -291,7 +292,6 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         if not osp.exists(score_file):
             model = judge_kwargs.get('model', 'exact_matching')
-            assert model in ['chatgpt-0125', 'exact_matching', 'gpt-4-0125']
 
             if model == 'exact_matching':
                 model = None


### PR DESCRIPTION
1. Some benchmarks restrict the judge model type by assertion. But it's not necessary to restrict users to choose judge models.
2. Remove the restriction of `OPENAI_API_KEY` format.
3. Respect `http_proxy` and `https_proxy` environment variables for `GPT4V`.