### PR TITLE
[Model] Add Solari: SmolVLM2-500M fine-tuned with QLoRA DPO on RLAIF-V

### DIFF
--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -1672,6 +1672,7 @@ smolvlm_series = {
         vlm.SmolVLM2, model_path="HuggingFaceTB/SmolVLM2-500M-Video-Instruct"
     ),
     "SmolVLM2": partial(vlm.SmolVLM2, model_path="HuggingFaceTB/SmolVLM2-2.2B-Instruct"),
+    "Solari": partial(vlm.SmolVLM2, model_path="Cubex11/Solari"),
 }
 
 instructblip_series = {

--- a/vlmeval/vlm/smolvlm.py
+++ b/vlmeval/vlm/smolvlm.py
@@ -364,10 +364,11 @@ class SmolVLM2(BaseModel):
         # Set resolution based on model
         if "SmolVLM2-2.2B" in model_path:
             self.resolution = 384
-        elif "SmolVLM2-256M" in model_path or "SmolVLM2-500M" in model_path:
+        elif "SmolVLM2-256M" in model_path or "SmolVLM2-500M" in model_path or "Solari" in model_path:
             self.resolution = 512
         else:
-            raise ValueError(f"Unknown model {model_path}, cannot determine resolution")
+            self.resolution = 512
+            warnings.warn(f"Unknown model {model_path}, defaulting to resolution 512")
 
         self.processor = AutoProcessor.from_pretrained(model_path)
         self.model = AutoModelForImageTextToText.from_pretrained(


### PR DESCRIPTION
## Add Solari to SmolVLM series

Adds [Solari](https://huggingface.co/Cubex11/Solari), a SmolVLM2-500M fine-tuned with QLoRA DPO on RLAIF-V for hallucination reduction.

### Changes
- `vlmeval/config.py` — added `Solari` to `smolvlm_series`
- `vlmeval/vlm/smolvlm.py` — extended resolution check to support fine-tuned SmolVLM2-500M variants

### Benchmark Results (vs base SmolVLM2-500M)

| Benchmark | Base | Solari | Δ |
|-----------|------|--------|---|
| POPE | 82.67 | **85.08** | +2.41 |
| AMBER | 79.38 | **79.77** | +0.39 |
| HallusionBench | 27.58 | **28.14** | +0.56 |
| A-OKVQA | 68.12 | **69.00** | +0.88 |
| MMStar | 38.33 | **39.60** | +1.27 |
| MMBench | 53.14 | **53.42** | +0.28 |
| RealWorldQA | 49.80 | **50.59** | +0.78 |
| MME Perception | **1216** | 1119 | -97 |

Model: https://huggingface.co/Cubex11/Solari
