### PR TITLE
[Benchmark] Add WikiVQABench dataset support

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -151,6 +151,7 @@ from .vlm2bench import VLM2Bench
 from .vlmbias import VLMBias
 from .vlrmbench import VLRMBench
 from .vsibench import VsiBench, VsiSuperCount, VsiSuperRecall
+from .wiki_vqa_bench import WikiVQABench
 from .wildvision import WildVision
 from .worldsense import WorldSense
 from .worldvqa import WorldVQA
@@ -287,7 +288,7 @@ IMAGE_DATASET = [
     AyaVisionBench, TopViewRS, VLMBias, MMHELIX, MedqbenchMCQDataset, MathCanvas, MMReason,
     MedqbenchPairedDescriptionDataset, MedqbenchCaptionDataset, ChartMuseum, ChartQAPro, ReasonMap_Plus,  # noqa: E501
     olmOCRBench, OceanOCRBench, MATBench, VLRMBench, RefCOCODataset, RefSpatialDataset,
-    ERQADataset, SimpleVQA, HiPhODataset, MaCBench,
+    ERQADataset, SimpleVQA, HiPhODataset, MaCBench, WikiVQABench,
     UniSVG, SArena, VLMsAreBiased, MMESCIDataset, CoreCognition, GroundingME,
     FoxBench, VTCBench, Asclepius, PlotQA, ChartX, ChartBench, ChartCapDataset, WorldVQA, PuzzleVQA, VisualPuzzles,  # noqa: E501
     MMSafetyBenchDataset, MSSBenchDataset, SIUODataset, SIUOGenDataset, SIUOMCQDataset, M3oralBenchDataset,  # noqa: E501

--- a/vlmeval/dataset/wiki_vqa_bench.py
+++ b/vlmeval/dataset/wiki_vqa_bench.py
@@ -1,14 +1,12 @@
-import os.path as osp
 import random
 import pandas as pd
 from .image_mcq import ImageMCQDataset
-from ..smp import LMUDataRoot
 
 
 class WikiVQABench(ImageMCQDataset):
     """WikiVQA benchmark - Image MCQ with question, correct answer, and 3 wrong answers
 
-    Data format (parquet):
+    Data loaded from HuggingFace: ibm-research/WikiVQABench
     - question: str
     - correct: str
     - wrongs: list of 3 strings
@@ -17,36 +15,29 @@ class WikiVQABench(ImageMCQDataset):
     Converts to standard image MCQ format with randomized option positions.
     """
 
-    RANDOM_SEED = None #42
+    RANDOM_SEED = None
 
-    def __init__(self, dataset='WikiVQABench', **kwargs):
-        # Set data_root before parent init calls load_data()
-        self.data_root = LMUDataRoot()
-        super().__init__(dataset=dataset, **kwargs)
+    DATASET_URL = {}
+    DATASET_MD5 = {}
 
     def load_data(self, dataset):
-        # Load parquet file from data root
-        data_path = osp.join(self.data_root, f'{dataset}.parquet')
-        data = pd.read_parquet(data_path)
+        from datasets import load_dataset
 
-        # Seed random for reproducibility
+        hf_dataset = load_dataset('ibm-research/WikiVQABench', split='train')
+
         random.seed(self.RANDOM_SEED)
 
         result_rows = []
-        for idx, row in data.iterrows():
-            # Get correct and wrong answers
+        for idx, row in enumerate(hf_dataset):
             correct_answer = row['correct']
             wrong_answers = row['wrongs']
 
-            # Combine all options and shuffle
             all_options = [correct_answer] + list(wrong_answers)
             random.shuffle(all_options)
 
-            # Find which position the correct answer is at (A=0, B=1, C=2, D=3)
             correct_pos = all_options.index(correct_answer)
             correct_letter = chr(ord('A') + correct_pos)
 
-            # Build row with randomized options
             converted = {
                 'index': idx,
                 'question': row['question'],
@@ -55,7 +46,7 @@ class WikiVQABench(ImageMCQDataset):
                 'C': all_options[2],
                 'D': all_options[3],
                 'answer': correct_letter,
-                'image': row['image']  # Base64 encoded image
+                'image': row['image'],
             }
             result_rows.append(converted)
 

--- a/vlmeval/dataset/wiki_vqa_bench.py
+++ b/vlmeval/dataset/wiki_vqa_bench.py
@@ -1,0 +1,66 @@
+import os.path as osp
+import random
+import pandas as pd
+from .image_mcq import ImageMCQDataset
+from ..smp import LMUDataRoot
+
+
+class WikiVQABench(ImageMCQDataset):
+    """WikiVQA benchmark - Image MCQ with question, correct answer, and 3 wrong answers
+
+    Data format (parquet):
+    - question: str
+    - correct: str
+    - wrongs: list of 3 strings
+    - image: str (base64 encoded image)
+
+    Converts to standard image MCQ format with randomized option positions.
+    """
+
+    RANDOM_SEED = None #42
+
+    def __init__(self, dataset='WikiVQABench', **kwargs):
+        # Set data_root before parent init calls load_data()
+        self.data_root = LMUDataRoot()
+        super().__init__(dataset=dataset, **kwargs)
+
+    def load_data(self, dataset):
+        # Load parquet file from data root
+        data_path = osp.join(self.data_root, f'{dataset}.parquet')
+        data = pd.read_parquet(data_path)
+
+        # Seed random for reproducibility
+        random.seed(self.RANDOM_SEED)
+
+        result_rows = []
+        for idx, row in data.iterrows():
+            # Get correct and wrong answers
+            correct_answer = row['correct']
+            wrong_answers = row['wrongs']
+
+            # Combine all options and shuffle
+            all_options = [correct_answer] + list(wrong_answers)
+            random.shuffle(all_options)
+
+            # Find which position the correct answer is at (A=0, B=1, C=2, D=3)
+            correct_pos = all_options.index(correct_answer)
+            correct_letter = chr(ord('A') + correct_pos)
+
+            # Build row with randomized options
+            converted = {
+                'index': idx,
+                'question': row['question'],
+                'A': all_options[0],
+                'B': all_options[1],
+                'C': all_options[2],
+                'D': all_options[3],
+                'answer': correct_letter,
+                'image': row['image']  # Base64 encoded image
+            }
+            result_rows.append(converted)
+
+        return pd.DataFrame(result_rows)
+
+    @classmethod
+    def supported_datasets(cls):
+        return ['WikiVQABench']


### PR DESCRIPTION
## Summary

Add [WikiVQABench](https://huggingface.co/datasets/ibm-research/WikiVQABench), a human-curated knowledge-grounded VQA benchmark constructed from Wikipedia images, article captions, and Wikidata structured knowledge.

- 344 multiple-choice questions (1 correct + 3 distractors) requiring external knowledge beyond visual evidence
- Extends `ImageMCQDataset` with randomized option positions
- **Task type:** Image MCQ (4 choices)
- **Domain:** Knowledge-grounded visual question answering
- **Construction:** LLM-generated candidates, human-curated for factual correctness and visual-text consistency
- **Paper:** https://arxiv.org/abs/2605.21479

## Leaderboard Results
| Model | Accuracy |
|-------|----------|
| InternVL3-78B | 75.6% |
| Claude-Opus-4-6 | 70.3% |
| Claude-Sonnet-4-6 | 66.3% |
| Llama-3.2-90B-Vision-Instruct | 65.7% |
| Qwen3-VL-32B-Instruct | 64.0% |
| Qwen3-VL-8B-Instruct | 63.1% |
| Qwen3-VL-4B-Instruct | 60.2% |
| Qwen3-VL-2B-Instruct | 56.4% |
| Granite-Vision-3.3-2B | 54.7% |
| SmolVLM2 | 54.1% |
| SmolVLM | 46.5% |
| SmolVLM2-500M | 36.6% |
| SmolVLM2-256M | 32.3% |
| SmolVLM-500M | 29.4% |
| SmolVLM-256M | 24.7% |

## Usage
```
python run.py --data WikiVQABench --model <model_name>
```

## Checklist
- [x] Dataset class registered in `vlmeval/dataset/__init__.py`
- [x] HuggingFace-based data loading (no manual download needed)
- [x] Standard MCQ evaluation (inherited from `ImageMCQDataset`)
- [x] Passes lint (flake8)