### PR TITLE
fix: drop n parameter for non-OpenAI API endpoints

### DIFF
--- a/vlmeval/api/gpt.py
+++ b/vlmeval/api/gpt.py
@@ -245,6 +245,9 @@ class OpenAIWrapper(BaseAPI):
             payload.pop('n')
             payload['reasoning_effort'] = 'high'
 
+        if 'openai.com' not in self.api_base and payload.get('n') == 1:
+            payload.pop('n', None)
+
         proxies = {}
         if os.getenv('http_proxy'):
             proxies['http'] = os.getenv('http_proxy')


### PR DESCRIPTION
## Summary

`OpenAIWrapper.generate_inner` hardcodes `n=1` in the request payload. Many OpenAI-compatible endpoints (e.g. gemini) reject this parameter with HTTP 422 since they don't support the `n` completions feature.

Since `n=1` is already the OpenAI API default, removing it for non-OpenAI base URLs is safe and has no effect on OpenAI calls.

## Change

A 2-line addition after the existing Gemini block (which already strips `n` for Gemini endpoints):

```python
if 'openai.com' not in self.api_base and payload.get('n') == 1:
    payload.pop('n', None)
```

This mirrors the Gemini precedent at lines 243–246 where unsupported parameters are stripped for non-standard endpoints.

## Test plan

- Verified against Cohere's OpenAI-compatible endpoint (`/compatibility/v1`) — requests now succeed instead of returning HTTP 422
- Verified that OpenAI endpoint behavior is unchanged (`n=1` is retained when `api_base` contains `openai.com`)
