### PR TITLE
[Benchmark] Add support for RefCOCO-M benchmark

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -103,6 +103,7 @@ from .plotqa import PlotQA
 from .qbench_video import QBench_Video, QBench_Video_MCQ, QBench_Video_VQA
 from .reasonmap_plus import ReasonMap_Plus
 from .refcoco import RefCOCODataset
+from .refcoco_m import RefCOCOMDataset
 from .refspatial import RefSpatialDataset
 from .refspatialbench import RefSpatialBench
 from .robospatialbench import RoboSpatialBench
@@ -286,7 +287,7 @@ IMAGE_DATASET = [
     OmniEarthMCQBench, VisFactor, OSTDataset, OCRBench_v2, TreeBench, CVQA, M4Bench,
     AyaVisionBench, TopViewRS, VLMBias, MMHELIX, MedqbenchMCQDataset, MathCanvas, MMReason,
     MedqbenchPairedDescriptionDataset, MedqbenchCaptionDataset, ChartMuseum, ChartQAPro, ReasonMap_Plus,  # noqa: E501
-    olmOCRBench, OceanOCRBench, MATBench, VLRMBench, RefCOCODataset, RefSpatialDataset,
+    olmOCRBench, OceanOCRBench, MATBench, VLRMBench, RefCOCODataset, RefCOCOMDataset, RefSpatialDataset,
     ERQADataset, SimpleVQA, HiPhODataset, MaCBench,
     UniSVG, SArena, VLMsAreBiased, MMESCIDataset, CoreCognition, GroundingME,
     FoxBench, VTCBench, Asclepius, PlotQA, ChartX, ChartBench, ChartCapDataset, WorldVQA, PuzzleVQA, VisualPuzzles,  # noqa: E501

--- a/vlmeval/dataset/refcoco_m.py
+++ b/vlmeval/dataset/refcoco_m.py
@@ -1,0 +1,14 @@
+from .refcoco import RefCOCODataset
+
+
+class RefCOCOMDataset(RefCOCODataset):
+    TYPE = 'GROUNDING'
+    MODALITY = 'IMAGE'
+    DATASET_URL = {
+        'RefCOCO-M': ''
+    }
+    DATASET_MD5 = {}
+
+    @classmethod
+    def supported_datasets(cls):
+        return ['RefCOCO-M']


### PR DESCRIPTION
## Summary

  This PR adds support for the `RefCOCO-M` benchmark in VLMEvalKit.

  ## Changes

  - adds a dedicated `RefCOCOMDataset`
  - registers `RefCOCO-M` in the dataset registry
  - keeps the benchmark separate instead of treating it as an alias of `RefCOCO`

  ## Dataset format

  Expected TSV columns:
  - `index`
  - `image`
  - `question`
  - `answer`
  - `bbox_x1`
  - `bbox_y1`
  - `bbox_x2`
  - `bbox_y2`
  - `width`
  - `height`
  - `category`

  ## Evaluation

  This benchmark reuses the existing RefCOCO-style grounding evaluation path.

  ## Notes

  - this PR only adds benchmark support code
  - hosted `DATASET_URL` / `DATASET_MD5` can be filled once the final TSV hosting location is settled (sending email to maintainers)