### PR TITLE
fix: guard choices[0] and message=None before content access

### DIFF
--- a/vlmeval/api/doubao_vl_api.py
+++ b/vlmeval/api/doubao_vl_api.py
@@ -182,6 +182,8 @@ class DoubaoVLWrapper(BaseAPI):
         payload = dict(model=self.endpoint, messages=input_msgs, max_tokens=max_tokens, temperature=temperature)
         try:
             response = self.client.chat.completions.create(**payload)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             answer = response.choices[0].message.content.strip()
             ret_code = 0
         except Exception as err:

--- a/vlmeval/api/glm_vision.py
+++ b/vlmeval/api/glm_vision.py
@@ -59,6 +59,8 @@ class GLMVisionWrapper(BaseAPI):
                 do_sample=False,
                 max_tokens=2048
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             answer = response.choices[0].message.content.strip()
             if self.verbose:
                 logger.info(f'inputs: {inputs}\nanswer: {answer}')

--- a/vlmeval/dataset/simplevqa.py
+++ b/vlmeval/dataset/simplevqa.py
@@ -162,6 +162,8 @@ class SimpleVQA(ImageBaseDataset):
                     messages=[{"role": "user", "content": prompt}],
                     temperature=1
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 res = response.choices[0].message.content
                 res = res.replace("```json", "").replace("```python", "").replace("```", "").strip()
                 if res[-1] != "}":


### PR DESCRIPTION
## Summary

OpenAI-compatible APIs can return **empty `choices`** on error or rate-limiting, causing `IndexError` at `choices[0]`. Gemini additionally returns `choices[0].message = None` on `PROHIBITED_CONTENT` safety filtering (HTTP 200 — no exception raised), causing `AttributeError` at `.content`.

This PR adds the comprehensive guard:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
before every bare `choices[0].message.content` access.

## Files changed (3 files, 3 sites)

- `vlmeval/dataset/simplevqa.py` — comparison answer extraction
- `vlmeval/api/glm_vision.py` — GLM vision API adapter
- `vlmeval/api/doubao_vl_api.py` — Doubao VL API adapter

## Verification

The Gemini `choices[0].message = None` crash is a documented production behavior on `PROHIBITED_CONTENT` safety filtering. Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule) found all 3 sites; post-fix scan returns 0 violations.