### PR TITLE
[Fix] SciDocBench: use empty DATASET_MD5 to skip hash check on TSV updates

### DIFF
--- a/vlmeval/dataset/scidocbench.py
+++ b/vlmeval/dataset/scidocbench.py
@@ -328,7 +328,7 @@ class SciDocBench(ImageBaseDataset):
         'SciDocBench': 'https://opencompass.openxlab.space/utils/VLMEvalKit/SciDocBench.tsv',
     }
     DATASET_MD5 = {
-        'SciDocBench': '8947fc96f82c825bd6c9c1167821cd5b',
+        'SciDocBench': '',
     }
 
     def dump_image(self, line):


### PR DESCRIPTION
…pdates