### PR TITLE
Handle recoverable truncated image payloads

### DIFF
--- a/tests/test_smp_vlm.py
+++ b/tests/test_smp_vlm.py
@@ -1,0 +1,33 @@
+import base64
+import importlib.util
+import io
+from pathlib import Path
+
+from PIL import Image, ImageFile
+
+
+def _load_vlm_module():
+    module_path = Path(__file__).resolve().parents[1] / "vlmeval" / "smp" / "vlm.py"
+    spec = importlib.util.spec_from_file_location("vlmeval_smp_vlm_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _truncated_png_base64():
+    image = Image.new("RGB", (20, 20), "white")
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()[:-20]).decode("utf-8")
+
+
+def test_decode_base64_to_image_file_allows_recoverable_truncated_png(tmp_path):
+    ImageFile.LOAD_TRUNCATED_IMAGES = False
+    vlm = _load_vlm_module()
+    output_path = tmp_path / "recovered.png"
+
+    vlm.decode_base64_to_image_file(_truncated_png_base64(), output_path)
+
+    with Image.open(output_path) as recovered:
+        recovered.load()
+        assert recovered.size == (20, 20)

--- a/tests/test_smp_vlm.py
+++ b/tests/test_smp_vlm.py
@@ -1,0 +1,34 @@
+import base64
+import importlib.util
+import io
+from pathlib import Path
+
+from PIL import Image, ImageFile
+
+
+def _load_vlm_module():
+    module_path = Path(__file__).resolve().parents[1] / "vlmeval" / "smp" / "vlm.py"
+    spec = importlib.util.spec_from_file_location("vlmeval_smp_vlm_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _truncated_png_base64():
+    image = Image.new("RGB", (20, 20), "white")
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()[:-20]).decode("utf-8")
+
+
+def test_decode_base64_to_image_file_allows_recoverable_truncated_png(tmp_path):
+    ImageFile.LOAD_TRUNCATED_IMAGES = False
+    vlm = _load_vlm_module()
+    output_path = tmp_path / "recovered.png"
+
+    vlm.decode_base64_to_image_file(_truncated_png_base64(), output_path)
+
+    assert ImageFile.LOAD_TRUNCATED_IMAGES is False
+    with Image.open(output_path) as recovered:
+        recovered.load()
+        assert recovered.size == (20, 20)

--- a/vlmeval/smp/vlm.py
+++ b/vlmeval/smp/vlm.py
@@ -4,9 +4,11 @@ import os
 import os.path as osp
 
 import pandas as pd
-from PIL import Image
+from PIL import Image, ImageFile
 
 Image.MAX_IMAGE_PIXELS = 1e9
+# Some benchmark TSVs include recoverable truncated image payloads.
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 def rescale_img(img, tgt=None):

--- a/vlmeval/smp/vlm.py
+++ b/vlmeval/smp/vlm.py
@@ -4,7 +4,7 @@ import os
 import os.path as osp
 
 import pandas as pd
-from PIL import Image
+from PIL import Image, ImageFile
 
 Image.MAX_IMAGE_PIXELS = 1e9
 
@@ -153,9 +153,33 @@ def encode_image_file_to_base64(image_path, target_size=-1, fmt='JPEG', max_file
         image, target_size=target_size, fmt=fmt, max_file_size=max_file_size)
 
 
+def _open_loaded_image(image_data):
+    image = Image.open(io.BytesIO(image_data))
+    try:
+        image.load()
+    except Exception:
+        image.close()
+        raise
+    return image
+
+
 def decode_base64_to_image(base64_string, target_size=-1):
     image_data = base64.b64decode(base64_string)
-    image = Image.open(io.BytesIO(image_data))
+    try:
+        image = _open_loaded_image(image_data)
+    except OSError as err:
+        if 'truncated' not in str(err).lower():
+            raise
+
+        # Pillow exposes truncated-image recovery as a process-wide flag. Enable
+        # it only for the retry and restore the previous state immediately.
+        previous_setting = ImageFile.LOAD_TRUNCATED_IMAGES
+        try:
+            ImageFile.LOAD_TRUNCATED_IMAGES = True
+            image = _open_loaded_image(image_data)
+        finally:
+            ImageFile.LOAD_TRUNCATED_IMAGES = previous_setting
+
     if image.mode in ('RGBA', 'P', 'LA'):
         image = image.convert('RGB')
     if target_size > 0:


### PR DESCRIPTION
## Summary

- retry recoverable truncated PNG/JPEG payloads in the central base64 image decoder
- keep strict Pillow decoding as the default path
- limit Pillow's process-wide truncated-image flag to the recovery attempt and restore its previous value immediately
- add a regression test covering base64 TSV image decoding and flag restoration

## Why

Some benchmark TSVs contain recoverable truncated image payloads. A single recoverable image should not cause an entire evaluation combination to fail, but permissive decoding should also not remain enabled globally.

Fixes #1400.

## Validation

- rebased onto current upstream `main`
- `python3 -m py_compile vlmeval/smp/vlm.py tests/test_smp_vlm.py`: passed
- direct execution of the regression function: passed
- verified that the recovered image is loadable and retains its expected dimensions
- verified that `ImageFile.LOAD_TRUNCATED_IMAGES` is restored after recovery
- `git diff --check origin/main...HEAD`: passed

Full pytest collection is not available in the local minimal environment because `pytest` and the repository's optional benchmark dependency stack are not installed.
