### PR TITLE
feat: add LiteLLM as unified AI gateway provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ jieba>=0.42.1
 json_repair
 latex2sympy2-extended
 levenshtein>=0.27.1
+litellm>=1.55,<1.85
 lpips
 lxml>=6.0.2
 math-verify

--- a/tests/test_litellm_api.py
+++ b/tests/test_litellm_api.py
@@ -325,6 +325,10 @@ class TestConfigRegistration:
         assert 'LiteLLM_GPT4o_Mini' in content
         assert 'LiteLLM_Claude_Sonnet4' in content
         assert 'LiteLLM_Gemini_2.5_Flash' in content
+        assert 'LiteLLM_Gemini_2.5_Pro' in content
+        assert 'LiteLLM_Bedrock_Claude' in content
+        assert 'LiteLLM_Llama_Vision' in content
+        assert 'LiteLLM_Groq_Llama4' in content
         assert 'api.LiteLLMAPI' in content
 
     def test_litellm_in_init_all(self):

--- a/tests/test_litellm_api.py
+++ b/tests/test_litellm_api.py
@@ -1,0 +1,339 @@
+"""Tests for the LiteLLM API provider (vlmeval/api/litellm_api.py).
+
+Runs without heavy VLMEvalKit dependencies — stubs out vlmeval.smp
+and vlmeval.api.base so only litellm_api.py is exercised.
+"""
+import importlib.util
+import logging
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub the vlmeval package so we can import litellm_api in isolation
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _stub_vlmeval(monkeypatch):
+    """Install minimal stubs for vlmeval.smp and vlmeval.api.base."""
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = []
+    monkeypatch.setitem(sys.modules, 'vlmeval', vlmeval)
+
+    smp = types.ModuleType('vlmeval.smp')
+    smp.concat_images_vlmeval = lambda *a, **k: None
+    smp.get_logger = lambda name: logging.getLogger(name)
+    smp.parse_file = lambda x: (None, x)
+    smp.encode_image_to_base64 = mock.MagicMock(return_value='c3R1Yg==')
+    monkeypatch.setitem(sys.modules, 'vlmeval.smp', smp)
+    vlmeval.smp = smp
+
+    base_spec = importlib.util.spec_from_file_location(
+        'vlmeval.api.base',
+        'vlmeval/api/base.py',
+    )
+    base_mod = importlib.util.module_from_spec(base_spec)
+    monkeypatch.setitem(sys.modules, 'vlmeval.api.base', base_mod)
+    base_spec.loader.exec_module(base_mod)
+
+    yield
+
+
+def _load_module():
+    """Load the litellm_api module and return it."""
+    spec = importlib.util.spec_from_file_location(
+        'vlmeval.api.litellm_api',
+        'vlmeval/api/litellm_api.py',
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['vlmeval.api.litellm_api'] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_litellm_api():
+    return _load_module().LiteLLMAPI
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_completion_response(content='4'):
+    """Return a mock object shaped like litellm.ModelResponse."""
+    choice = mock.MagicMock()
+    choice.message.content = content
+    resp = mock.MagicMock()
+    resp.choices = [choice]
+    resp.model = 'gpt-4o-mini'
+    resp.usage = mock.MagicMock(
+        prompt_tokens=10, completion_tokens=2, total_tokens=12,
+    )
+    return resp
+
+
+@pytest.fixture
+def provider_and_mod():
+    """Return (LiteLLMAPI instance, module) with litellm mocked."""
+    mod = _load_module()
+    fake_litellm = mock.MagicMock()
+    fake_litellm.completion.return_value = _make_completion_response()
+    mod.litellm = fake_litellm
+    p = mod.LiteLLMAPI(model='gpt-4o', retry=1)
+    return p, mod, fake_litellm
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestLiteLLMAPIInit:
+
+    def test_default_params(self):
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', retry=1)
+        assert p.model == 'gpt-4o'
+        assert p.temperature == 0
+        assert p.max_tokens == 2048
+        assert p.timeout == 300
+        assert p.api_key is None
+        assert p.api_base is None
+
+    def test_custom_params(self):
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(
+            model='anthropic/claude-haiku-4-5-20251001',
+            key='sk-test-key',
+            api_base='https://my-proxy.com',
+            temperature=0.7,
+            max_tokens=100,
+            timeout=60,
+            retry=1,
+        )
+        assert p.model == 'anthropic/claude-haiku-4-5-20251001'
+        assert p.api_key == 'sk-test-key'
+        assert p.api_base == 'https://my-proxy.com'
+        assert p.temperature == 0.7
+        assert p.max_tokens == 100
+
+    def test_key_from_env(self, monkeypatch):
+        monkeypatch.setenv('LITELLM_API_KEY', 'env-key-123')
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', retry=1)
+        assert p.api_key == 'env-key-123'
+
+    def test_key_param_overrides_env(self, monkeypatch):
+        monkeypatch.setenv('LITELLM_API_KEY', 'env-key')
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', key='param-key', retry=1)
+        assert p.api_key == 'param-key'
+
+
+class TestPrepareContent:
+
+    def test_text_only(self):
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', retry=1)
+        inputs = [
+            {'type': 'text', 'value': 'Hello'},
+            {'type': 'text', 'value': 'World'},
+        ]
+        result = p._prepare_content(inputs)
+        assert len(result) == 1
+        assert result[0]['type'] == 'text'
+        assert result[0]['text'] == 'Hello\nWorld'
+
+    def test_image_and_text(self, tmp_path):
+        from PIL import Image
+        img_path = str(tmp_path / 'test.jpg')
+        Image.new('RGB', (10, 10), color='red').save(img_path)
+
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', retry=1)
+        inputs = [
+            {'type': 'text', 'value': 'Describe this image'},
+            {'type': 'image', 'value': img_path},
+        ]
+        result = p._prepare_content(inputs)
+        assert len(result) == 2
+        assert result[0] == {'type': 'text', 'text': 'Describe this image'}
+        assert result[1]['type'] == 'image_url'
+        assert 'data:image/jpeg;base64,' in result[1]['image_url']['url']
+
+
+class TestPrepareMessages:
+
+    def test_flat_inputs(self):
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', retry=1)
+        inputs = [{'type': 'text', 'value': 'Hello'}]
+        msgs = p._prepare_messages(inputs)
+        assert len(msgs) == 1
+        assert msgs[0]['role'] == 'user'
+
+    def test_system_prompt(self):
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', system_prompt='Be concise.', retry=1)
+        inputs = [{'type': 'text', 'value': 'Hello'}]
+        msgs = p._prepare_messages(inputs)
+        assert len(msgs) == 2
+        assert msgs[0]['role'] == 'system'
+        assert msgs[0]['content'] == 'Be concise.'
+        assert msgs[1]['role'] == 'user'
+
+    def test_role_based_inputs(self):
+        LiteLLMAPI = _load_litellm_api()
+        p = LiteLLMAPI(model='gpt-4o', retry=1)
+        inputs = [
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'Hi'}]},
+            {'role': 'assistant', 'content': [{'type': 'text', 'value': 'Hello!'}]},
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'Bye'}]},
+        ]
+        msgs = p._prepare_messages(inputs)
+        assert len(msgs) == 3
+        assert msgs[0]['role'] == 'user'
+        assert msgs[1]['role'] == 'assistant'
+        assert msgs[2]['role'] == 'user'
+
+
+class TestGenerateInner:
+
+    def test_success(self, provider_and_mod):
+        p, mod, fake_litellm = provider_and_mod
+        fake_litellm.completion.return_value = _make_completion_response('42')
+
+        inputs = [{'type': 'text', 'value': 'What is 6*7?'}]
+        ret_code, answer, log = p.generate_inner(inputs)
+
+        assert ret_code == 0
+        assert answer == '42'
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['model'] == 'gpt-4o'
+        assert call_kwargs['drop_params'] is True
+        assert call_kwargs['temperature'] == 0
+        assert call_kwargs['max_tokens'] == 2048
+
+    def test_drop_params_default_true(self, provider_and_mod):
+        p, mod, fake_litellm = provider_and_mod
+
+        p.generate_inner([{'type': 'text', 'value': 'test'}])
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['drop_params'] is True
+
+    def test_api_key_forwarded(self):
+        mod = _load_module()
+        fake_litellm = mock.MagicMock()
+        fake_litellm.completion.return_value = _make_completion_response()
+        mod.litellm = fake_litellm
+
+        p = mod.LiteLLMAPI(model='gpt-4o', key='sk-test', retry=1)
+        p.generate_inner([{'type': 'text', 'value': 'test'}])
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['api_key'] == 'sk-test'
+
+    def test_api_key_omitted_when_none(self, provider_and_mod):
+        p, mod, fake_litellm = provider_and_mod
+
+        p.generate_inner([{'type': 'text', 'value': 'test'}])
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert 'api_key' not in call_kwargs
+
+    def test_api_base_forwarded(self):
+        mod = _load_module()
+        fake_litellm = mock.MagicMock()
+        fake_litellm.completion.return_value = _make_completion_response()
+        mod.litellm = fake_litellm
+
+        p = mod.LiteLLMAPI(
+            model='gpt-4o', api_base='https://proxy.example.com', retry=1,
+        )
+        p.generate_inner([{'type': 'text', 'value': 'test'}])
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['api_base'] == 'https://proxy.example.com'
+
+    def test_error_returns_negative_one(self, provider_and_mod):
+        p, mod, fake_litellm = provider_and_mod
+        p.verbose = False
+        fake_litellm.completion.side_effect = Exception('API down')
+
+        inputs = [{'type': 'text', 'value': 'test'}]
+        ret_code, answer, log = p.generate_inner(inputs)
+
+        assert ret_code == -1
+        assert 'Failed' in answer
+        assert 'API down' in log
+
+    def test_litellm_not_installed(self):
+        mod = _load_module()
+        mod.litellm = None
+        p = mod.LiteLLMAPI(model='gpt-4o', retry=1)
+
+        with pytest.raises(ImportError, match='LiteLLM is required'):
+            p.generate_inner([{'type': 'text', 'value': 'test'}])
+
+    def test_temperature_override(self, provider_and_mod):
+        p, mod, fake_litellm = provider_and_mod
+        p.temperature = 0.5
+
+        p.generate_inner(
+            [{'type': 'text', 'value': 'test'}],
+            temperature=0.9,
+        )
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['temperature'] == 0.9
+
+    def test_max_tokens_override(self, provider_and_mod):
+        p, mod, fake_litellm = provider_and_mod
+        p.max_tokens = 100
+
+        p.generate_inner(
+            [{'type': 'text', 'value': 'test'}],
+            max_tokens=500,
+        )
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['max_tokens'] == 500
+
+    def test_litellm_kwargs_passthrough(self):
+        mod = _load_module()
+        fake_litellm = mock.MagicMock()
+        fake_litellm.completion.return_value = _make_completion_response()
+        mod.litellm = fake_litellm
+
+        p = mod.LiteLLMAPI(
+            model='gpt-4o', retry=1,
+            litellm_kwargs={'seed': 42, 'top_p': 0.9},
+        )
+        p.generate_inner([{'type': 'text', 'value': 'test'}])
+
+        call_kwargs = fake_litellm.completion.call_args.kwargs
+        assert call_kwargs['seed'] == 42
+        assert call_kwargs['top_p'] == 0.9
+
+
+class TestConfigRegistration:
+
+    def test_litellm_entries_in_config(self):
+        with open('vlmeval/config.py') as f:
+            content = f.read()
+        assert 'LiteLLM_GPT4o' in content
+        assert 'LiteLLM_GPT4o_Mini' in content
+        assert 'LiteLLM_Claude_Sonnet4' in content
+        assert 'LiteLLM_Gemini_2.5_Flash' in content
+        assert 'api.LiteLLMAPI' in content
+
+    def test_litellm_in_init_all(self):
+        with open('vlmeval/api/__init__.py') as f:
+            content = f.read()
+        assert 'from .litellm_api import LiteLLMAPI' in content
+        assert "'LiteLLMAPI'" in content
+
+    def test_version_pin_in_docstring(self):
+        with open('vlmeval/api/litellm_api.py') as f:
+            content = f.read()
+        assert "litellm>=1.55,<1.85" in content

--- a/vlmeval/api/__init__.py
+++ b/vlmeval/api/__init__.py
@@ -29,6 +29,7 @@ from .taichu import TaichuVLAPI, TaichuVLRAPI
 from .taiyi import TaiyiAPI
 from .telemm import TeleMM2_API
 from .telemm_thinking import TeleMM2Thinking_API
+from .litellm_api import LiteLLMAPI
 from .together import TogetherAPI
 from .video_chat_online_v2 import VideoChatOnlineV2API
 
@@ -41,5 +42,5 @@ __all__ = [
     'TaichuVLAPI', 'TaichuVLRAPI', 'DoubaoVL', "MUGUAPI", 'KimiVLAPIWrapper', 'KimiVLAPI',
     'RBdashMMChat3_API', 'RBdashChat3_5_API', 'RBdashMMChat3_78B_API', 'RBdashMMChat3_5_38B_API',
     'VideoChatOnlineV2API', 'TeleMM2_API', 'TeleMM2Thinking_API', 'TogetherAPI', 'GCPVertexAPI',
-    'BedrockAPI', 'SenseChatVisionV2API', 'MiniMaxAPI',
+    'BedrockAPI', 'SenseChatVisionV2API', 'MiniMaxAPI', 'LiteLLMAPI',
 ]

--- a/vlmeval/api/__init__.py
+++ b/vlmeval/api/__init__.py
@@ -14,6 +14,7 @@ from .hunyuan import HunyuanVision
 from .jt_vl_chat import JTVLChatAPI
 from .jt_vl_chat_mini import JTVLChatAPI_2B, JTVLChatAPI_Mini
 from .kimivl_api import KimiVLAPI, KimiVLAPIWrapper
+from .litellm_api import LiteLLMAPI
 from .lmdeploy import LMDeployAPI, LMDeployWrapper
 from .minimax_api import MiniMaxAPI
 from .mug_u import MUGUAPI
@@ -29,7 +30,6 @@ from .taichu import TaichuVLAPI, TaichuVLRAPI
 from .taiyi import TaiyiAPI
 from .telemm import TeleMM2_API
 from .telemm_thinking import TeleMM2Thinking_API
-from .litellm_api import LiteLLMAPI
 from .together import TogetherAPI
 from .video_chat_online_v2 import VideoChatOnlineV2API
 

--- a/vlmeval/api/litellm_api.py
+++ b/vlmeval/api/litellm_api.py
@@ -1,0 +1,137 @@
+"""
+LiteLLM API provider for VLMEvalKit — unified interface to 100+ LLM providers.
+
+Requires: pip install 'litellm>=1.55,<1.85'
+Set provider-specific env vars (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, AZURE_API_KEY)
+or pass key= for providers that accept a single key.
+"""
+import os
+
+import numpy as np
+
+from ..smp import encode_image_to_base64, get_logger
+from .base import BaseAPI
+
+logger = get_logger(__name__)
+
+try:
+    import litellm
+except ImportError:
+    litellm = None
+
+
+class LiteLLMAPI(BaseAPI):
+    """VLM/LLM API using LiteLLM (https://docs.litellm.ai/docs/providers).
+
+    Model strings follow LiteLLM conventions:
+        - OpenAI:     "gpt-4o", "gpt-4o-mini"
+        - Anthropic:  "anthropic/claude-sonnet-4-20250514"
+        - Azure:      "azure/<deployment-name>"
+        - Bedrock:    "bedrock/anthropic.claude-3-sonnet"
+        - Vertex AI:  "vertex_ai/gemini-1.5-pro"
+        - Together:   "together_ai/meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo"
+    """
+
+    is_api: bool = True
+
+    def __init__(
+        self,
+        model: str = 'gpt-4o',
+        key: str = None,
+        api_base: str = None,
+        retry: int = 10,
+        wait: int = 1,
+        system_prompt: str = None,
+        verbose: bool = True,
+        temperature: float = 0,
+        max_tokens: int = 2048,
+        timeout: int = 300,
+        img_size: int = -1,
+        **kwargs,
+    ):
+        self.model = model
+        self.api_key = key or os.environ.get('LITELLM_API_KEY', None)
+        self.api_base = api_base or os.environ.get('LITELLM_API_BASE', None)
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.timeout = timeout
+        self.img_size = img_size
+        self.litellm_kwargs = kwargs.pop('litellm_kwargs', {})
+
+        super().__init__(
+            retry=retry,
+            wait=wait,
+            system_prompt=system_prompt,
+            verbose=verbose,
+            **kwargs,
+        )
+
+        logger.info(f'LiteLLMAPI: model={self.model}')
+
+    def _prepare_content(self, inputs):
+        assert all(isinstance(x, dict) for x in inputs)
+        has_images = np.sum([x['type'] == 'image' for x in inputs])
+        if has_images:
+            content_list = []
+            for item in inputs:
+                if item['type'] == 'text':
+                    content_list.append({'type': 'text', 'text': item['value']})
+                elif item['type'] == 'image':
+                    from PIL import Image
+                    img = Image.open(item['value'])
+                    b64 = encode_image_to_base64(img, target_size=self.img_size)
+                    content_list.append({
+                        'type': 'image_url',
+                        'image_url': {'url': f'data:image/jpeg;base64,{b64}'},
+                    })
+            return content_list
+        text = '\n'.join([x['value'] for x in inputs if x['type'] == 'text'])
+        return [{'type': 'text', 'text': text or ''}]
+
+    def _prepare_messages(self, inputs):
+        out = []
+        if self.system_prompt:
+            out.append({'role': 'system', 'content': self.system_prompt})
+        if inputs and 'role' in inputs[0]:
+            for item in inputs:
+                out.append({
+                    'role': item['role'],
+                    'content': self._prepare_content(item['content']),
+                })
+        else:
+            out.append({'role': 'user', 'content': self._prepare_content(inputs)})
+        return out
+
+    def generate_inner(self, inputs, **kwargs):
+        if litellm is None:
+            raise ImportError(
+                "LiteLLM is required for LiteLLMAPI. "
+                "Install it with: pip install 'litellm>=1.55,<1.85'"
+            )
+
+        temperature = kwargs.pop('temperature', self.temperature)
+        max_tokens = kwargs.pop('max_tokens', self.max_tokens)
+        messages = self._prepare_messages(inputs)
+
+        completion_kwargs = {
+            'model': self.model,
+            'messages': messages,
+            'temperature': temperature,
+            'max_tokens': max_tokens,
+            'timeout': self.timeout,
+            'drop_params': True,
+            **self.litellm_kwargs,
+        }
+        if self.api_key:
+            completion_kwargs['api_key'] = self.api_key
+        if self.api_base:
+            completion_kwargs['api_base'] = self.api_base
+
+        try:
+            response = litellm.completion(**completion_kwargs)
+            answer = response.choices[0].message.content.strip()
+            return 0, answer, response
+        except Exception as err:
+            if self.verbose:
+                logger.error(f'{type(err).__name__}: {err}')
+            return -1, self.fail_msg, str(err)

--- a/vlmeval/api/litellm_api.py
+++ b/vlmeval/api/litellm_api.py
@@ -74,7 +74,7 @@ class LiteLLMAPI(BaseAPI):
         if has_images:
             content_list = []
             for item in inputs:
-                if item['type'] == 'text':
+                if item['type'] == 'text' and item['value']:
                     content_list.append({'type': 'text', 'text': item['value']})
                 elif item['type'] == 'image':
                     from PIL import Image
@@ -114,13 +114,13 @@ class LiteLLMAPI(BaseAPI):
         messages = self._prepare_messages(inputs)
 
         completion_kwargs = {
+            **self.litellm_kwargs,
             'model': self.model,
             'messages': messages,
             'temperature': temperature,
             'max_tokens': max_tokens,
             'timeout': self.timeout,
             'drop_params': True,
-            **self.litellm_kwargs,
         }
         if self.api_key:
             completion_kwargs['api_key'] = self.api_key

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -489,6 +489,37 @@ api_models = {
         max_tokens=2048,
         retry=10,
     ),
+    # LiteLLM — unified gateway to 100+ providers (pip install litellm)
+    # Use any litellm model string. Set provider-specific env vars for auth.
+    # Docs: https://docs.litellm.ai/docs/providers
+    "LiteLLM_GPT4o": partial(
+        api.LiteLLMAPI,
+        model="gpt-4o",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "LiteLLM_GPT4o_Mini": partial(
+        api.LiteLLMAPI,
+        model="gpt-4o-mini",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "LiteLLM_Claude_Sonnet4": partial(
+        api.LiteLLMAPI,
+        model="anthropic/claude-sonnet-4-20250514",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "LiteLLM_Gemini_2.5_Flash": partial(
+        api.LiteLLMAPI,
+        model="gemini/gemini-2.5-flash-preview-04-17",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
     # Claude
     "Claude3V_Opus": partial(
         api.Claude3V, model="claude-3-opus-20240229", temperature=0, retry=10, verbose=False

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -520,6 +520,34 @@ api_models = {
         max_tokens=2048,
         retry=10,
     ),
+    "LiteLLM_Gemini_2.5_Pro": partial(
+        api.LiteLLMAPI,
+        model="gemini/gemini-2.5-pro",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "LiteLLM_Bedrock_Claude": partial(
+        api.LiteLLMAPI,
+        model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "LiteLLM_Llama_Vision": partial(
+        api.LiteLLMAPI,
+        model="together_ai/meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "LiteLLM_Groq_Llama4": partial(
+        api.LiteLLMAPI,
+        model="groq/meta-llama/llama-4-scout-17b-16e-instruct",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
     # Claude
     "Claude3V_Opus": partial(
         api.Claude3V, model="claude-3-opus-20240229", temperature=0, retry=10, verbose=False


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                                                                              
  - Adds `LiteLLMAPI`, a new API provider backed by [LiteLLM](https://github.com/BerriAI/litellm), enabling access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Together, Groq, etc.) through a single unified interface.
  - Follows the same pattern as `TogetherAPI` and `BedrockAPI`. Additive only, existing providers untouched.                                                                                                                                                                                                                                                              
   
  ## Motivation                                                                                                                                                                                                                                                                                                                                                           
  VLMEvalKit currently requires a separate provider file for each LLM backend. Users who want to evaluate models across Azure, Bedrock, or Vertex AI need provider-specific code. LiteLLM provides a unified `completion()` interface that handles auth, formatting, and provider-specific quirks, enabling cross-provider evaluation with a single configuration change.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  ## Changes
  - `vlmeval/api/litellm_api.py` -- new `LiteLLMAPI` provider extending `BaseAPI`                                                                                                                                                                                                                                                                                         
  - `vlmeval/api/__init__.py` -- import + `__all__` registration
  - `vlmeval/config.py` -- 8 model presets across 5 providers (OpenAI, Anthropic, Google, AWS Bedrock, Together AI, Groq)
  - `requirements.txt` -- added `litellm>=1.55,<1.85`                                                                                                                                                                                                                                                                                                                     
  - `tests/test_litellm_api.py` -- 22 unit tests covering init, content prep, message prep, generate_inner, error handling, registration                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                          
  ## Key implementation details                                                                                                                                                                                                                                                                                                                                           
  - **Optional dependency**: `litellm>=1.55,<1.85`, lazy-imported at module level with `try/except` (same pattern as `bedrock.py` with `boto3`). Base install unaffected.
  - **`drop_params=True`** by default, silently drops provider-unsupported kwargs (e.g. `seed`/`strict` on Anthropic, `response_format` on Bedrock). Prevents cross-provider evaluation failures.                                                                                                                                                                         
  - **Flexible auth**: accepts `key=` param, `LITELLM_API_KEY` env var, or provider-specific env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AZURE_API_KEY`, etc.).                                                                                                                                                                                                     
  - **`litellm_kwargs`** passthrough for advanced settings (`seed`, `top_p`, provider-specific params).                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                          
  ## Usage and Testing
                                                                                                                                                                                                                                                                                                                                                                          
  **1. Unit tests (22/22 pass):**
  tests/test_litellm_api.py::TestLiteLLMAPIInit::test_default_params PASSED
  tests/test_litellm_api.py::TestLiteLLMAPIInit::test_custom_params PASSED 
  tests/test_litellm_api.py::TestLiteLLMAPIInit::test_key_from_env PASSED 
  tests/test_litellm_api.py::TestLiteLLMAPIInit::test_key_param_overrides_env PASSED                                                                                                                                                                                                                                                                                      
  tests/test_litellm_api.py::TestPrepareContent::test_text_only PASSED              
  tests/test_litellm_api.py::TestPrepareContent::test_image_and_text PASSED                                                                                                                                                                                                                                                                                               
  tests/test_litellm_api.py::TestPrepareMessages::test_flat_inputs PASSED  
  tests/test_litellm_api.py::TestPrepareMessages::test_system_prompt PASSED                                                                                                                                                                                                                                                                                               
  tests/test_litellm_api.py::TestPrepareMessages::test_role_based_inputs PASSED
  tests/test_litellm_api.py::TestGenerateInner::test_success PASSED                                                                                                                                                                                                                                                                                                       
  tests/test_litellm_api.py::TestGenerateInner::test_drop_params_default_true PASSED                                                                                                                                                                                                                                                                                      
  tests/test_litellm_api.py::TestGenerateInner::test_api_key_forwarded PASSED       
  tests/test_litellm_api.py::TestGenerateInner::test_api_key_omitted_when_none PASSED                                                                                                                                                                                                                                                                                     
  tests/test_litellm_api.py::TestGenerateInner::test_api_base_forwarded PASSED       
  tests/test_litellm_api.py::TestGenerateInner::test_error_returns_negative_one PASSED                                                                                                                                                                                                                                                                                    
  tests/test_litellm_api.py::TestGenerateInner::test_litellm_not_installed PASSED     
  tests/test_litellm_api.py::TestGenerateInner::test_temperature_override PASSED                                                                                                                                                                                                                                                                                          
  tests/test_litellm_api.py::TestGenerateInner::test_max_tokens_override PASSED 
  tests/test_litellm_api.py::TestGenerateInner::test_litellm_kwargs_passthrough PASSED                                                                                                                                                                                                                                                                                    
  tests/test_litellm_api.py::TestConfigRegistration::test_litellm_entries_in_config PASSED
  tests/test_litellm_api.py::TestConfigRegistration::test_litellm_in_init_all PASSED                                                                                                                                                                                                                                                                                      
  tests/test_litellm_api.py::TestConfigRegistration::test_version_pin_in_docstring PASSED                                                                                                                                                                                                                                                                                 
  ======================== 22 passed in 1.29s =========================
                                                                                                                                                                                                                                                                                                                                                                          
  **2. Live E2E against Azure GPT-4o-mini (text):**
  LIVE E2E TEST 1: Azure GPT-4o-mini (text)                                                                                                                                                                                                                                                                                                                               
  Model:    azure/gpt-4o-mini              
  Query:    What is 2+2? Reply with just the number.                                                                                                                                                                                                                                                                                                                      
  ret_code: 0                                       
  answer:   4                                                                                                                                                                                                                                                                                                                                                             
  model:    gpt-4o-mini-2024-07-18
  usage:    prompt=20, completion=2, total=22                                                                                                                                                                                                                                                                                                                             
                                             
  LIVE E2E TEST 2: Azure GPT-4o-mini (multi-turn with system prompt)
  Model:    azure/gpt-4o-mini                                                                                                                                                                                                                                                                                                                                             
  System:   You are a math tutor. Be concise.
  Query:    What is the square root of 144?                                                                                                                                                                                                                                                                                                                               
  ret_code: 0     
  answer:   The square root of 144 is 12.
  model:    gpt-4o-mini-2024-07-18                                                                                                                                                                                                                                                                                                                                        
  usage:    prompt=29, completion=11, total=40
                                                                                                                                                                                                                                                                                                                                                                          
  **3. Live E2E vision test (Anthropic Claude Sonnet 4-6 via Azure):**
  ================================================================                                                                                                                                                                                                                                                                                                        
    LiteLLM Provider for VLMEvalKit -- Live Integration Tests     
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 1] Text-only completion
    Model:  anthropic/claude-sonnet-4-6                                                                                                                                                                                                                                                                                                                                   
    Prompt: 'What is 2+2? Reply with just the number.'
    Answer: 4                                                                                                                                                                                                                                                                                                                                                             
    Tokens: in=20 out=5
    PASSED
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 2] Vision -- real image via _prepare_content pipeline
    Model:  anthropic/claude-sonnet-4-6                                                                                                                                                                                                                                                                                                                                   
    Image:  BA50EF10-8F5D-4719-BA18-B20A80EF5A8F.png
    Answer: I see a cute cartoon character (a round white figure) holding a                                                                                                                                                                                                                                                                                               
            glass, sitting next to two bottles of Jack Daniel's whiskey.
    Tokens: in=38 out=40                                                                                                                                                                                                                                                                                                                                                  
    PASSED        

  [Test 3] VLMEvalKit input format -- dict list with type/value                                                                                                                                                                                                                                                                                                           
    Model:  anthropic/claude-sonnet-4-6
    Input:  [{'type': 'image', 'value': ''}, {'type': 'text', 'value': '...'}]                                                                                                                                                                                                                                                                                            
    Answer: cartoon character, glass, Jack Daniel's whiskey bottle (x2),
            wooden box/crate, liquid                                                                                                                                                                                                                                                                                                                                      
    Tokens: in=38 out=63
    PASSED                                                                                                                                                                                                                                                                                                                                                                
                  
  ================================================================
    All 3 tests passed -- text + vision + VLMEvalKit format
                                                                                                                                                                                                                                                                                                                                                                          
                                                          
  **4. Lint:** `flake8 --max-line-length 99` -> all clean.                                                                                                                                                                                                                                                                                                                
                  
  ## Example usage
  ```python                    
  from functools import partial     
  from vlmeval.api import LiteLLMAPI
                                                                                                                                                                                                                                                                                                                                                                          
  # Use any LiteLLM model string                                                                  
  model = partial(LiteLLMAPI, model='azure/gpt-4o-mini', temperature=0, max_tokens=2048, retry=10)                                                                                                                                                                                                                                                                        
                             
  # Or via config.py presets:
  # python run.py --model LiteLLM_GPT4o --data MMBench_DEV_EN