### PR TITLE
[Fix] Fix judge intermediate result caching and resume support

### DIFF
--- a/vlmeval/dataset/EgoExoBench/egoexobench.py
+++ b/vlmeval/dataset/EgoExoBench/egoexobench.py
@@ -17,6 +17,8 @@ from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermedi
                          load, md5)
 from vlmeval.smp.file import LMUDataRoot
 from ..utils import DEBUG_MESSAGE, build_judge
+from ..utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                 has_judge_failure, load_judge_cache)
 from ..video_base import VideoBaseDataset
 from .utils import Stack, ToTorchFormatTensor
 
@@ -255,40 +257,55 @@ class EgoExoBench_MCQ(VideoBaseDataset):
         assert get_file_extension(eval_file) in ['xlsx', 'json', 'tsv'], \
             'data file should be an supported format (xlsx/json/tsv) file'
 
-        tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
-        tgt_file = get_intermediate_file_path(eval_file, '_rating', 'json')
-        score_file = get_intermediate_file_path(eval_file, '_score', 'csv')
+        judge_name = judge_kwargs.get('model', 'exact_matching')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
-        if not osp.exists(score_file):
-            model = judge_kwargs.get('model', 'exact_matching')
-
-            if model == 'exact_matching':
-                model = None
-            else:
-                model = build_judge(**judge_kwargs)
-                if not model.working():
-                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-                    warnings.warn(DEBUG_MESSAGE)
-                    model = None
-            res = {} if not osp.exists(tmp_file) else load(tmp_file)
-            res = {k: v for k, v in res.items() if FAIL_MSG not in v}
+        if not osp.exists(detail_file):
+            res = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
 
             data = load(eval_file)
             data_un = data[~pd.isna(data['prediction'])]
+            model = None
+            model_built = False
+
+            def get_model():
+                nonlocal model, model_built
+                if judge_name == 'exact_matching':
+                    return None
+                if not model_built:
+                    model = build_judge(**judge_kwargs)
+                    if not model.working():
+                        warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
+                        warnings.warn(DEBUG_MESSAGE)
+                        model = None
+                    model_built = True
+                return model
 
             for idx in data['index']:
                 ans = data.loc[data['index'] == idx, 'answer'].values[0]
                 pred = data.loc[data['index'] == idx, 'prediction'].values[0]
 
                 if extract_characters_regex(pred) == '':
-                    extract_pred = extract_option(
-                        model,
-                        data.loc[data['index'] == idx].to_dict(orient='records')[0],
-                        'EgoExoBench_MCQ',
+                    extract_pred = res.get(idx)
+                    if has_judge_failure(extract_pred):
+                        extract_pred = extract_option(
+                            get_model(),
+                            data.loc[data['index'] == idx].to_dict(orient='records')[0],
+                            'EgoExoBench_MCQ',
+                        )
+                        res[idx] = extract_pred
+                        dump(res, tmp_file)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = (
+                        -1 if extract_pred in ['Fail', ''] else int(extract_pred == ans)
                     )
-                    data.loc[idx, 'score'] = int(extract_pred == ans)
                 else:
-                    data.loc[idx, 'score'] = int(extract_characters_regex(pred) == ans)
+                    extract_pred = extract_characters_regex(pred)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
 
             rejected = [x for x in data['score'] if x == -1]
 
@@ -298,8 +315,9 @@ class EgoExoBench_MCQ(VideoBaseDataset):
                 f'Those questions will be counted as -1 score in ALL rating, and will not be counted in VALID rating.'
             )
 
-            dump(data, score_file)
+            dump(data, detail_file)
 
-        rating = get_dimension_rating(score_file)
-        dump(rating, tgt_file)
+        rating = load(score_file) if osp.exists(score_file) else get_dimension_rating(detail_file)
+        if not osp.exists(score_file):
+            dump(rating, score_file)
         return rating

--- a/vlmeval/dataset/dude.py
+++ b/vlmeval/dataset/dude.py
@@ -9,13 +9,15 @@ from typing import List
 
 import pandas as pd
 from PIL import Image
-from tqdm import tqdm
 
+from vlmeval.dataset.utils.judge_cache import (get_judge_cache_file, get_judge_detail_file,
+                                               get_judge_score_file, load_judge_cache,
+                                               run_cached_tasks)
 from vlmeval.smp import (LMUDataRoot, decode_base64_to_image_file, download_file, dump,
                          encode_image_to_base64, get_intermediate_file_path, get_logger, listinstr,
                          load, md5, read_ok, toliststr)
 from .image_base import ImageBaseDataset
-from .mmlongbench import MMLongBench_auxeval, anls_compute, concat_images
+from .mmlongbench import MMLongBench_auxeval, MMLongBench_judge_failed, anls_compute, concat_images
 from .utils.judge_util import build_judge
 
 logger = get_logger(__name__)
@@ -176,36 +178,34 @@ class DUDE(ImageBaseDataset):
 
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
-        model = judge_kwargs['model']
-
-        storage = get_intermediate_file_path(eval_file, f'_{model}')
-        tmp_file = get_intermediate_file_path(eval_file, f'_{model}', 'pkl')
+        judge_name = judge_kwargs['model']
+        storage = get_judge_detail_file(eval_file, 'extract', judge_name)
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, f'_{judge_name}', 'pkl')
 
         if osp.exists(storage):
             logger.warning(f'GPT scoring file {storage} already exists, will reuse it in DUDE_eval. ')
         else:
             data = load(eval_file)
-            model = build_judge(max_tokens=128, **judge_kwargs)
             lt = len(data)
             lines = [data.iloc[i] for i in range(lt)]
-            tups = [(model, line) for line in lines]
             indices = [line['index'] for line in lines]
-
-            ans = {}
-            if osp.exists(tmp_file):
-                ans = load(tmp_file)
-            tups = [x for x, i in zip(tups, indices) if i not in ans]
-            indices = [i for i in indices if i not in ans]
-
-            if len(indices):
-                new_results = list()
-                for model, line in tqdm(tups):
-                    res = MMLongBench_auxeval(model, line)
-                    new_results.append(res)
+            ans = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
+            pending = [idx for idx in indices if idx not in ans or MMLongBench_judge_failed(ans[idx])]
+            if pending:
+                model = build_judge(max_tokens=128, **judge_kwargs)
+                tups = [(model, line) for line in lines]
+                ans = run_cached_tasks(
+                    MMLongBench_auxeval,
+                    tups,
+                    indices,
+                    tmp_file,
+                    legacy_files=[legacy_tmp_file],
+                    failure_fn=MMLongBench_judge_failed,
+                )
 
             log_map, res_map, pred_map = {}, {}, {}
-            all_inds = [line['index'] for line in lines]
-            for k, v in zip(all_inds, new_results):
+            for k, v in ans.items():
                 log_map[k] = v['log']
                 res_map[k] = v['res']
                 pred_map[k] = v['pred']
@@ -215,7 +215,7 @@ class DUDE(ImageBaseDataset):
             dump(data, storage)
 
         score = DUDE_acc(storage)
-        score_pth = get_intermediate_file_path(storage, '_score', 'csv')
+        score_pth = get_judge_score_file(eval_file, judge_name, 'csv')
 
         dump(score, score_pth)
         logger.info(f'DUDE successfully finished evaluating {eval_file}, results saved in {score_pth}')

--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -22,7 +22,25 @@ from vlmeval.smp import (LMUDataRoot, d2df, decode_base64_to_image_file, downloa
 from ..utils import track_progress_rich
 from .image_base import ImageBaseDataset
 from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                load_judge_cache, run_cached_tasks)
 from .utils.vqa_eval import istype
+
+
+def llava_judge_failed(result):
+    return (
+        not isinstance(result, (list, tuple)) or len(result) != 2
+        or any(score is None or score < 0 for score in result)
+    )
+
+
+def vgrp_judge_failed(result):
+    required = {'perception_correct', 'answer_correct', 'number_of_samples'}
+    return not isinstance(result, dict) or not required.issubset(result)
+
+
+def corecognition_judge_failed(result):
+    return not isinstance(result, dict) or result.get('matched', 'Fail').upper() == 'FAIL'
 
 
 class ImageVQADataset(ImageBaseDataset):
@@ -1901,27 +1919,38 @@ class LLaVABench(ImageBaseDataset):
     def evaluate(self, eval_file, **judge_kwargs):
         from .utils.llavabench import LLaVABench_atomeval, LLaVABench_score, build_prompt
 
-        record_file = get_intermediate_file_path(eval_file, '_openai_result')
-        score_file = get_intermediate_file_path(eval_file, '_score', 'csv')
+        judge_name = judge_kwargs.get('model', 'default')
+        tmp_file = get_judge_cache_file(eval_file, 'eval', judge_name)
+        record_file = get_judge_detail_file(eval_file, 'eval', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'csv')
         nproc = judge_kwargs.pop('nproc', 4)
         system_prompt = 'You are a helpful and precise assistant for checking the quality of the answer.'
 
         if not osp.exists(record_file):
             data = load(eval_file)
             lines = [data.iloc[i] for i in range(len(data))]
-            model = build_judge(temperature=0.2,
-                                system_prompt=system_prompt,
-                                **judge_kwargs)
-            assert model.working(), 'LLaVABench evaluation requires a working OPENAI API\n' + DEBUG_MESSAGE
+            indices = data['index'].tolist() if 'index' in data.columns else list(range(len(data)))
 
             prompts = [build_prompt(line) for line in lines]
-            tups = [(model, prompt) for prompt in prompts]
-            scores = track_progress_rich(LLaVABench_atomeval,
-                                         tups,
-                                         nproc=nproc,
-                                         chunksize=nproc)
-            data['gpt4_score'] = [x[0] for x in scores]
-            data['score'] = [x[1] for x in scores]
+            scores = load_judge_cache(tmp_file)
+            pending = [idx for idx in indices if idx not in scores or llava_judge_failed(scores[idx])]
+            if pending:
+                model = build_judge(temperature=0.2,
+                                    system_prompt=system_prompt,
+                                    **judge_kwargs)
+                assert model.working(), 'LLaVABench evaluation requires a working OPENAI API\n' + DEBUG_MESSAGE
+                tups = [(model, prompt) for prompt in prompts]
+                scores = run_cached_tasks(
+                    LLaVABench_atomeval,
+                    tups,
+                    indices,
+                    tmp_file,
+                    nproc=nproc,
+                    chunksize=nproc,
+                    failure_fn=llava_judge_failed,
+                )
+            data['gpt4_score'] = [scores[idx][0] for idx in indices]
+            data['score'] = [scores[idx][1] for idx in indices]
             dump(data, record_file)
 
         data = load(record_file)
@@ -1943,27 +1972,38 @@ class LLaVABench_KO(ImageBaseDataset):
     def evaluate(self, eval_file, **judge_kwargs):
         from .utils.llavabench import LLaVABench_atomeval, LLaVABench_score, build_prompt_ko
 
-        record_file = get_intermediate_file_path(eval_file, '_openai_result')
-        score_file = get_intermediate_file_path(eval_file, '_score', 'csv')
+        judge_name = judge_kwargs.get('model', 'default')
+        tmp_file = get_judge_cache_file(eval_file, 'eval', judge_name)
+        record_file = get_judge_detail_file(eval_file, 'eval', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'csv')
         nproc = judge_kwargs.pop('nproc', 4)
         system_prompt = 'You are a helpful and precise assistant for checking the quality of the answer.'
 
         if not osp.exists(record_file):
             data = load(eval_file)
             lines = [data.iloc[i] for i in range(len(data))]
-            model = build_judge(temperature=0.2,
-                                system_prompt=system_prompt,
-                                **judge_kwargs)
-            assert model.working(), 'LLaVABench_KO evaluation requires a working OPENAI API\n' + DEBUG_MESSAGE
+            indices = data['index'].tolist() if 'index' in data.columns else list(range(len(data)))
 
             prompts = [build_prompt_ko(line) for line in lines]
-            tups = [(model, prompt) for prompt in prompts]
-            scores = track_progress_rich(LLaVABench_atomeval,
-                                         tups,
-                                         nproc=nproc,
-                                         chunksize=nproc)
-            data['gpt4_score'] = [x[0] for x in scores]
-            data['score'] = [x[1] for x in scores]
+            scores = load_judge_cache(tmp_file)
+            pending = [idx for idx in indices if idx not in scores or llava_judge_failed(scores[idx])]
+            if pending:
+                model = build_judge(temperature=0.2,
+                                    system_prompt=system_prompt,
+                                    **judge_kwargs)
+                assert model.working(), 'LLaVABench_KO evaluation requires a working OPENAI API\n' + DEBUG_MESSAGE
+                tups = [(model, prompt) for prompt in prompts]
+                scores = run_cached_tasks(
+                    LLaVABench_atomeval,
+                    tups,
+                    indices,
+                    tmp_file,
+                    nproc=nproc,
+                    chunksize=nproc,
+                    failure_fn=llava_judge_failed,
+                )
+            data['gpt4_score'] = [scores[idx][0] for idx in indices]
+            data['score'] = [scores[idx][1] for idx in indices]
             dump(data, record_file)
 
         data = load(record_file)
@@ -1987,42 +2027,51 @@ class VGRPBench(ImageBaseDataset):
         from .utils.vgrpbench.evaluation import (VGRPBench_atomeval, VGRPBench_get_system_prompt,
                                                  VGRPBench_score, build_prompt)
 
-        record_file = get_intermediate_file_path(eval_file, '_openai_result')
-        score_file = get_intermediate_file_path(eval_file, '_score', 'csv')
+        judge_name = judge_kwargs.get('model', 'default')
+        tmp_file = get_judge_cache_file(eval_file, 'eval', judge_name)
+        record_file = get_judge_detail_file(eval_file, 'eval', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'csv')
 
         nproc = judge_kwargs.pop('nproc', 4)
 
         if not osp.exists(record_file):
             data = load(eval_file)
             lines = [data.iloc[i] for i in range(len(data))]
+            indices = data['index'].tolist() if 'index' in data.columns else list(range(len(data)))
 
             system_prompts = [
                 VGRPBench_get_system_prompt(line) for line in lines
             ]
 
-            models = [
-                build_judge(temperature=0.0,
-                            system_prompt=system_prompt,
-                            **judge_kwargs) for system_prompt in system_prompts
-            ]
-
             prompts = [build_prompt(line) for line in lines]
+            scores = load_judge_cache(tmp_file)
+            pending = [idx for idx in indices if idx not in scores or vgrp_judge_failed(scores[idx])]
+            if pending:
+                tups = []
+                for idx, system_prompt, prompt, line in zip(indices, system_prompts, prompts, lines):
+                    if idx not in pending:
+                        continue
+                    model = build_judge(temperature=0.0,
+                                        system_prompt=system_prompt,
+                                        **judge_kwargs)
+                    tups.append((model, prompt, line))
 
-            tups = [(model, prompt, line)
-                    for model, prompt, line in zip(models, prompts, lines)]
-
-            # Original parallel processing
-            scores = track_progress_rich(VGRPBench_atomeval,
-                                         tups,
-                                         nproc=nproc,
-                                         chunksize=nproc)
+                scores = run_cached_tasks(
+                    VGRPBench_atomeval,
+                    tups,
+                    pending,
+                    tmp_file,
+                    nproc=nproc,
+                    chunksize=nproc,
+                    failure_fn=vgrp_judge_failed,
+                )
 
             data['perception_correct'] = [
-                x['perception_correct'] for x in scores
+                scores[idx]['perception_correct'] for idx in indices
             ]
-            data['answer_correct'] = [x['answer_correct'] for x in scores]
+            data['answer_correct'] = [scores[idx]['answer_correct'] for idx in indices]
             data['number_of_samples'] = [
-                x['number_of_samples'] for x in scores
+                scores[idx]['number_of_samples'] for idx in indices
             ]
             dump(data, record_file)
 
@@ -4135,26 +4184,26 @@ class MathCanvas(ImageBaseDataset):
             "temperature": 0.0,
         })
 
+        judge_name = judge_kwargs.get('model', 'default')
         config = {'hint': self.HINT, 'judge_kwargs': judge_kwargs}
         config_file = get_intermediate_file_path(eval_file, '_config')
         with open(config_file, 'w', encoding='utf-8') as f:
             json.dump(config, f, ensure_ascii=False, indent=4)
 
-        detailed_results_file = get_intermediate_file_path(eval_file, '_meta')
+        tmp_file = get_judge_cache_file(eval_file, 'eval', judge_name)
+        detailed_results_file = get_judge_detail_file(eval_file, 'eval', judge_name, 'json')
         if not os.path.exists(detailed_results_file):
             print("Evaluating with judge, this may take a while...")
-            eval_results_list = evaluate_with_judge(eval_file, self.data, **judge_kwargs)
-            with open(detailed_results_file, 'w', encoding='utf-8') as f:
-                json.dump(eval_results_list, f, ensure_ascii=False, indent=4)
+            eval_results_list = evaluate_with_judge(eval_file, self.data, cache_file=tmp_file, **judge_kwargs)
+            dump(eval_results_list, detailed_results_file)
         else:
             print(f"Loading existing evaluation results from {detailed_results_file}")
             eval_results_list = load(detailed_results_file)
 
         summary_dict = summarize_mathcanvas_results(eval_results_list)
 
-        score_file = get_intermediate_file_path(eval_file, '_metrics', target_format='json')
-        with open(score_file, 'w', encoding='utf-8') as f:
-            json.dump(summary_dict, f, ensure_ascii=False, indent=4)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
+        dump(summary_dict, score_file)
 
         return summary_dict
 
@@ -4286,23 +4335,17 @@ class CoreCognition(ImageBaseDataset):
 
     def evaluate(self, eval_file, **judge_kwargs):
         assert os.path.exists(eval_file), '{} does not exist!'.format(eval_file)
-        from .utils.corecognition import CoreCognition_acc, CoreCognition_eval
+        from .utils.corecognition import CoreCognition_acc, CoreCognition_eval_single
 
         nproc = judge_kwargs.pop('nproc', 4)
-        model = judge_kwargs.get('model', 'exact_matching')
-        name_str_map = {'chatgpt-0125': 'openai', 'gpt-4-0125': 'gpt4', 'gpt-4o-mini': 'gpt4omini', 'gpt-4.1': 'gpt41'}
-        name_str = name_str_map[model] if model in name_str_map else model
+        judge_name = judge_kwargs.get('model', 'exact_matching')
 
-        score_file = get_intermediate_file_path(eval_file, '_acc', 'csv')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'csv')
         if osp.exists(score_file):
             acc = load(score_file)
             return acc
-
-        model = build_judge(**judge_kwargs)
-        if not model.working():
-            warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-            warnings.warn(DEBUG_MESSAGE)
-            model = None
 
         data = load(eval_file)
         data = data.sort_values(by='index')
@@ -4319,11 +4362,33 @@ class CoreCognition(ImageBaseDataset):
         meta_merge = meta[['index', 'answer', 'category', 'l2-category', 'question_type']]
         data = data.merge(meta_merge, on='index', how='left')
 
-        # Evaluate predictions using hybrid matching with parallel processing
-        data['correct'] = CoreCognition_eval(model, data, nproc=nproc)
-
-        result_file = get_intermediate_file_path(eval_file, f'_{name_str}_result')
-        dump(data, result_file)
+        if not osp.exists(detail_file):
+            indices = data['index'].tolist()
+            judged = load_judge_cache(tmp_file)
+            pending = [idx for idx in indices if idx not in judged or corecognition_judge_failed(judged[idx])]
+            if pending:
+                model = build_judge(**judge_kwargs)
+                if not model.working():
+                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
+                    warnings.warn(DEBUG_MESSAGE)
+                    model = None
+                tasks = [(model, row.to_dict()) for _, row in data.iterrows()]
+                judged = run_cached_tasks(
+                    CoreCognition_eval_single,
+                    tasks,
+                    indices,
+                    tmp_file,
+                    nproc=nproc,
+                    chunksize=nproc,
+                    failure_fn=corecognition_judge_failed,
+                )
+            data['judge_pred'] = [judged[idx]['matched'] for idx in indices]
+            data['judge_log'] = [judged[idx]['judge_log'] for idx in indices]
+            data['judge_method'] = [judged[idx]['judge_method'] for idx in indices]
+            data['correct'] = [judged[idx]['correct'] for idx in indices]
+            dump(data, detail_file)
+        else:
+            data = load(detail_file)
 
         # Calculate accuracy
         acc = CoreCognition_acc(data)

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -13,6 +13,8 @@ from PIL import Image
 from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermediate_file_path,
                          load, md5, modelscope_flag_set)
 from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                has_judge_failure, load_judge_cache)
 from .video_base import VideoBaseDataset
 
 FAIL_MSG = 'Failed to obtain answer via API.'
@@ -292,26 +294,32 @@ class LongVideoBench(VideoBaseDataset):
 
         assert get_file_extension(eval_file) in ['xlsx', 'json', 'tsv'], 'data file should be an supported format (xlsx/json/tsv) file'  # noqa: E501
 
-        tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
-        tgt_file = get_intermediate_file_path(eval_file, '_rating', 'json')
-        score_file = get_intermediate_file_path(eval_file, '_score')
+        judge_name = judge_kwargs.get('model', 'exact_matching')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
-        if not osp.exists(score_file):
-            model = judge_kwargs.get('model', 'exact_matching')
-
-            if model == 'exact_matching':
-                model = None
-            else:
-                model = build_judge(**judge_kwargs)
-                if not model.working():
-                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-                    warnings.warn(DEBUG_MESSAGE)
-                    model = None
-            res = {} if not osp.exists(tmp_file) else load(tmp_file)
-            res = {k: v for k, v in res.items() if FAIL_MSG not in v}
+        if not osp.exists(detail_file):
+            res = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
 
             data = load(eval_file)
             data_un = data[~pd.isna(data['prediction'])]
+            model = None
+            model_built = False
+
+            def get_model():
+                nonlocal model, model_built
+                if judge_name == 'exact_matching':
+                    return None
+                if not model_built:
+                    model = build_judge(**judge_kwargs)
+                    if not model.working():
+                        warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
+                        warnings.warn(DEBUG_MESSAGE)
+                        model = None
+                    model_built = True
+                return model
 
             for idx in data['index']:
                 ans = data.loc[data['index'] == idx, 'correct_choice'].values[0]
@@ -319,14 +327,23 @@ class LongVideoBench(VideoBaseDataset):
                 pred = str(data.loc[data['index'] == idx, 'prediction'].values[0])
 
                 if extract_characters_regex(pred) == '':
-                    extract_pred = extract_option(
-                        model,
-                        data.loc[data['index'] == idx].to_dict(orient='records')[0],
-                        'LongVideoBench'
+                    extract_pred = res.get(idx)
+                    if has_judge_failure(extract_pred):
+                        extract_pred = extract_option(
+                            get_model(),
+                            data.loc[data['index'] == idx].to_dict(orient='records')[0],
+                            'LongVideoBench'
+                        )
+                        res[idx] = extract_pred
+                        dump(res, tmp_file)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = (
+                        -1 if extract_pred in ['Fail', ''] else int(extract_pred == ans)
                     )
-                    data.loc[idx, 'score'] = int(extract_pred == ans)
                 else:
-                    data.loc[idx, 'score'] = int(extract_characters_regex(pred) == ans)
+                    extract_pred = extract_characters_regex(pred)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
 
             rejected = [x for x in data['score'] if x == -1]
 
@@ -336,8 +353,9 @@ class LongVideoBench(VideoBaseDataset):
                 f'Those questions will be counted as -1 score in ALL rating, and will not be counted in VALID rating.'
             )
 
-            dump(data, score_file)
+            dump(data, detail_file)
 
-        rating = get_dimension_rating(score_file)
-        dump(rating, tgt_file)
+        rating = load(score_file) if osp.exists(score_file) else get_dimension_rating(detail_file)
+        if not osp.exists(score_file):
+            dump(rating, score_file)
         return rating

--- a/vlmeval/dataset/m4bench.py
+++ b/vlmeval/dataset/m4bench.py
@@ -1,14 +1,29 @@
 import re
 from os import path as osp
 
-import pandas as pd
 from tqdm import tqdm
 
-from ..smp import decode_base64_to_image_file, dump, get_intermediate_file_path, load
+from ..smp import decode_base64_to_image_file, dump, load
+from ..utils import track_progress_rich
 from .image_base import ImageBaseDataset
 from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                load_judge_cache)
 
 FAIL_MSG = 'Failed to obtain answer via API.'
+
+
+def m4bench_judge_extract(judge, prompt):
+    input_msg = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "value": prompt}
+            ]
+        }
+    ]
+    _, judge_output, _ = judge.generate_inner(input_msg)
+    return judge_output
 
 
 class M4Bench(ImageBaseDataset):
@@ -84,6 +99,8 @@ class M4Bench(ImageBaseDataset):
         Evaluates the model predictions against the ground truth.
         """
         results_df = load(eval_file)
+        judge_kwargs = judge_kwargs.copy()
+        judge_name = judge_kwargs.get('model', 'exact_matching')
 
         dataset_name = None
         for name in self.DATASET_URL:
@@ -101,94 +118,114 @@ class M4Bench(ImageBaseDataset):
 
         # # Merge predictions with ground truth
         df = results_df.copy()
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
         def get_ans(s):
             s = str(s)
-            match = re.search(r'^\s*\(([A-Z])\)', s)
+            match = re.search(r'\(([A-Z])\)', s)
             if match:
                 return match.group(1)
-
-            options = list('ABCDEFGHIJKLMNOPQRSTUVWXYZ')
-            for op in options:
-                if s.startswith(op):
-                    return op
+            match = re.search(r'(?i)(?:answer|output)\s*[:：]\s*([A-Z])\b', s)
+            if match:
+                return match.group(1).upper()
+            match = re.search(r'^\s*([A-Z])\s*[\).:：]?', s)
+            if match and len(s.strip().split()) <= 3:
+                return match.group(1)
             return None
 
-        if judge_kwargs:
-            try:
-                # Use LLM as a judge to parse the prediction
-                judge = build_judge(**judge_kwargs)
+        if judge_kwargs and not osp.exists(detail_file):
+            nproc = judge_kwargs.pop('nproc', 4)
+            tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+            indices = df['index'].tolist() if 'index' in df.columns else list(range(len(df)))
 
-                # Prepare data for the judge
-                def extract_question(q):
-                    return q.split('\n(')[0]
+            # Prepare data for the judge
+            def extract_question(q):
+                return q.split('\n(')[0]
 
-                def extract_options(q):
-                    parts = q.split('\n(')
-                    return '\n('.join(parts[1:]) if len(parts) > 1 else ''
+            def extract_options(q):
+                parts = q.split('\n(')
+                return '\n('.join(parts[1:]) if len(parts) > 1 else ''
 
-                df['question_text'] = df['query'].apply(extract_question)
-                df['options_text'] = df['query'].apply(extract_options)
+            df['question_text'] = df['query'].apply(extract_question)
+            df['options_text'] = df['query'].apply(extract_options)
 
-                prompt_tmpl = (
-                    'You are an AI assistant who will help me to match '
-                    'an answer with several options of a single-choice question. '    # noqa: E501
-                    'You are provided with a question, several options, and an answer, '    # noqa: E501
-                    'and you need to find which option is most similar to the answer. '    # noqa: E501
-                    'If the meaning of all options are significantly different from the answer, output Z. '   # noqa: E501
-                    'Your should output a single uppercase character in A, B, C, D (if they are valid options), and Z. \n'    # noqa: E501
-                    'Example 1: \n'
-                    'Question: What is the main object in image?\nOptions: A. teddy bear B. rabbit C. cat D. dog\n'    # noqa: E501
-                    'Answer: a cute teddy bear\nYour output: A\n'
-                    'Example 2: \n'
-                    'Question: What is the main object in image?\nOptions: A. teddy bear B. rabbit C. cat D. dog\n'    # noqa: E501
-                    'Answer: Spider\nYour output: Z\n'
-                    'Example 3: \n'
-                    'Question: {question}\nOptions: {options}\nAnswer: {prediction}\nYour output: '    # noqa: E501
+            prompt_tmpl = (
+                'You are an AI assistant who will help me to match '
+                'an answer with several options of a single-choice question. '    # noqa: E501
+                'You are provided with a question, several options, and an answer, '    # noqa: E501
+                'and you need to find which option is most similar to the answer. '    # noqa: E501
+                'If the meaning of all options are significantly different from the answer, output Z. '   # noqa: E501
+                'Your should output a single uppercase character in A, B, C, D (if they are valid options), and Z. \n'    # noqa: E501
+                'Example 1: \n'
+                'Question: What is the main object in image?\nOptions: A. teddy bear B. rabbit C. cat D. dog\n'    # noqa: E501
+                'Answer: a cute teddy bear\nYour output: A\n'
+                'Example 2: \n'
+                'Question: What is the main object in image?\nOptions: A. teddy bear B. rabbit C. cat D. dog\n'    # noqa: E501
+                'Answer: Spider\nYour output: Z\n'
+                'Example 3: \n'
+                'Question: {question}\nOptions: {options}\nAnswer: {prediction}\nYour output: '    # noqa: E501
+            )
+
+            prompts = [
+                prompt_tmpl.format(
+                    question=row['question_text'],
+                    options=row['options_text'],
+                    prediction=row['prediction']
                 )
+                for _, row in tqdm(df.iterrows(), total=len(df), desc="Processing rows")
+            ]
+            cache = load_judge_cache(tmp_file)
+            pending_prompts = []
+            pending_indices = []
+            for idx, prompt in zip(indices, prompts):
+                if idx not in cache or get_ans(cache[idx]) is None:
+                    pending_prompts.append(prompt)
+                    pending_indices.append(idx)
 
-                prompts = [
-                    prompt_tmpl.format(
-                        question=row['question_text'],
-                        options=row['options_text'],
-                        prediction=row['prediction']
+            if pending_indices:
+                try:
+                    judge = build_judge(**judge_kwargs)
+                    assert judge.working(), 'M4Bench evaluation requires a working OPENAI API\n' + DEBUG_MESSAGE
+                    pending_tasks = [(judge, prompt) for prompt in pending_prompts]
+                    _ = track_progress_rich(
+                        m4bench_judge_extract,
+                        pending_tasks,
+                        nproc=nproc,
+                        chunksize=nproc,
+                        keys=pending_indices,
+                        save=tmp_file,
                     )
-                    for _, row in tqdm(df.iterrows(), total=len(df), desc="Processing rows")
-                ]
-                parsed_pred = []
+                    cache = load_judge_cache(tmp_file)
+                except Exception as e:
+                    print(f"Error during judge evaluation: {e}")
+                    print(DEBUG_MESSAGE)
+                    prediction_map = dict(zip(indices, df['prediction']))
+                    cache.update({idx: prediction_map[idx] for idx in pending_indices})
+                    dump(cache, tmp_file)
 
-                for prompt in tqdm(prompts, desc="Calling judge"):
-                    input_msg = [
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "value": prompt}
-                            ]
-                        }
-                    ]
-
-                    _, judge_output, res = judge.generate_inner(input_msg)
-                    judge_ans = get_ans(judge_output)
-                    parsed_pred.append(judge_ans)
-                df['parsed_pred'] = pd.Series(parsed_pred)
-
-            except Exception as e:
-                print(f"Error during judge evaluation: {e}")
-                print(DEBUG_MESSAGE)
-                df['parsed_pred'] = df['prediction'].apply(get_ans)
+            df['judge_raw'] = [cache.get(idx, '') for idx in indices]
+            df['parsed_pred'] = [
+                get_ans(cache.get(idx, '')) or get_ans(pred)
+                for idx, pred in zip(indices, df['prediction'])
+            ]
         else:
             # Fallback to simple parsing if no judge is provided
-            df['parsed_pred'] = df['prediction'].apply(get_ans)
+            if osp.exists(detail_file):
+                df = load(detail_file)
+            else:
+                df['judge_raw'] = df['prediction']
+                df['parsed_pred'] = df['prediction'].apply(get_ans)
 
         # Calculate score
         df['score'] = (df['parsed_pred'] == df['response'])
 
         # Save detailed results
-        details_file = get_intermediate_file_path(eval_file, '_details')
-        dump(df, details_file)
+        dump(df, detail_file)
 
         # Calculate and return accuracy
         acc = df['score'].mean() * 100
-        results = {'acc': acc, 'details': details_file}
+        results = {'acc': acc, 'details': detail_file}
+        dump(results, score_file)
 
         return results

--- a/vlmeval/dataset/mmlongbench.py
+++ b/vlmeval/dataset/mmlongbench.py
@@ -10,9 +10,11 @@ from urllib.request import urlopen
 import pandas as pd
 import torchvision.transforms as transforms
 from PIL import Image, ImageDraw, ImageFont
-from tqdm import tqdm
 
 from vlmeval.dataset.utils import build_judge, levenshtein_distance
+from vlmeval.dataset.utils.judge_cache import (get_judge_cache_file, get_judge_detail_file,
+                                               get_judge_score_file, has_judge_failure,
+                                               load_judge_cache, run_cached_tasks)
 from vlmeval.smp import (decode_base64_to_image_file, dump, encode_image_to_base64,
                          get_intermediate_file_path, get_logger, listinstr, load, read_ok,
                          toliststr)
@@ -373,6 +375,12 @@ def MMLongBench_auxeval(model, line):
     return dict(log=log, res='', pred='')
 
 
+def MMLongBench_judge_failed(result):
+    if has_judge_failure(result):
+        return True
+    return not isinstance(result, dict) or not result.get('res') or not result.get('pred')
+
+
 def get_f1(data):
     gt_pos_data = data[data.apply(lambda k: k['answer'] != 'Not answerable', axis=1)]
     pred_pos_data = data[data.apply(lambda k: k['pred'] != 'Not answerable', axis=1)]
@@ -547,36 +555,34 @@ class MMLongBench(ImageBaseDataset):
 
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
-        model = judge_kwargs['model']
-
-        storage = get_intermediate_file_path(eval_file, f'_{model}')
-        tmp_file = get_intermediate_file_path(eval_file, f'_{model}', 'pkl')
+        judge_name = judge_kwargs['model']
+        storage = get_judge_detail_file(eval_file, 'extract', judge_name)
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, f'_{judge_name}', 'pkl')
 
         if osp.exists(storage):
             logger.warning(f'GPT scoring file {storage} already exists, will reuse it in MMLongBench_eval. ')
         else:
             data = load(eval_file)
-            model = build_judge(max_tokens=128, **judge_kwargs)
             lt = len(data)
             lines = [data.iloc[i] for i in range(lt)]
-            tups = [(model, line) for line in lines]
             indices = [line['index'] for line in lines]
-
-            ans = {}
-            if osp.exists(tmp_file):
-                ans = load(tmp_file)
-            tups = [x for x, i in zip(tups, indices) if i not in ans]
-            indices = [i for i in indices if i not in ans]
-
-            if len(indices):
-                new_results = list()
-                for model, line in tqdm(tups):
-                    res = MMLongBench_auxeval(model, line)
-                    new_results.append(res)
+            ans = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
+            pending = [idx for idx in indices if idx not in ans or MMLongBench_judge_failed(ans[idx])]
+            if pending:
+                model = build_judge(max_tokens=128, **judge_kwargs)
+                tups = [(model, line) for line in lines]
+                ans = run_cached_tasks(
+                    MMLongBench_auxeval,
+                    tups,
+                    indices,
+                    tmp_file,
+                    legacy_files=[legacy_tmp_file],
+                    failure_fn=MMLongBench_judge_failed,
+                )
 
             log_map, res_map, pred_map = {}, {}, {}
-            all_inds = [line['index'] for line in lines]
-            for k, v in zip(all_inds, new_results):
+            for k, v in ans.items():
                 log_map[k] = v['log']
                 res_map[k] = v['res']
                 pred_map[k] = v['pred']
@@ -586,7 +592,7 @@ class MMLongBench(ImageBaseDataset):
             dump(data, storage)
 
         score = MMLongBench_acc(storage)
-        score_pth = get_intermediate_file_path(storage, '_score', 'csv')
+        score_pth = get_judge_score_file(eval_file, judge_name, 'csv')
 
         dump(score, score_pth)
         logger.info(f'MMLongBench_eval successfully finished evaluating {eval_file}, results saved in {score_pth}')

--- a/vlmeval/dataset/simplevqa.py
+++ b/vlmeval/dataset/simplevqa.py
@@ -1,7 +1,6 @@
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import pandas as pd
@@ -9,9 +8,10 @@ from openai import OpenAI
 from tqdm import tqdm
 
 from vlmeval.dataset.image_base import ImageBaseDataset
+from vlmeval.dataset.utils.judge_cache import (get_judge_cache_file, get_judge_detail_file,
+                                               get_judge_score_file, load_judge_cache)
 from vlmeval.dataset.utils.simplevqa import SimpleVQAEval
 from vlmeval.smp import file, misc
-from vlmeval.smp.file import get_intermediate_file_path
 
 NUM_WORKERS = 16
 
@@ -95,6 +95,15 @@ COMPARE_ANSWER_PROMPT = """
             """.strip()
 
 
+def simplevqa_judge_failed(result):
+    if not isinstance(result, dict):
+        return True
+    judge_res = result.get('judge_res', {}).get('model_response')
+    if isinstance(judge_res, dict):
+        return judge_res.get('conclusion') == '答案解析失败'
+    return judge_res is None or '答案解析失败' in str(judge_res)
+
+
 class SimpleVQA(ImageBaseDataset):
     TYPE = "VQA"
     DATASET_URL = {
@@ -134,31 +143,31 @@ class SimpleVQA(ImageBaseDataset):
 
         return msgs
 
-    def get_scores(self, result_file: str, **judge_kwargs: Any) -> pd.DataFrame:
+    def get_scores(self, result_file: str, cache_file: str, **judge_kwargs: Any):
         data = file.load(result_file)
         model_keys = ['model_response']
-        fout = open(str(Path(result_file).parent) + '/gpt_eval.json', 'w', encoding='utf-8')
+        judge_kwargs = judge_kwargs.copy()
+        judge_model = judge_kwargs.get('model', 'gpt-4o')
 
         gpt4_key = os.environ.get('OPENAI_API_KEY', None)
         base_url = os.environ.get('OPENAI_API_BASE', None)
-        nproc = judge_kwargs.get('nproc', 16)
+        nproc = judge_kwargs.pop('nproc', 16)
 
-        client = OpenAI(
-            api_key=gpt4_key,
-            base_url=base_url
-        )
+        indices = data['index'].tolist() if 'index' in data.columns else list(range(len(data)))
+        cache = load_judge_cache(cache_file)
+        client = None
 
-        def process_one(idx):
-            question = data['question'][idx]
-            answer = data['answer'][idx]
-            model_response = data['prediction'][idx]
+        def process_one(row_idx, cache_key):
+            question = data['question'][row_idx]
+            answer = data['answer'][row_idx]
+            model_response = data['prediction'][row_idx]
             line = {'question': question, 'answer': answer, 'model_response': model_response}
             res_json = line.copy()
             candidates = "\n[预测答案0]：{}".format(model_response)
             prompt = COMPARE_ANSWER_PROMPT.format(question=question, answer=answer, candidates=candidates)
             try:
                 response = client.chat.completions.create(
-                    model="gpt-4o",
+                    model=judge_model,
                     messages=[{"role": "user", "content": prompt}],
                     temperature=1
                 )
@@ -175,20 +184,33 @@ class SimpleVQA(ImageBaseDataset):
                     break
                 new_res[model_keys[i]] = res[key]
             res_json["judge_res"] = new_res
-            return idx, res_json
+            return cache_key, res_json
 
-        results = [None] * len(data)
-        with ThreadPoolExecutor(max_workers=nproc) as executor:
-            futures = {executor.submit(process_one, i): i for i in range(len(data))}
+        pending = [
+            (row_idx, cache_key)
+            for row_idx, cache_key in enumerate(indices)
+            if cache_key not in cache or simplevqa_judge_failed(cache[cache_key])
+        ]
 
-            for future in tqdm(as_completed(futures), total=len(data)):
-                idx, res_json = future.result()
-                results[idx] = res_json
+        if pending:
+            client = OpenAI(
+                api_key=gpt4_key,
+                base_url=base_url
+            )
+            with ThreadPoolExecutor(max_workers=nproc) as executor:
+                futures = {
+                    executor.submit(process_one, row_idx, cache_key): cache_key
+                    for row_idx, cache_key in pending
+                }
 
-        json.dump(results, fout, ensure_ascii=False, indent=4)
-        fout.close()
+                for future in tqdm(as_completed(futures), total=len(pending)):
+                    cache_key, res_json = future.result()
+                    cache[cache_key] = res_json
+                    file.dump(cache, cache_file)
+
+        results = [cache[key] for key in indices]
         scores = SimpleVQAEval(results)
-        return pd.DataFrame(list(scores.items()))
+        return results, pd.DataFrame(list(scores.items()))
 
     def evaluate(self, eval_file: str, **judge_kwargs: Any) -> pd.DataFrame:
         """
@@ -201,7 +223,17 @@ class SimpleVQA(ImageBaseDataset):
         Returns:
             DataFrame with evaluation scores by category
         """
-        score = self.get_scores(eval_file, **judge_kwargs)
-        score_file = get_intermediate_file_path(eval_file, "_acc", "csv")
+        judge_name = judge_kwargs.get('model', 'gpt-4o')
+        tmp_file = get_judge_cache_file(eval_file, 'eval', judge_name)
+        detail_file = get_judge_detail_file(eval_file, 'eval', judge_name, 'json')
+        score_file = get_judge_score_file(eval_file, judge_name, 'csv')
+
+        if not os.path.exists(detail_file):
+            results, score = self.get_scores(eval_file, cache_file=tmp_file, **judge_kwargs)
+            file.dump(results, detail_file)
+        else:
+            results = file.load(detail_file)
+            score = pd.DataFrame(list(SimpleVQAEval(results).items()))
+
         file.dump(score, score_file)
         return score

--- a/vlmeval/dataset/slidevqa.py
+++ b/vlmeval/dataset/slidevqa.py
@@ -5,14 +5,16 @@ import re
 from typing import List
 
 import pandas as pd
-from tqdm import tqdm
 
+from vlmeval.dataset.utils.judge_cache import (get_judge_cache_file, get_judge_detail_file,
+                                               get_judge_score_file, load_judge_cache,
+                                               run_cached_tasks)
 from vlmeval.dataset.utils.judge_util import build_judge
 from vlmeval.smp import (decode_base64_to_image_file, dump, encode_image_to_base64,
                          get_intermediate_file_path, get_logger, listinstr, load, read_ok,
                          toliststr)
 from .image_base import ImageBaseDataset
-from .mmlongbench import MMLongBench_auxeval, anls_compute, concat_images
+from .mmlongbench import MMLongBench_auxeval, MMLongBench_judge_failed, anls_compute, concat_images
 
 logger = get_logger(__name__)
 
@@ -149,36 +151,34 @@ class SlideVQA(ImageBaseDataset):
 
     @classmethod
     def evaluate(self, eval_file, **judge_kwargs):
-        model = judge_kwargs['model']
-
-        storage = get_intermediate_file_path(eval_file, f'_{model}')
-        tmp_file = get_intermediate_file_path(eval_file, f'_{model}', 'pkl')
+        judge_name = judge_kwargs['model']
+        storage = get_judge_detail_file(eval_file, 'extract', judge_name)
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, f'_{judge_name}', 'pkl')
 
         if osp.exists(storage):
             logger.warning(f'GPT scoring file {storage} already exists, will reuse it in SlideVQA_eval. ')
         else:
             data = load(eval_file)
-            model = build_judge(max_tokens=128, **judge_kwargs)
             lt = len(data)
             lines = [data.iloc[i] for i in range(lt)]
-            tups = [(model, line) for line in lines]
             indices = [line['index'] for line in lines]
-
-            ans = {}
-            if osp.exists(tmp_file):
-                ans = load(tmp_file)
-            tups = [x for x, i in zip(tups, indices) if i not in ans]
-            indices = [i for i in indices if i not in ans]
-
-            if len(indices):
-                new_results = list()
-                for model, line in tqdm(tups):
-                    res = MMLongBench_auxeval(model, line)
-                    new_results.append(res)
+            ans = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
+            pending = [idx for idx in indices if idx not in ans or MMLongBench_judge_failed(ans[idx])]
+            if pending:
+                model = build_judge(max_tokens=128, **judge_kwargs)
+                tups = [(model, line) for line in lines]
+                ans = run_cached_tasks(
+                    MMLongBench_auxeval,
+                    tups,
+                    indices,
+                    tmp_file,
+                    legacy_files=[legacy_tmp_file],
+                    failure_fn=MMLongBench_judge_failed,
+                )
 
             log_map, res_map, pred_map = {}, {}, {}
-            all_inds = [line['index'] for line in lines]
-            for k, v in zip(all_inds, new_results):
+            for k, v in ans.items():
                 log_map[k] = v['log']
                 res_map[k] = v['res']
                 pred_map[k] = v['pred']
@@ -188,7 +188,7 @@ class SlideVQA(ImageBaseDataset):
             dump(data, storage)
 
         score = SlideVQA_acc(storage)
-        score_pth = get_intermediate_file_path(storage, '_score', 'csv')
+        score_pth = get_judge_score_file(eval_file, judge_name, 'csv')
 
         dump(score, score_pth)
         logger.info(f'SlideVQA successfully finished evaluating {eval_file}, results saved in {score_pth}')

--- a/vlmeval/dataset/utils/corecognition.py
+++ b/vlmeval/dataset/utils/corecognition.py
@@ -211,23 +211,35 @@ def hybrid_match(model, prediction, question, question_type):
     # Step 1: Try template matching
     template_result = template_match(pred, question_type)
     if template_result != 'Fail':
-        return template_result
+        return dict(opt=template_result, log='Matched by template.', method='template')
 
     # Step 2: Fall back to LLM matching
     result = llm_match(model, question, prediction, question_type)
-    return result['opt']
+    result['method'] = 'llm'
+    return result
 
 
-def _eval_single_row(args):
-    """Process a single row for parallel execution."""
-    model, row_dict = args
+def CoreCognition_eval_single(model, row_dict):
+    """Evaluate a single row and return detailed judge outputs."""
     prediction = str(row_dict.get('prediction', ''))
     answer = str(row_dict.get('answer', '')).strip().upper()
     question = str(row_dict.get('question', ''))
     question_type = str(row_dict.get('question_type', 'MCQ')).upper()
 
     matched = hybrid_match(model, prediction, question, question_type)
-    return 1 if matched.upper() == answer else 0
+    opt = matched.get('opt', 'Fail').upper()
+    return {
+        'matched': opt,
+        'judge_log': matched.get('log', ''),
+        'judge_method': matched.get('method', 'unknown'),
+        'correct': int(opt == answer),
+    }
+
+
+def _eval_single_row(args):
+    """Process a single row for parallel execution."""
+    model, row_dict = args
+    return CoreCognition_eval_single(model, row_dict)['correct']
 
 
 def CoreCognition_eval(model, data, nproc=4):

--- a/vlmeval/dataset/utils/judge_cache.py
+++ b/vlmeval/dataset/utils/judge_cache.py
@@ -1,0 +1,94 @@
+import os.path as osp
+import re
+
+from vlmeval.smp import dump, get_file_extension, get_intermediate_file_path, load
+from vlmeval.utils import track_progress_rich
+
+DEFAULT_FAIL_MSG = 'Failed to obtain answer via API.'
+
+
+def normalize_judge_name(model):
+    if model is None:
+        model = 'exact_matching'
+    return re.sub(r'[^0-9A-Za-z._-]+', '_', str(model)).strip('_')
+
+
+def get_judge_cache_file(eval_file, stage, model):
+    return get_intermediate_file_path(eval_file, f'_judge_{stage}_{normalize_judge_name(model)}', 'pkl')
+
+
+def get_judge_detail_file(eval_file, stage, model, fmt=None):
+    if fmt is None:
+        fmt = get_file_extension(eval_file)
+    return get_intermediate_file_path(eval_file, f'_judge_{stage}_{normalize_judge_name(model)}', fmt)
+
+
+def get_judge_score_file(eval_file, model, fmt):
+    return get_intermediate_file_path(eval_file, f'_score_{normalize_judge_name(model)}', fmt)
+
+
+def has_judge_failure(result, fail_msg=DEFAULT_FAIL_MSG):
+    if result is None:
+        return True
+    if isinstance(result, str):
+        return fail_msg in result
+    if isinstance(result, dict):
+        return any(has_judge_failure(v, fail_msg=fail_msg) for v in result.values())
+    if isinstance(result, (list, tuple)):
+        return any(has_judge_failure(v, fail_msg=fail_msg) for v in result)
+    return False
+
+
+def is_failed_result(result, fail_msg=DEFAULT_FAIL_MSG, failure_fn=None):
+    if failure_fn is not None:
+        return failure_fn(result)
+    return has_judge_failure(result, fail_msg=fail_msg)
+
+
+def load_judge_cache(cache_file, legacy_files=None):
+    cache = {}
+    for path in legacy_files or []:
+        if osp.exists(path):
+            data = load(path)
+            if isinstance(data, dict):
+                cache.update(data)
+    if osp.exists(cache_file):
+        data = load(cache_file)
+        if isinstance(data, dict):
+            cache.update(data)
+    if cache and not osp.exists(cache_file):
+        dump(cache, cache_file)
+    return cache
+
+
+def filter_cached_tasks(tasks, keys, cache, fail_msg=DEFAULT_FAIL_MSG, failure_fn=None):
+    pending_tasks, pending_keys = [], []
+    for task, key in zip(tasks, keys):
+        if key not in cache or is_failed_result(cache[key], fail_msg=fail_msg, failure_fn=failure_fn):
+            pending_tasks.append(task)
+            pending_keys.append(key)
+    return pending_tasks, pending_keys
+
+
+def run_cached_tasks(func, tasks, keys, cache_file, nproc=4, chunksize=None, fail_msg=DEFAULT_FAIL_MSG,
+                     legacy_files=None, failure_fn=None, **kwargs):
+    cache = load_judge_cache(cache_file, legacy_files=legacy_files)
+    pending_tasks, pending_keys = filter_cached_tasks(
+        tasks,
+        keys,
+        cache,
+        fail_msg=fail_msg,
+        failure_fn=failure_fn,
+    )
+    if pending_keys:
+        track_progress_rich(
+            func,
+            pending_tasks,
+            nproc=nproc,
+            chunksize=chunksize or nproc,
+            keys=pending_keys,
+            save=cache_file,
+            **kwargs,
+        )
+        cache = load_judge_cache(cache_file, legacy_files=legacy_files)
+    return cache

--- a/vlmeval/dataset/utils/mathcanvas.py
+++ b/vlmeval/dataset/utils/mathcanvas.py
@@ -10,7 +10,8 @@ from openai import OpenAI
 from pydantic import BaseModel, Field, model_validator
 from tqdm import tqdm
 
-from vlmeval.smp import load, load_env
+from vlmeval.smp import dump, load, load_env
+from .judge_cache import load_judge_cache
 
 current_script_path = Path(__file__).resolve()
 current_dir = current_script_path.parent
@@ -159,31 +160,52 @@ def _process_single_item(item_data):
         return final_result
 
 
-def evaluate_with_judge(eval_file, ground_truth_data, **judge_kwargs):
+def mathcanvas_judge_failed(result):
+    return not isinstance(result, dict) or result.get('status') != 'success' or 'evaluation' not in result
+
+
+def evaluate_with_judge(eval_file, ground_truth_data, cache_file=None, **judge_kwargs):
     if OpenAI is None:
         raise ImportError("OpenAI library is required for MathCanvas evaluation. Please install it.")
 
     predictions = load(eval_file)
 
-    load_env()
-    api_key = os.environ.get("OPENAI_API_KEY", None)
-    base_url = os.environ.get("OPENAI_API_BASE", None)
-    client = OpenAI(api_key=api_key, base_url=base_url)
-
     tasks = []
-    gt_map = {row['index']: row for _, row in ground_truth_data.iterrows()}
+    task_keys = []
+    gt_map = {row['index']: row.to_dict() for _, row in ground_truth_data.iterrows()}
+    cache = load_judge_cache(cache_file) if cache_file is not None else {}
 
     for _, pred_row in predictions.iterrows():
         gt_row = gt_map.get(pred_row['index'])
         if gt_row is not None:
-            tasks.append((client, gt_row, pred_row.to_dict(), judge_kwargs))
+            task_key = pred_row['index']
+            if task_key not in cache or mathcanvas_judge_failed(cache[task_key]):
+                tasks.append((gt_row, pred_row.to_dict(), judge_kwargs))
+                task_keys.append(task_key)
+
+    max_workers = judge_kwargs.get('nproc', 16)
+    if tasks:
+        load_env()
+        api_key = os.environ.get("OPENAI_API_KEY", None)
+        base_url = os.environ.get("OPENAI_API_BASE", None)
+        client = OpenAI(api_key=api_key, base_url=base_url)
+        tasks = [(client, gt_row, pred_row, kwargs) for gt_row, pred_row, kwargs in tasks]
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            results_iterator = executor.map(_process_single_item, tasks)
+            for task_key, result in tqdm(
+                zip(task_keys, results_iterator),
+                total=len(tasks),
+                desc="Evaluating with Judge LLM",
+            ):
+                cache[task_key] = result
+                if cache_file is not None:
+                    dump(cache, cache_file)
 
     detailed_results = []
-    max_workers = judge_kwargs.get('nproc', 16)
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        results_iterator = executor.map(_process_single_item, tasks)
-        for result in tqdm(results_iterator, total=len(tasks), desc="Evaluating with Judge LLM"):
-            detailed_results.append(result)
+    for _, pred_row in predictions.iterrows():
+        gt_row = gt_map.get(pred_row['index'])
+        if gt_row is not None and pred_row['index'] in cache:
+            detailed_results.append(cache[pred_row['index']])
 
     return detailed_results
 

--- a/vlmeval/dataset/video_holmes.py
+++ b/vlmeval/dataset/video_holmes.py
@@ -2,7 +2,6 @@ import json
 import os
 import os.path as osp
 import pickle
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -12,7 +11,8 @@ from PIL import Image
 
 from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermediate_file_path,
                          load, md5, modelscope_flag_set)
-from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                load_judge_cache)
 from .video_base import VideoBaseDataset
 
 FAIL_MSG = 'Failed to obtain answer via API.'
@@ -219,23 +219,14 @@ class Video_Holmes(VideoBaseDataset):
 
         assert get_file_extension(eval_file) in ['xlsx', 'json', 'tsv'], 'data file should be an supported format (xlsx/json/tsv) file'  # noqa: E501
 
-        tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
-        tgt_file = get_intermediate_file_path(eval_file, '_rating', 'json')
-        score_file = get_intermediate_file_path(eval_file, '_score')
+        judge_name = judge_kwargs.get('model', 'exact_matching')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
-        if not osp.exists(score_file):
-            model = judge_kwargs.get('model', 'exact_matching')
-
-            if model == 'exact_matching':
-                model = None
-            else:
-                model = build_judge(**judge_kwargs)
-                if not model.working():
-                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-                    warnings.warn(DEBUG_MESSAGE)
-                    model = None
-            res = {} if not osp.exists(tmp_file) else load(tmp_file)
-            res = {k: v for k, v in res.items() if FAIL_MSG not in v}
+        if not osp.exists(detail_file):
+            res = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
 
             data = load(eval_file)
             data_un = data[~pd.isna(data['prediction'])]
@@ -244,9 +235,12 @@ class Video_Holmes(VideoBaseDataset):
                 ans = data.loc[data['index'] == idx, 'answer'].values[0]
                 pred = str(data.loc[data['index'] == idx, 'prediction'].values[0])
 
-                predicted_answer = extract_option(pred)
+                predicted_answer = res.get(idx, extract_option(pred))
+                res[idx] = predicted_answer
+                dump(res, tmp_file)
 
-                data.loc[idx, 'score'] = int(predicted_answer == ans)
+                data.loc[data['index'] == idx, 'judge_pred'] = predicted_answer
+                data.loc[data['index'] == idx, 'score'] = int(predicted_answer == ans)
 
             rejected = [x for x in data['score'] if x == -1]
 
@@ -256,8 +250,9 @@ class Video_Holmes(VideoBaseDataset):
                 f'Those questions will be counted as -1 score in ALL rating, and will not be counted in VALID rating.'
             )
 
-            dump(data, score_file)
+            dump(data, detail_file)
 
-        rating = get_dimension_rating(score_file)
-        dump(rating, tgt_file)
+        rating = load(score_file) if osp.exists(score_file) else get_dimension_rating(detail_file)
+        if not osp.exists(score_file):
+            dump(rating, score_file)
         return rating

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -12,6 +12,8 @@ from PIL import Image
 from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermediate_file_path,
                          load, md5, modelscope_flag_set)
 from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                has_judge_failure, load_judge_cache)
 from .video_base import VideoBaseDataset
 
 FAIL_MSG = 'Failed to obtain answer via API.'
@@ -246,40 +248,55 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         assert get_file_extension(eval_file) in ['xlsx', 'json', 'tsv'], 'data file should be an supported format (xlsx/json/tsv) file'  # noqa: E501
 
-        tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
-        tgt_file = get_intermediate_file_path(eval_file, '_rating', 'json')
-        score_file = get_intermediate_file_path(eval_file, '_score')
+        judge_name = judge_kwargs.get('model', 'exact_matching')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
-        if not osp.exists(score_file):
-            model = judge_kwargs.get('model', 'exact_matching')
-
-            if model == 'exact_matching':
-                model = None
-            else:
-                model = build_judge(**judge_kwargs)
-                if not model.working():
-                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-                    warnings.warn(DEBUG_MESSAGE)
-                    model = None
-            res = {} if not osp.exists(tmp_file) else load(tmp_file)
-            res = {k: v for k, v in res.items() if FAIL_MSG not in v}
+        if not osp.exists(detail_file):
+            res = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
 
             data = load(eval_file)
             data_un = data[~pd.isna(data['prediction'])]
+            model = None
+            model_built = False
+
+            def get_model():
+                nonlocal model, model_built
+                if judge_name == 'exact_matching':
+                    return None
+                if not model_built:
+                    model = build_judge(**judge_kwargs)
+                    if not model.working():
+                        warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
+                        warnings.warn(DEBUG_MESSAGE)
+                        model = None
+                    model_built = True
+                return model
 
             for idx in data['index']:
                 ans = data.loc[data['index'] == idx, 'answer'].values[0]
                 pred = str(data.loc[data['index'] == idx, 'prediction'].values[0])
 
                 if extract_characters_regex(pred) == '':
-                    extract_pred = extract_option(
-                        model,
-                        data.loc[data['index'] == idx].to_dict(orient='records')[0],
-                        'Video-MME'
+                    extract_pred = res.get(idx)
+                    if has_judge_failure(extract_pred):
+                        extract_pred = extract_option(
+                            get_model(),
+                            data.loc[data['index'] == idx].to_dict(orient='records')[0],
+                            'Video-MME'
+                        )
+                        res[idx] = extract_pred
+                        dump(res, tmp_file)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = (
+                        -1 if extract_pred in ['Fail', ''] else int(extract_pred == ans)
                     )
-                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
                 else:
-                    data.loc[data['index'] == idx, 'score'] = int(extract_characters_regex(pred) == ans)
+                    extract_pred = extract_characters_regex(pred)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
 
             rejected = [x for x in data['score'] if x == -1]
 
@@ -289,10 +306,11 @@ Respond with only the letter (A, B, C, or D) of the correct option.
                 f'Those questions will be counted as -1 score in ALL rating, and will not be counted in VALID rating.'
             )
 
-            dump(data, score_file)
+            dump(data, detail_file)
 
-        rating = get_dimension_rating(score_file)
-        dump(rating, tgt_file)
+        rating = load(score_file) if osp.exists(score_file) else get_dimension_rating(detail_file)
+        if not osp.exists(score_file):
+            dump(rating, score_file)
         return rating
 
     @classmethod

--- a/vlmeval/dataset/videott.py
+++ b/vlmeval/dataset/videott.py
@@ -13,6 +13,8 @@ from PIL import Image
 from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermediate_file_path,
                          load, md5, modelscope_flag_set)
 from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                has_judge_failure, load_judge_cache)
 from .video_base import VideoBaseDataset
 
 FAIL_MSG = 'Failed to obtain answer via API.'
@@ -199,40 +201,55 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         assert get_file_extension(eval_file) in ['xlsx', 'json', 'tsv'], 'data file should be an supported format (xlsx/json/tsv) file'  # noqa: E501
 
-        tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
-        tgt_file = get_intermediate_file_path(eval_file, '_rating', 'json')
-        score_file = get_intermediate_file_path(eval_file, '_score')
+        judge_name = judge_kwargs.get('model', 'exact_matching')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
-        if not osp.exists(score_file):
-            model = judge_kwargs.get('model', 'exact_matching')
-
-            if model == 'exact_matching':
-                model = None
-            else:
-                model = build_judge(**judge_kwargs)
-                if not model.working():
-                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-                    warnings.warn(DEBUG_MESSAGE)
-                    model = None
-            res = {} if not osp.exists(tmp_file) else load(tmp_file)
-            res = {k: v for k, v in res.items() if FAIL_MSG not in v}
+        if not osp.exists(detail_file):
+            res = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
 
             data = load(eval_file)
             data_un = data[~pd.isna(data['prediction'])]
+            model = None
+            model_built = False
+
+            def get_model():
+                nonlocal model, model_built
+                if judge_name == 'exact_matching':
+                    return None
+                if not model_built:
+                    model = build_judge(**judge_kwargs)
+                    if not model.working():
+                        warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
+                        warnings.warn(DEBUG_MESSAGE)
+                        model = None
+                    model_built = True
+                return model
 
             for idx in data['index']:
                 ans = data.loc[data['index'] == idx, 'answer'].values[0]
                 pred = str(data.loc[data['index'] == idx, 'prediction'].values[0])
 
                 if extract_characters_regex(pred) == '':
-                    extract_pred = extract_option(
-                        model,
-                        data.loc[data['index'] == idx].to_dict(orient='records')[0],
-                        'Video-MME'
+                    extract_pred = res.get(idx)
+                    if has_judge_failure(extract_pred):
+                        extract_pred = extract_option(
+                            get_model(),
+                            data.loc[data['index'] == idx].to_dict(orient='records')[0],
+                            'Video-MME'
+                        )
+                        res[idx] = extract_pred
+                        dump(res, tmp_file)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = (
+                        -1 if extract_pred in ['Fail', ''] else int(extract_pred == ans)
                     )
-                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
                 else:
-                    data.loc[data['index'] == idx, 'score'] = int(extract_characters_regex(pred) == ans)
+                    extract_pred = extract_characters_regex(pred)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
 
             rejected = [x for x in data['score'] if x == -1]
 
@@ -242,8 +259,9 @@ Respond with only the letter (A, B, C, or D) of the correct option.
                 f'Those questions will be counted as -1 score in ALL rating, and will not be counted in VALID rating.'
             )
 
-            dump(data, score_file)
+            dump(data, detail_file)
 
-        rating = get_dimension_rating(score_file)
-        dump(rating, tgt_file)
+        rating = load(score_file) if osp.exists(score_file) else get_dimension_rating(detail_file)
+        if not osp.exists(score_file):
+            dump(rating, score_file)
         return rating

--- a/vlmeval/dataset/worldsense.py
+++ b/vlmeval/dataset/worldsense.py
@@ -12,6 +12,8 @@ from PIL import Image
 from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermediate_file_path,
                          get_logger, load, md5, modelscope_flag_set)
 from .utils import DEBUG_MESSAGE, build_judge
+from .utils.judge_cache import (get_judge_cache_file, get_judge_detail_file, get_judge_score_file,
+                                has_judge_failure, load_judge_cache)
 from .video_base import VideoBaseDataset
 
 logger = get_logger(__name__)
@@ -299,40 +301,55 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         assert get_file_extension(eval_file) in ['xlsx', 'json', 'tsv'], 'data file should be an supported format (xlsx/json/tsv) file'  # noqa: E501
 
-        tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
-        tgt_file = get_intermediate_file_path(eval_file, '_rating', 'json')
-        score_file = get_intermediate_file_path(eval_file, '_score')
+        judge_name = judge_kwargs.get('model', 'exact_matching')
+        tmp_file = get_judge_cache_file(eval_file, 'extract', judge_name)
+        legacy_tmp_file = get_intermediate_file_path(eval_file, '_tmp', 'pkl')
+        detail_file = get_judge_detail_file(eval_file, 'extract', judge_name)
+        score_file = get_judge_score_file(eval_file, judge_name, 'json')
 
-        if not osp.exists(score_file):
-            model = judge_kwargs.get('model', 'exact_matching')
-
-            if model == 'exact_matching':
-                model = None
-            else:
-                model = build_judge(**judge_kwargs)
-                if not model.working():
-                    warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
-                    warnings.warn(DEBUG_MESSAGE)
-                    model = None
-            res = {} if not osp.exists(tmp_file) else load(tmp_file)
-            res = {k: v for k, v in res.items() if FAIL_MSG not in v}
+        if not osp.exists(detail_file):
+            res = load_judge_cache(tmp_file, legacy_files=[legacy_tmp_file])
 
             data = load(eval_file)
             data_un = data[~pd.isna(data['prediction'])]
+            model = None
+            model_built = False
+
+            def get_model():
+                nonlocal model, model_built
+                if judge_name == 'exact_matching':
+                    return None
+                if not model_built:
+                    model = build_judge(**judge_kwargs)
+                    if not model.working():
+                        warnings.warn('OPENAI API is not working properly, will use exact matching for evaluation')
+                        warnings.warn(DEBUG_MESSAGE)
+                        model = None
+                    model_built = True
+                return model
 
             for idx in data['index']:
                 ans = data.loc[data['index'] == idx, 'answer'].values[0]
                 pred = str(data.loc[data['index'] == idx, 'prediction'].values[0])
 
                 if extract_characters_regex(pred) == '':
-                    extract_pred = extract_option(
-                        model,
-                        data.loc[data['index'] == idx].to_dict(orient='records')[0],
-                        'WorldSense'
+                    extract_pred = res.get(idx)
+                    if has_judge_failure(extract_pred):
+                        extract_pred = extract_option(
+                            get_model(),
+                            data.loc[data['index'] == idx].to_dict(orient='records')[0],
+                            'WorldSense'
+                        )
+                        res[idx] = extract_pred
+                        dump(res, tmp_file)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = (
+                        -1 if extract_pred in ['Fail', ''] else int(extract_pred == ans)
                     )
-                    data.loc[idx, 'score'] = int(extract_pred == ans)
                 else:
-                    data.loc[idx, 'score'] = int(extract_characters_regex(pred) == ans)
+                    extract_pred = extract_characters_regex(pred)
+                    data.loc[data['index'] == idx, 'judge_pred'] = extract_pred
+                    data.loc[data['index'] == idx, 'score'] = int(extract_pred == ans)
 
             rejected = [x for x in data['score'] if x == -1]
 
@@ -342,8 +359,9 @@ Respond with only the letter (A, B, C, or D) of the correct option.
                 f'Those questions will be counted as -1 score in ALL rating, and will not be counted in VALID rating.'
             )
 
-            dump(data, score_file)
+            dump(data, detail_file)
 
-        rating = get_dimension_rating(score_file)
-        dump(rating, tgt_file)
+        rating = load(score_file) if osp.exists(score_file) else get_dimension_rating(detail_file)
+        if not osp.exists(score_file):
+            dump(rating, score_file)
         return rating


### PR DESCRIPTION
  ## Summary
  This PR fixes missing llm-judge intermediate result.

  The main goal is to make llm-judge-based evaluation resumable and recoverable:
  - Save per-sample raw judge responses as `*_judge_{stage}_{model}.pkl`.
  - Save judge detail files as `*_judge_{stage}_{model}.{tsv,json,xlsx}`.
  - Save aggregate score files as `*_score_{model}.{json,csv}`.
  - Reuse existing judge cache and only retry missing or failed samples.
  - Allow detail/score files to be regenerated from complete judge pkl cache without calling the judge again.

  ## Benchmarks Covered
  - MMLongBench
  - DUDE
  - SlideVQA
  - VideoMME
  - VideoTT
  - WorldSense
  - LongVideoBench
  - VideoHolmes
  - EgoExoBench_MCQ
  - M4Bench
  - LLaVABench / LLaVABench_KO
  - VGRPBench
  - CoreCognition
  - MathCanvas
  - SimpleVQA

  ## Verification
  - `python -m compileall` passed for modified files.
  - `pre-commit` passed on modified files.
  - M4Bench pkl restore test verified detail/score regeneration.
  - M4Bench interrupted-cache resume test verified only missing samples are judged.