### PR TITLE
[Benchmark] Add support for MMOral-OPG-Closed benchmark

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -83,6 +83,7 @@ from .mmhelix import MMHELIX
 from .mmifeval import MMIFEval
 from .mmlongbench import MMLongBench
 from .mmmath import MMMath
+from .mmoral_opg_closed import MMOral_OPG_CLOSED
 from .mmoral_opg_open import MMOral_OPG_OPEN
 from .mmsafetybench import MMSafetyBenchDataset
 from .mmsibench import MMSIBench, MMSIVideoBench
@@ -154,8 +155,6 @@ from .worldvqa import WorldVQA
 from .xstest import XSTestDataset
 
 from .video_dataset_config import supported_video_datasets  # isort: skip
-
-from .mmoral_opg_closed import MMOral_OPG_CLOSED
 
 
 class ConcatDataset(ImageBaseDataset):

--- a/vlmeval/dataset/mmoral_opg_closed.py
+++ b/vlmeval/dataset/mmoral_opg_closed.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 import pandas as pd
 from tqdm import tqdm
 
-from .image_base import ImageBaseDataset
 from ..smp import decode_base64_to_image_file, dump, load, read_ok
+from .image_base import ImageBaseDataset
 
 
 class MMOralBase(ImageBaseDataset):

--- a/vlmeval/dataset/utils/mmoral_opg.py
+++ b/vlmeval/dataset/utils/mmoral_opg.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import random
+from collections import defaultdict
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary

This PR adds **MMOral_OPG_CLOSED**, a closed-ended 4-option MCQ benchmark on panoramic radiographs analysis, to VLMEvalKit.  
The benchmark is from the NeurIPS 2025 paper *“Towards Better Dental AI: A Multimodal Benchmark and Instruction Dataset for Panoramic X-ray Analysis”* ([arXiv:2509.09254](https://arxiv.org/pdf/2509.09254)).

## Dataset

- Task: single-choice MCQ (A/B/C/D) on OPG images, covering tooth findings, pathology, treatment history, jaw 
- URL: `https://huggingface.co/datasets/OralGPT/MMOral-OPG-Bench/resolve/main/MMOral-OPG-Bench-Closed-Ended.tsv`

## Evaluation

- Models generate free-form predictions that may include the option letter and/or option text.
- We decode the final choice using `get_single_choice_prediction` from `vlmeval/dataset/utils/mmoral_opg.py`.
- We report accuracy per main category (Teeth, Patho, HisT, Jaw, SumRec) and overall in:
  - `<model>_MMOral_OPG_CLOSED_acc.csv`
  - `<model>_MMOral_OPG_CLOSED_detailed_acc.csv`.
