### PR TITLE
[Fix] Optimize the evaluation process for OCR-Reasoning

### DIFF
--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -2899,7 +2899,7 @@ class OCR_Reasoning(ImageBaseDataset):
         nproc = judge_kwargs.pop('nproc', 4)
         if not osp.exists(storage):
             data = load(eval_file)
-            model = build_judge(max_tokens=1024, **judge_kwargs)
+            model = build_judge(max_tokens=16384, **judge_kwargs)
             assert model.working(), 'OCRReasoning evaluation requires a working OPENAI API\n' + DEBUG_MESSAGE
             lt = len(data)
             lines = [data.iloc[i] for i in range(lt)]


### PR DESCRIPTION
## fix1: delete the hardcoded "nproc=1" in the evaluation of OCR_Reasoning
Delete the hardcoded "nproc=1" in the evaluation of OCR_Reasoning to accelerate the LLM judging process.

## fix2: Increase max_tokens of the LLM Judge for OCR-Reasoning
The OCR-Reasoning evaluation involves scoring of reasoning processes where the LLM judge is prompted to output explanatory text before final ratings.

https://github.com/open-compass/VLMEvalKit/blob/2c25371d602909ae3d6d395185aff1bc9493262d/vlmeval/dataset/utils/ocr_reasoning.py#L7

Therefore, the original 1024 max_tokens setting is insufficient, constantly leading to unintended response truncation.