### PR TITLE
[Cleanup] Remove unused Polygon3 dependency (#1528)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ openpyxl
 pandas
 pdf2image>=1.17.0
 pillow
-polygon3>=3.0.9.1
 portalocker
 protobuf
 pylatexenc==2.10

--- a/vlmeval/dataset/utils/Ocrbench_v2/requirements.txt
+++ b/vlmeval/dataset/utils/Ocrbench_v2/requirements.txt
@@ -7,6 +7,5 @@ Levenshtein
 lxml
 nltk
 numpy
-Polygon3
 tqdm
 zss

--- a/vlmeval/vlm/qwen3_vl/model.py
+++ b/vlmeval/vlm/qwen3_vl/model.py
@@ -74,13 +74,19 @@ class Qwen3VLChat(Qwen3VLPromptMixin, BaseModel):
         self.temperature = temperature
         if self.total_pixels and self.total_pixels > 24576 * 32 * 32:
             print('The total number of video tokens might too large, resulting in an overly long input sequence.')
+        do_sample = kwargs.pop('do_sample', temperature is not None and temperature > 0)
+
         self.generate_kwargs = dict(
             max_new_tokens=self.max_new_tokens,
-            top_p=top_p,
-            top_k=top_k,
-            temperature=temperature,
             repetition_penalty=repetition_penalty,
+            do_sample=do_sample,
         )
+        if do_sample:
+            self.generate_kwargs.update(
+                top_p=top_p,
+                top_k=top_k,
+                temperature=temperature,
+            )
         self.system_prompt = system_prompt
         self.verbose = verbose
         self.post_process = post_process


### PR DESCRIPTION
## Summary

Closes #1528.

`Polygon3` was listed in two requirements files but is not imported or used 
anywhere in the codebase. As noted in #1528, the package bundles the GPC 
component which carries proprietary licensing terms (`Other/Proprietary 
License` on PyPI), which can create friction for commercial users.

## Changes

- Removed `Polygon3` from `requirements.txt`
- Removed `Polygon3` from `vlmeval/dataset/utils/Ocrbench_v2/requirements.txt`

## Verification

Searched the full codebase for any usage of Polygon3 / GPC: