### PR TITLE
anno-qwen-pixels

### DIFF
--- a/docs/en/Quickstart.md
+++ b/docs/en/Quickstart.md
@@ -54,6 +54,19 @@ To infer with API models (GPT-4v, Gemini-Pro-V, etc.) or use LLM APIs as the **j
 
 **VLM Configuration**: All VLMs are configured in `vlmeval/config.py`. Few legacy VLMs (like MiniGPT-4, LLaVA-v1-7B) requires additional configuration (configuring the code / model_weight root in the config file). During evaluation, you should use the model name specified in `supported_VLM` in `vlmeval/config.py` to select the VLM. Make sure you can successfully infer with the VLM before starting the evaluation with the following command `vlmutil check {MODEL_NAME}`.
 
+Note: For the Qwen-VL series models (Qwen-VL, Qwen2-VL, Qwen2.5-VL), the upper and lower bounds of the number of pixels specified in vlmeval/config.py are as follows:
+
+```
+min_pixels=1280 * 28 * 28,
+max_pixels=16384 * 28 * 28,
+```
+Where 1280 is the maximum value recommended by Qwen for balancing performance, computational resources, and memory, and 16384 is the theoretical maximum value for model input. This setting has a positive effect on some vision tasks that require high resolution (such as document understanding). However, there is no practical basis for considering this setting. If you need to align with the official settings, you can remove these two values, or set them to the following values from the official Qwen demo:
+
+```
+min_pixels=256 * 28 * 28,
+max_pixels=1280 * 28 * 28,
+```
+
 ## Step 2. Evaluation
 
 **New!!!**  We integrated a new config system to enable more flexible evaluation settings. Check the [Document](/docs/en/ConfigSystem.md) or run `python run.py --help` for more details 🔥🔥🔥

--- a/docs/zh-CN/Quickstart.md
+++ b/docs/zh-CN/Quickstart.md
@@ -53,6 +53,19 @@ pip install -e .
 
 **VLM 配置**：所有 VLMs 都在 `vlmeval/config.py` 中配置。对于某些 VLMs（如 MiniGPT-4、LLaVA-v1-7B），需要额外的配置（在配置文件中配置代码 / 模型权重根目录）。在评估时，你应该使用 `vlmeval/config.py` 中 `supported_VLM` 指定的模型名称来选择 VLM。确保在开始评估之前，你可以成功使用 VLM 进行推理，使用以下命令 `vlmutil check {MODEL_NAME}`。
 
+注：对于Qwen-VL系列模型（Qwen-VL, Qwen2-VL, Qwen2.5-VL），vlmeval/config.py 中所指定的像素数量上下界如下：
+
+```
+min_pixels=1280 * 28 * 28,
+max_pixels=16384 * 28 * 28,
+```
+其中，1280为Qwen官方为平衡性能、计算资源与内存的推荐最大值，而16384为模型输入的理论最大值。这种设定对于部分需要高分辨率的视觉任务（如文档理解）有着积极的作用。但考虑这一设定并没有实际的依据，如果需要与官方的设定对齐，可以去掉这两个数值，或是设置为以下来自Qwen官方demo的数值：
+
+```
+min_pixels=256 * 28 * 28,
+max_pixels=1280 * 28 * 28,
+```
+
 ## 第2步 评测
 
 **新功能!!!** 我们集成了一个新的配置系统，以实现更灵活的评估设置。查看[文档](/docs/zh-CN/ConfigSystem.md)或运行`python run.py --help`了解更多详情 🔥🔥🔥


### PR DESCRIPTION
Add explanations and customization suggestions for the default pixel count settings of the Qwen-VL series to ensure that the results obtained using VLMEvalKit are comparable to those obtained using other eval methods. #1370 