### PR TITLE
Fix lint failures

### DIFF
--- a/vlmeval/api/bluelm_api.py
+++ b/vlmeval/api/bluelm_api.py
@@ -71,7 +71,7 @@ def extract_boxed(pred_str: str, strip_double_curly_brace=False):
     if answer is None:
         return pred_str  # 返回原始字符串
     if strip_double_curly_brace:
-        match = re.match('^\{(.*)\}$', answer)  # noqa: W605
+        match = re.match(r'^\{(.*)\}$', answer)
         if match:
             answer = match.group(1)
     return answer

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -69,14 +69,10 @@ from .m3oralbench import M3oralBenchDataset
 from .m4bench import M4Bench
 from .macbench import MaCBench
 from .matbench import MATBench
+from .medq_deg_bench import MedQDEGBenchDataset
 from .medqbench_caption import MedqbenchCaptionDataset
 from .medqbench_mcq import MedqbenchMCQDataset
 from .medqbench_paired_description import MedqbenchPairedDescriptionDataset
-from .medq_deg_bench import MedQDEGBenchDataset
-from .olmOCRBench.olmocrbench import olmOCRBench
-from .oceanocr import OceanOCRBench
-from .matbench import MATBench
-
 # Add by EASI team
 from .megabench import MEGABench
 from .miabench import MIABench

--- a/vlmeval/dataset/hipho.py
+++ b/vlmeval/dataset/hipho.py
@@ -841,7 +841,7 @@ class HiPhODataset(ImageBaseDataset):
         earned_points = max(result['fine_grained_score'], result['coarse_grained_score'])
 
         return {
-            "id": str(row.get('id', f"{self.dataset_name}_{index+1}")),
+            "id": str(row.get('id', f"{self.dataset_name}_{index + 1}")),
             "context": str(row.get('context', '')).strip(),
             "question": str(row.get('question', '')).strip(),
             "solution": str(row.get('solution', '')).strip(),

--- a/vlmeval/dataset/medq_deg_bench.py
+++ b/vlmeval/dataset/medq_deg_bench.py
@@ -1,8 +1,11 @@
 import os
+import os.path as osp
+
 import pandas as pd
 from huggingface_hub import snapshot_download
+
+from vlmeval.smp import dump, get_cache_path, get_intermediate_file_path, load
 from .image_mcq import ImageMCQDataset
-from ..smp import *
 
 
 class MedQDEGBenchDataset(ImageMCQDataset):

--- a/vlmeval/dataset/mmalignbench.py
+++ b/vlmeval/dataset/mmalignbench.py
@@ -79,7 +79,7 @@ PROMPT_TEMPLATE_GT = """**INPUT**:
 """
 
 
-REGEX_PATTERN = re.compile("\[\[([AB<>=]+)\]\]")  # noqa: W605
+REGEX_PATTERN = re.compile(r"\[\[([AB<>=]+)\]\]")
 
 
 def get_score(judgement, pattern=REGEX_PATTERN):

--- a/vlmeval/dataset/olmOCRBench/evaluator.py
+++ b/vlmeval/dataset/olmOCRBench/evaluator.py
@@ -265,7 +265,7 @@ def evaluator(tsv_path, eval_file):
         #         f.write(entry["md_content"])
         # repeat==1
         for i, entry in enumerate(items):
-            md_file = os.path.join(cate_dir, f"{base}_pg{entry['test'].page}_repeat{i+1}.md")
+            md_file = os.path.join(cate_dir, f"{base}_pg{entry['test'].page}_repeat{i + 1}.md")
             with open(md_file, "w", encoding="utf-8") as f:
                 f.write(entry["md_content"])
             break

--- a/vlmeval/dataset/olmOCRBench/repeatdetect.py
+++ b/vlmeval/dataset/olmOCRBench/repeatdetect.py
@@ -168,7 +168,7 @@ class BenchmarkRepeatDetect(unittest.TestCase):
 
         end = time.perf_counter()
 
-        print(f"testLargeRandom took {end-start:0.0001f} seconds")
+        print(f"testLargeRandom took {end - start:0.0001f} seconds")
 
 
 if __name__ == "__main__":

--- a/vlmeval/dataset/olmOCRBench/tests.py
+++ b/vlmeval/dataset/olmOCRBench/tests.py
@@ -991,7 +991,7 @@ class BaselineTest(BasePDFTest):
 
         for index, count in enumerate(repeats):
             if count > self.max_repeats:
-                return False, f"Text ends with {count} repeating {index+1}-grams, invalid"
+                return False, f"Text ends with {count} repeating {index + 1}-grams, invalid"
 
         pattern = re.compile(
             r"["

--- a/vlmeval/dataset/utils/mmhelix/evaluators/calcudoku_eval.py
+++ b/vlmeval/dataset/utils/mmhelix/evaluators/calcudoku_eval.py
@@ -48,7 +48,7 @@ class CalcudokuEvaluator(BaseEvaluator):
             display_op = '×' if operator == '*' else operator
 
             cell_str = ', '.join([f"({r},{c})" for r, c in cells])
-            prompt += f"Region {i+1}: Cells {cell_str}, Operation: {display_op}, Target: {target}\n"
+            prompt += f"Region {i + 1}: Cells {cell_str}, Operation: {display_op}, Target: {target}\n"
 
         prompt += (
             "\nPlease solve the puzzle and provide the solution as a two-dimensional array.\n"

--- a/vlmeval/dataset/utils/mmhelix/evaluators/campsite_eval.py
+++ b/vlmeval/dataset/utils/mmhelix/evaluators/campsite_eval.py
@@ -547,7 +547,7 @@ class CampsiteEvaluator:
             # 检查边界
             for row, col in tent_positions_0based:
                 if row < 0 or row >= rows or col < 0 or col >= cols:
-                    feedback["rule_violations"].append(f"帐篷位置 ({row+1}, {col+1}) 超出网格边界")
+                    feedback["rule_violations"].append(f"帐篷位置 ({row + 1}, {col + 1}) 超出网格边界")
 
             # 检查树邻接
             directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
@@ -559,7 +559,7 @@ class CampsiteEvaluator:
                         adjacent_to_tree = True
                         break
                 if not adjacent_to_tree:
-                    feedback["rule_violations"].append(f"帐篷 ({row+1}, {col+1}) 没有与树相邻")
+                    feedback["rule_violations"].append(f"帐篷 ({row + 1}, {col + 1}) 没有与树相邻")
 
             # 检查帐篷相邻
             all_directions = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
@@ -567,7 +567,9 @@ class CampsiteEvaluator:
                 for dr, dc in all_directions:
                     nr, nc = row + dr, col + dc
                     if (nr, nc) in tent_positions_0based:
-                        feedback["rule_violations"].append(f"帐篷 ({row+1}, {col+1}) 与帐篷 ({nr+1}, {nc+1}) 相邻")
+                        feedback["rule_violations"].append(
+                            f"帐篷 ({row + 1}, {col + 1}) 与帐篷 ({nr + 1}, {nc + 1}) 相邻"
+                        )
 
             # 检查行约束
             actual_row_counts = [0] * rows
@@ -576,7 +578,7 @@ class CampsiteEvaluator:
 
             for i, (actual, expected) in enumerate(zip(actual_row_counts, row_constraints)):
                 if actual != expected:
-                    feedback["rule_violations"].append(f"第{i+1}行帐篷数量错误: 实际{actual}, 期望{expected}")
+                    feedback["rule_violations"].append(f"第{i + 1}行帐篷数量错误: 实际{actual}, 期望{expected}")
 
             # 检查列约束
             actual_col_counts = [0] * cols
@@ -585,7 +587,7 @@ class CampsiteEvaluator:
 
             for i, (actual, expected) in enumerate(zip(actual_col_counts, col_constraints)):
                 if actual != expected:
-                    feedback["rule_violations"].append(f"第{i+1}列帐篷数量错误: 实际{actual}, 期望{expected}")
+                    feedback["rule_violations"].append(f"第{i + 1}列帐篷数量错误: 实际{actual}, 期望{expected}")
 
             feedback["is_correct"] = len(feedback["rule_violations"]) == 0
 

--- a/vlmeval/dataset/utils/mmhelix/evaluators/nibbles_eval.py
+++ b/vlmeval/dataset/utils/mmhelix/evaluators/nibbles_eval.py
@@ -172,7 +172,7 @@ class NibblesEvaluator(BaseEvaluator):
             if move == opposites.get(direction):
                 return {
                     'success': False,
-                    'error': f"Invalid move at step {i+1}: Cannot reverse direction from {direction} to {move}",
+                    'error': f"Invalid move at step {i + 1}: Cannot reverse direction from {direction} to {move}",
                     'apples_eaten': apples_eaten,
                     'total_apples': total_apples
                 }
@@ -189,7 +189,7 @@ class NibblesEvaluator(BaseEvaluator):
             if not (0 <= new_head[0] < rows and 0 <= new_head[1] < cols):
                 return {
                     'success': False,
-                    'error': f"Hit boundary at step {i+1}: position {new_head} out of bounds ({rows}x{cols})",
+                    'error': f"Hit boundary at step {i + 1}: position {new_head} out of bounds ({rows}x{cols})",
                     'apples_eaten': apples_eaten,
                     'total_apples': total_apples
                 }
@@ -198,7 +198,7 @@ class NibblesEvaluator(BaseEvaluator):
             if new_head in snake:
                 return {
                     'success': False,
-                    'error': f"Self-collision at step {i+1}: position {new_head} already occupied by snake",
+                    'error': f"Self-collision at step {i + 1}: position {new_head} already occupied by snake",
                     'apples_eaten': apples_eaten,
                     'total_apples': total_apples
                 }

--- a/vlmeval/dataset/utils/vdc.py
+++ b/vlmeval/dataset/utils/vdc.py
@@ -25,8 +25,8 @@ Predicted Answer: {pred_response}
 Provide your evaluation only as a yes/no and score where the score is an integer value between 0 and 5, with 5 indicating the highest meaningful match.
 Please generate the response in the form of a Python dictionary string with keys 'pred' and 'score', where value of 'pred' is  a string of 'yes' or 'no' and value of 'score' is in INTEGER, not STRING.
 DO NOT PROVIDE ANY OTHER OUTPUT TEXT OR EXPLANATION. Only provide the Python dictionary string.
-For example, your response should look like this: \{'pred': 'yes', 'score': 4.8\}.
-"""  # noqa: W605, E501
+For example, your response should look like this: {{'pred': 'yes', 'score': 4.8}}.
+"""  # noqa: E501
 
 SYSTEM_GENER_PRED_PROMPT = """You are an intelligent chatbot designed for providing accurate answers to questions related to the content based on a detailed description of a video or image.
 Here's how you can accomplish the task:

--- a/vlmeval/dataset/wiki_vqa_bench.py
+++ b/vlmeval/dataset/wiki_vqa_bench.py
@@ -1,5 +1,7 @@
 import random
+
 import pandas as pd
+
 from .image_mcq import ImageMCQDataset
 
 

--- a/vlmeval/dataset/wildvision.py
+++ b/vlmeval/dataset/wildvision.py
@@ -54,7 +54,7 @@ PROMPT_TEMPLATE = """\
 """
 
 
-REGEX_PATTERN = re.compile("\[\[([AB<>=]+)\]\]")  # noqa: W605
+REGEX_PATTERN = re.compile(r"\[\[([AB<>=]+)\]\]")
 
 
 def get_score(judgement, pattern=REGEX_PATTERN):

--- a/vlmeval/vlm/granite_docling.py
+++ b/vlmeval/vlm/granite_docling.py
@@ -412,7 +412,7 @@ class DOCLING(BaseModel):
         if pam is not None:
             # Expect bool/long with 0/1 values
             assert pam.dtype in (torch.bool, torch.long), f"pixel_attention_mask must be bool or long {messages}"
-            assert pam.min().item() >= 0 and pam.max().item() <= 1, f"mask values must be in {0,1} {messages}"
+            assert pam.min().item() >= 0 and pam.max().item() <= 1, f"mask values must be in {(0, 1)} {messages}"
 
             # Allow (B,H,W) or (B,N,H,W) to match pixel_values
             if pv is not None and pv.ndim == 5:

--- a/vlmeval/vlm/nanovlm.py
+++ b/vlmeval/vlm/nanovlm.py
@@ -32,7 +32,7 @@ class NanoVLM(BaseModel):
             from models.vision_language_model import VisionLanguageModel
         except ImportError:
             raise ImportError(_NANOVLM_INSTALL_MSG)
-        from data.processors import get_tokenizer, get_image_processor
+        from data.processors import get_image_processor, get_tokenizer
 
         self.vlm = VisionLanguageModel.from_pretrained(model_path).to('cuda').eval()
         self.cfg = self.vlm.cfg


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace star import usage in the MedQ DEG dataset with explicit imports
- apply isort output and whitespace-only flake8 fixes
- convert invalid escape examples and regexes to lint-clean forms

## Verification
- `/home/ubuntu/.local/bin/pre-commit run --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9195faae-e25f-4a05-8e73-0c8901d8725c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9195faae-e25f-4a05-8e73-0c8901d8725c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

