### PR TITLE
granite vision fix for transformers 4.57.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,4 +213,3 @@ SenseNova*
 
 temp
 result*
-*.tsv


### PR DESCRIPTION
Fixes granite vision for new transformers version as the syntax of llava class changed and caused the code to fail. Also adding slight prompt adjustments.
I am a part of the team building GraniteVision.
Expected results for this version are similar to before transformers LLAVA change and fits GraniteVision3.3 HF model card.
Results summary:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/amit/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/amit/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:1.0in .75in 1.0in .75in;
	mso-header-margin:.5in;
	mso-footer-margin:.5in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->
</head>

<body link="#467886" vlink="#96607D">


dataset(metric) | granite_vision_3.3_2b
-- | --
AI2D_TEST(Overall) | 0.76522021
ChartQA_TEST(Overall) | 86.8
ChartQA_TEST(test_augmented) | 95.44
ChartQA_TEST(test_human) | 78.16
DocVQA_VAL(Overall) | 90.376641
InfoVQA_VAL(Overall) | 68.6316922
MMMU_DEV_VAL(Overall) | 0.40666667
OCRBench(Final Score Norm) | 82.2
RealWorldQA(Overall) | 0.66143791
TextVQA_VAL(Overall) | 81.1
OCRVQA_TEST | 62.07



</body>

</html>
