### PR TITLE
[Fix] stop poisoning EVAL_FORMAT for subsequent datasets

### DIFF
--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -4298,7 +4298,7 @@ class VLMsAreBiased(ImageBaseDataset):
 
         summary_dict = vlms_are_biased_aggregate_by_topic(detail_result)
 
-        score_file = get_intermediate_file_path(eval_file, '_metrics', 'json')
+        score_file = get_intermediate_file_path(eval_file, '_metrics', target_format='json')
         dump(summary_dict, score_file)
 
         return summary_dict


### PR DESCRIPTION
Two benchmarks' evaluate() functions did os.environ['EVAL_FORMAT'] = 'json' to make their own output JSON.

But, os.environ is global for the entire process. Every dataset evaluated after this one in the same run would then also output JSON, silently. They should not modify global environment variables.

Fixed by passing 'json' directly as target_format to get_intermediate_file_path().