### PR TITLE
[Fix] Prevent API pipeline hang after eval process failures

### DIFF
--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -1,0 +1,237 @@
+import asyncio
+import importlib.util
+import logging
+import multiprocessing as mp
+import os
+import pickle
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def _dump(obj, path):
+    with open(path, 'wb') as f:
+        pickle.dump(obj, f)
+
+
+def _load(path):
+    with open(path, 'rb') as f:
+        return pickle.load(f)
+
+
+def _load_inference_api():
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = ['vlmeval']
+
+    smp = types.ModuleType('vlmeval.smp')
+    smp.dump = _dump
+    smp.get_logger = lambda name: logging.getLogger(name)
+    smp.load = _load
+    smp.upsert_dataset_status = lambda *args, **kwargs: None
+
+    smp_log = types.ModuleType('vlmeval.smp.log')
+    smp_log.setup_subprocess_logger = lambda *args, **kwargs: None
+
+    utils = types.ModuleType('vlmeval.utils')
+    utils.__path__ = ['vlmeval/utils']
+
+    modules = {
+        'vlmeval': vlmeval,
+        'vlmeval.smp': smp,
+        'vlmeval.smp.log': smp_log,
+        'vlmeval.utils': utils,
+    }
+    with mock.patch.dict(sys.modules, modules):
+        mp_spec = importlib.util.spec_from_file_location(
+            'vlmeval.utils.mp_util',
+            'vlmeval/utils/mp_util.py',
+        )
+        mp_util = importlib.util.module_from_spec(mp_spec)
+        sys.modules['vlmeval.utils.mp_util'] = mp_util
+        mp_spec.loader.exec_module(mp_util)
+
+        spec = importlib.util.spec_from_file_location(
+            'vlmeval.inference_api',
+            'vlmeval/inference_api.py',
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules['vlmeval.inference_api'] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop('vlmeval.inference_api', None)
+        sys.modules.pop('vlmeval.utils.mp_util', None)
+        return module
+
+
+def _exit_abruptly():
+    os._exit(1)
+
+
+class FakePromptDataset:
+
+    def build_prompt(self, index, video_llm=False):
+        return {'index': index, 'video_llm': video_llm}
+
+
+class FakeEvalDataset:
+    dataset_name = 'FakeEval'
+    data = [0]
+
+    def evaluate(self, result_file, **judge_kwargs):
+        return {'result_file': result_file, 'judge_kwargs': judge_kwargs}
+
+
+class FakeCrashEvalDataset:
+    dataset_name = 'CrashEval'
+    data = [0]
+
+    def evaluate(self, result_file, **judge_kwargs):
+        os._exit(1)
+
+
+class TestInferenceApiProcessHelpers(unittest.TestCase):
+
+    def test_async_wait_process_observes_abrupt_exit(self):
+        inference_api = _load_inference_api()
+        process = mp.Process(target=_exit_abruptly)
+        process.start()
+
+        try:
+            exitcode = asyncio.run(
+                inference_api.async_wait_process(process, poll_interval=0.01)
+            )
+            self.assertEqual(exitcode, 1)
+        finally:
+            inference_api.terminate_processes([process])
+
+    def test_async_recv_process_message_raises_when_process_exits(self):
+        inference_api = _load_inference_api()
+        parent_conn, child_conn = mp.Pipe(duplex=True)
+        process = mp.Process(target=_exit_abruptly)
+        process.start()
+        child_conn.close()
+
+        try:
+            with self.assertRaisesRegex(RuntimeError, 'exited unexpectedly'):
+                asyncio.run(
+                    inference_api.async_recv_process_message(
+                        parent_conn,
+                        process,
+                        'test process',
+                        poll_interval=0.01,
+                    )
+                )
+        finally:
+            parent_conn.close()
+            inference_api.terminate_processes([process])
+
+    def test_prompt_process_builds_prompt_and_exits(self):
+        inference_api = _load_inference_api()
+        parent_conn, child_conn = mp.Pipe(duplex=True)
+        process = mp.Process(
+            target=inference_api._prompt_subprocess_target,
+            args=(FakePromptDataset(), True, child_conn, parent_conn),
+        )
+        process.start()
+        child_conn.close()
+
+        try:
+            parent_conn.send(7)
+            reply = asyncio.run(
+                inference_api.async_recv_process_message(
+                    parent_conn,
+                    process,
+                    'prompt process',
+                    poll_interval=0.01,
+                )
+            )
+            self.assertEqual(reply, {
+                'success': True,
+                'result': {'index': 7, 'video_llm': True},
+                'error': None,
+            })
+
+            parent_conn.send(None)
+            process.join(timeout=5)
+            self.assertEqual(process.exitcode, 0)
+        finally:
+            parent_conn.close()
+            inference_api.terminate_processes([process])
+
+    def test_eval_process_sends_result(self):
+        inference_api = _load_inference_api()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            log_file = tmpdir / 'eval.log'
+            parent_conn, child_conn = mp.Pipe(duplex=False)
+            process = mp.Process(
+                target=inference_api._eval_process_entry,
+                args=(
+                    FakeEvalDataset(),
+                    'pred.pkl',
+                    {'judge': 'mock'},
+                    str(log_file),
+                    child_conn,
+                    parent_conn,
+                ),
+            )
+            process.start()
+            child_conn.close()
+
+            try:
+                eval_result = asyncio.run(
+                    inference_api.async_recv_process_message(
+                        parent_conn,
+                        process,
+                        'eval process',
+                        poll_interval=0.01,
+                    )
+                )
+                asyncio.run(
+                    inference_api.async_wait_process(process, poll_interval=0.01)
+                )
+                self.assertEqual(process.exitcode, 0)
+                self.assertEqual(eval_result, {
+                    'success': True,
+                    'result': {
+                        'result_file': 'pred.pkl',
+                        'judge_kwargs': {'judge': 'mock'},
+                    },
+                    'error': None,
+                })
+            finally:
+                parent_conn.close()
+                inference_api.terminate_processes([process])
+
+    def test_run_eval_in_subprocess_handles_abrupt_exit(self):
+        inference_api = _load_inference_api()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = inference_api.DatasetConfig(
+                dataset_name='CrashEval',
+                dataset_obj=FakeCrashEvalDataset(),
+                model_name='mock',
+                model_obj=None,
+                work_dir=tmpdir,
+                result_file='pred.pkl',
+                judge_kwargs={},
+            )
+            pipeline = inference_api.APIEvalPipeline([cfg], concurrency=1)
+
+            try:
+                log_file = str(Path(tmpdir) / 'eval.log')
+                logging.disable(logging.CRITICAL)
+                asyncio.run(pipeline._run_eval_in_subprocess('CrashEval', log_file))
+
+                self.assertEqual(cfg.eval_status, inference_api.EvalStatus.Error)
+                self.assertEqual(pipeline.eval_processes, {})
+            finally:
+                logging.disable(logging.NOTSET)
+                pipeline._shutdown_executors()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlmeval/inference_api.py
+++ b/vlmeval/inference_api.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 import math
+import multiprocessing as mp
 import threading
 import time
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass, field
 from enum import Enum
@@ -16,6 +17,8 @@ from tabulate import tabulate
 
 from vlmeval.smp import dump, get_logger, load, upsert_dataset_status
 from vlmeval.smp.log import setup_subprocess_logger
+from vlmeval.utils.mp_util import (async_recv_process_message, async_wait_process,
+                                   terminate_processes)
 
 logger = get_logger(__name__)
 
@@ -46,6 +49,51 @@ def _eval_subprocess_target(
         print(f"\n❌ EVALUATION ERROR: {error_msg}")
 
         return {'success': False, 'result': None, 'error': error_msg}
+
+
+def _eval_process_entry(
+    dataset_obj,
+    result_file: str,
+    judge_kwargs: dict,
+    log_file: str,
+    conn,
+    parent_conn=None,
+):
+    """Run evaluation in a standalone process and send the result to parent."""
+    if parent_conn is not None:
+        parent_conn.close()
+
+    try:
+        eval_result = _eval_subprocess_target(dataset_obj, result_file, judge_kwargs, log_file)
+        conn.send(eval_result)
+    finally:
+        conn.close()
+
+
+def _prompt_subprocess_target(dataset_obj, video_llm: bool, conn, parent_conn=None):
+    """Build video prompts sequentially in a subprocess main thread."""
+    if parent_conn is not None:
+        parent_conn.close()
+
+    try:
+        while True:
+            try:
+                index = conn.recv()
+            except EOFError:
+                break
+
+            if index is None:
+                break
+
+            try:
+                prompt_struct = dataset_obj.build_prompt(index, video_llm=video_llm)
+                conn.send({'success': True, 'result': prompt_struct, 'error': None})
+            except Exception as e:
+                import traceback
+                error_msg = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+                conn.send({'success': False, 'result': None, 'error': error_msg})
+    finally:
+        conn.close()
 
 
 def chat_mt(model, messages: List[dict], dataset_name: str) -> List[str]:
@@ -169,8 +217,9 @@ class APIEvalPipeline:
         self.all_infer_done = False
 
         self.infer_executor = ThreadPoolExecutor(max_workers=concurrency)
-        self.eval_executor = ProcessPoolExecutor(max_workers=4)
-        self.producer_executor = ProcessPoolExecutor(max_workers=1)
+        self.eval_semaphore = asyncio.Semaphore(4)
+        self.eval_processes: Dict[str, mp.Process] = {}
+        self.producer_processes: Dict[str, mp.Process] = {}
         # The inference tasks queue (Prefetch 20% data).
         self.queue = asyncio.Queue(maxsize=int(concurrency * 1.2))
         self.states: Dict[str, DatasetConfig] = {
@@ -241,37 +290,24 @@ class APIEvalPipeline:
             self.infer_executor.shutdown(wait=False, cancel_futures=True)
             logger.debug("Shutdown infer_executor")
 
-            for name, executor in [
-                ("eval_executor", self.eval_executor),
-                ("producer_executor", self.producer_executor),
-            ]:
-                # 必须在 shutdown() 前获取进程引用。shutdown() 会唤醒管理线程
-                # 执行清理，可能将 _processes 置为 None，之后就无法访问了。
-                processes = getattr(executor, '_processes', None) or {}
-                alive = [p for p in processes.values() if p.is_alive()]
-                executor.shutdown(wait=False, cancel_futures=True)
-                self._terminate_workers(name, alive)
+            terminate_processes(
+                list(self.eval_processes.values()),
+                name="eval_process",
+                logger=logger,
+            )
+            self.eval_processes.clear()
+
+            terminate_processes(
+                list(self.producer_processes.values()),
+                name="producer_process",
+                logger=logger,
+            )
+            self.producer_processes.clear()
 
             logger.info("All executors shutdown")
 
         except Exception as e:
             logger.warning(f"Failed to shutdown executors: {e}")
-
-    @staticmethod
-    def _terminate_workers(name, alive, timeout=5):
-        """Terminate worker processes.
-
-        Sends SIGTERM first, waits up to *timeout* seconds, then SIGKILL
-        for any process that is still alive.
-        """
-        for p in alive:
-            logger.debug(f"Terminating {name} worker (pid={p.pid})")
-            p.terminate()
-        for p in alive:
-            p.join(timeout=timeout)
-            if p.is_alive():
-                logger.debug(f"Force killing {name} worker (pid={p.pid})")
-                p.kill()
 
     def _get_checkpoint_file(self, dataset_name: str) -> Path:
         cfg = self.states[dataset_name]
@@ -526,11 +562,11 @@ class APIEvalPipeline:
 
     async def _produce_video_tasks(self, cfg: DatasetConfig, existing_results: dict) -> int:
         """Produce video dataset inference task."""
-        loop = asyncio.get_running_loop()
-        model = cfg.model_obj
         dataset = cfg.dataset_obj
         dataset_name = cfg.dataset_name
+        process_name = f"{dataset_name} prompt process"
 
+        model = cfg.model_obj
         if cfg.video_llm is not None:
             video_llm = cfg.video_llm
         else:
@@ -538,39 +574,69 @@ class APIEvalPipeline:
 
         logger.info(f"   [{dataset_name}] Video mode: video_llm={video_llm}")
 
+        parent_conn, child_conn = mp.Pipe(duplex=True)
+        process = mp.Process(
+            target=_prompt_subprocess_target,
+            args=(dataset, video_llm, child_conn, parent_conn),
+        )
+        try:
+            process.start()
+        except Exception:
+            parent_conn.close()
+            child_conn.close()
+            raise
+        child_conn.close()
+        self.producer_processes[dataset_name] = process
+
         tasks_generated = 0
-        for i in range(len(dataset)):
-            item = dataset[i]
-            idx_str = str(item['index'])
+        try:
+            for i in range(len(dataset)):
+                item = dataset[i]
+                idx_str = str(item['index'])
 
-            if idx_str in existing_results:
-                continue
-
-            try:
-                # Use process executor to produce video sample since it's heavy.
-                prompt_struct = await loop.run_in_executor(
-                    self.producer_executor,
-                    partial(dataset.build_prompt, i, video_llm=video_llm),
-                )
-                if prompt_struct is None:
+                if idx_str in existing_results:
                     continue
-            except Exception as e:
-                import traceback
-                logger.error(f"   [{dataset_name}] Failed to build prompt "
-                             f"for sample {idx_str}: {repr(e)}")
-                logger.debug(traceback.format_exception(e))
-                # Skip dataset if has fatal sample.
-                return 0
 
-            task = InferenceTask(
-                dataset_name=dataset_name,
-                model_name=cfg.model_name,
-                sample_index=idx_str,
-                prompt_struct=prompt_struct,
-                dataset_type="video"
-            )
-            await self.queue.put(task)
-            tasks_generated += 1
+                try:
+                    parent_conn.send(i)
+                    reply = await async_recv_process_message(
+                        parent_conn,
+                        process,
+                        process_name,
+                    )
+                    if not reply['success']:
+                        raise RuntimeError(reply['error'])
+                    prompt_struct = reply['result']
+                    if prompt_struct is None:
+                        continue
+                except Exception as e:
+                    import traceback
+                    logger.error(f"   [{dataset_name}] Failed to build prompt "
+                                 f"for sample {idx_str}: {repr(e)}")
+                    logger.debug(traceback.format_exception(e))
+                    # Skip dataset if has fatal sample.
+                    return 0
+
+                task = InferenceTask(
+                    dataset_name=dataset_name,
+                    model_name=cfg.model_name,
+                    sample_index=idx_str,
+                    prompt_struct=prompt_struct,
+                    dataset_type="video"
+                )
+                await self.queue.put(task)
+                tasks_generated += 1
+        finally:
+            self.producer_processes.pop(dataset_name, None)
+            if process.is_alive():
+                try:
+                    parent_conn.send(None)
+                except Exception:
+                    pass
+                await async_wait_process(process, timeout=5)
+            if process.is_alive():
+                terminate_processes([process], name=process_name, logger=logger)
+            parent_conn.close()
 
         return tasks_generated
 
@@ -749,19 +815,44 @@ class APIEvalPipeline:
 
     async def _run_eval_in_subprocess(self, dataset_name: str, eval_log_path: str):
         cfg = self.states[dataset_name]
-
-        loop = asyncio.get_running_loop()
+        process = None
+        parent_conn = None
+        child_conn = None
 
         try:
-            eval_result = await loop.run_in_executor(
-                self.eval_executor,
-                _eval_subprocess_target,
-                cfg.dataset_obj,
-                cfg.result_file,
-                cfg.judge_kwargs,
-                eval_log_path,
-            )
-            self._handle_eval_result(dataset_name, eval_result, eval_log_path)
+            async with self.eval_semaphore:
+                parent_conn, child_conn = mp.Pipe(duplex=False)
+                process = mp.Process(
+                    target=_eval_process_entry,
+                    args=(
+                        cfg.dataset_obj,
+                        cfg.result_file,
+                        cfg.judge_kwargs,
+                        eval_log_path,
+                        child_conn,
+                        parent_conn,
+                    ),
+                )
+                try:
+                    process.start()
+                except Exception:
+                    parent_conn.close()
+                    child_conn.close()
+                    raise
+                child_conn.close()
+                self.eval_processes[dataset_name] = process
+
+                eval_result = await async_recv_process_message(
+                    parent_conn,
+                    process,
+                    f"{dataset_name} eval process",
+                )
+                await async_wait_process(process)
+                if process.exitcode != 0:
+                    raise RuntimeError(
+                        f"evaluation process exited with code {process.exitcode}"
+                    )
+                self._handle_eval_result(dataset_name, eval_result, eval_log_path)
 
         except Exception as e:
             cfg.eval_status = EvalStatus.Error
@@ -775,6 +866,16 @@ class APIEvalPipeline:
                 status='done',
                 error_message=str(e),
             )
+        finally:
+            self.eval_processes.pop(dataset_name, None)
+            if process is not None and process.is_alive():
+                terminate_processes(
+                    [process],
+                    name=f"{dataset_name} eval process",
+                    logger=logger,
+                )
+            if parent_conn is not None:
+                parent_conn.close()
 
     def _handle_eval_result(self,
                             dataset_name: str,

--- a/vlmeval/utils/mp_util.py
+++ b/vlmeval/utils/mp_util.py
@@ -1,4 +1,7 @@
+import asyncio
+import multiprocessing as mp
 import os.path as osp
+import time
 from pathlib import Path
 from typing import Callable, Iterable
 
@@ -17,6 +20,56 @@ def cpu_count():
 
     import os
     return os.cpu_count()
+
+
+async def async_wait_process(process: mp.Process, timeout=None, poll_interval=0.1):
+    """Wait for a child process without blocking the asyncio event loop."""
+    start = time.monotonic()
+    while process.is_alive():
+        if timeout is not None and time.monotonic() - start >= timeout:
+            return process.exitcode
+        await asyncio.sleep(poll_interval)
+
+    process.join(timeout=0)
+    return process.exitcode
+
+
+async def async_recv_process_message(conn, process: mp.Process, process_name: str,
+                                     poll_interval=0.1):
+    """Receive one pipe message without blocking the asyncio event loop."""
+    while True:
+        if conn.poll():
+            try:
+                return conn.recv()
+            except EOFError:
+                process.join(timeout=0)
+                break
+
+        if not process.is_alive():
+            process.join(timeout=0)
+            if conn.poll():
+                continue
+            break
+
+        await asyncio.sleep(poll_interval)
+
+    raise RuntimeError(f"{process_name} exited unexpectedly with code {process.exitcode}")
+
+
+def terminate_processes(processes, name='process', timeout=5, logger=None):
+    """Terminate child processes with SIGTERM first, then SIGKILL."""
+    alive = [p for p in processes if p is not None and p.is_alive()]
+    for p in alive:
+        if logger is not None:
+            logger.debug(f"Terminating {name} (pid={p.pid})")
+        p.terminate()
+    for p in alive:
+        p.join(timeout=timeout)
+        if p.is_alive():
+            if logger is not None:
+                logger.debug(f"Force killing {name} (pid={p.pid})")
+            p.kill()
+            p.join(timeout=timeout)
 
 
 def new_func(idx: int, func, inputs):


### PR DESCRIPTION
Replace ProcessPoolExecutor-based API eval and video prompt workers with explicit multiprocessing.Process management. Use Pipe-based result passing and async process polling so abrupt child exits are observed without relying on executor internals or blocking joins.