### PR TITLE
[Benchmark] Add support for PixmoCount benchmark

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -100,6 +100,7 @@ from .omnispatialbench import OmniSpatialBench
 from .omtgbench import OMTGBench
 from .ost_bench import OSTDataset
 from .plotqa import PlotQA
+from .pixmocount import PixmoCountDataset
 from .qbench_video import QBench_Video, QBench_Video_MCQ, QBench_Video_VQA
 from .reasonmap_plus import ReasonMap_Plus
 from .refcoco import RefCOCODataset
@@ -280,7 +281,7 @@ IMAGE_DATASET = [
     LEGO, MMSci_Captioning, Physics_yale, ScreenSpot_Pro, ScreenSpot, VenusBench_GD,
     ScreenSpotV2, OSWorld_G, VBGD, MMIFEval, Spatial457, VisuLogic, CVBench, PathVQA_VAL,
     PathVQA_TEST, TDBench, TDBenchGrounding, MicroBench, CharXiv, OmniMedVQA,
-    WildDocBenchmark, MSEarthMCQ, OCR_Reasoning, PhyX, VLMBlind, CountBenchQA,
+    WildDocBenchmark, MSEarthMCQ, OCR_Reasoning, PhyX, VLMBlind, CountBenchQA, PixmoCountDataset,
     ZEROBench, SCAM, Omni3DBench, TallyQA, _3DSRBench, BMMR, AffordanceDataset,
     MMEReasoning, GOBenchDataset, SFE, ChartMimic, MMVMBench, XLRSBench,
     OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench, CVQA, M4Bench,

--- a/vlmeval/dataset/pixmocount.py
+++ b/vlmeval/dataset/pixmocount.py
@@ -1,0 +1,13 @@
+from .image_vqa import CountBenchQA
+
+
+class PixmoCountDataset(CountBenchQA):
+    TYPE = 'VQA'
+    DATASET_URL = {
+        'PixmoCount': ''
+    }
+    DATASET_MD5 = {}
+
+    @classmethod
+    def supported_datasets(cls):
+        return ['PixmoCount']


### PR DESCRIPTION
  ## Summary

  This PR adds support for the `PixmoCount` benchmark in VLMEvalKit.

  ## Changes

  - adds a dedicated `PixmoCountDataset`
  - registers `PixmoCount` in the dataset registry
  - keeps the benchmark separate instead of aliasing it through an unrelated existing dataset

  ## Dataset format

  The benchmark follows the standard TSV-based dataset flow used by VLMEvalKit.

  Expected TSV columns:
  - `index`
  - `image`
  - `question`
  - `answer`
  - `category`

  ## Notes

  - this PR only adds benchmark support code
  - hosted `DATASET_URL` / `DATASET_MD5` can be filled once the final TSV hosting location is settled (sending email to maintainers)