### PR TITLE
[Fix] Qwen3-VL: set do_sample explicitly to avoid sampling param conflicts (#1275)

### DIFF
--- a/vlmeval/vlm/qwen3_vl/model.py
+++ b/vlmeval/vlm/qwen3_vl/model.py
@@ -74,13 +74,19 @@ class Qwen3VLChat(Qwen3VLPromptMixin, BaseModel):
         self.temperature = temperature
         if self.total_pixels and self.total_pixels > 24576 * 32 * 32:
             print('The total number of video tokens might too large, resulting in an overly long input sequence.')
+        do_sample = kwargs.pop('do_sample', temperature is not None and temperature > 0)
+
         self.generate_kwargs = dict(
             max_new_tokens=self.max_new_tokens,
-            top_p=top_p,
-            top_k=top_k,
-            temperature=temperature,
             repetition_penalty=repetition_penalty,
+            do_sample=do_sample,
         )
+        if do_sample:
+            self.generate_kwargs.update(
+                top_p=top_p,
+                top_k=top_k,
+                temperature=temperature,
+            )
         self.system_prompt = system_prompt
         self.verbose = verbose
         self.post_process = post_process


### PR DESCRIPTION
## Summary

Closes #1275.

The `generate_kwargs` dict in `Qwen3VLChat.__init__` passes `top_p`, `top_k`, 
and `temperature` to `model.generate()` without setting `do_sample`. 
HuggingFace defaults `do_sample` to `False`, which causes these sampling 
parameters to be silently ignored and falls back to greedy decoding. This 
means evaluation results do not reflect the configured sampling behavior, 
and users see warnings like:

## Changes

- Derive `do_sample` from `temperature` (`do_sample = temperature > 0`).
- Only include `top_p`, `top_k`, and `temperature` in `generate_kwargs` when 
  `do_sample=True`, avoiding the symmetric warning in the greedy path.
- Allow callers to override via `kwargs.pop('do_sample', ...)`.

## Scope

- Only affects the `transformers` inference path (`generate_inner_transformers`).
- The vLLM path is unchanged — vLLM already treats `temperature=0` as greedy 
  internally, so no fix is needed there.

## Testing

Tested locally on `Qwen/Qwen3-VL-<variant>` with `MMMU_DEV_VAL`:

```bash
python run.py --data MMMU_DEV_VAL --model Qwen3-VL-<variant> --verbose
```

- No more `do_sample` / `temperature` conflict warnings.
- Generation respects configured sampling parameters when `temperature > 0`.
- Greedy decoding works cleanly when `temperature=0`.
- Users can pass `do_sample=False` via kwargs to force greedy regardless of temperature.