### PR TITLE
[Feature] Add MiniMax-M3 model and set as default

### DIFF
--- a/vlmeval/api/minimax_api.py
+++ b/vlmeval/api/minimax_api.py
@@ -3,7 +3,7 @@ MiniMax API support for text-based LLM evaluation.
 OpenAI-compatible chat completions endpoint.
 Set MINIMAX_API_KEY or pass key=...
 
-Models: MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed
+Models: MiniMax-M3, MiniMax-M2.7
 API docs: https://platform.minimaxi.com/document/guides/chat-model/text-generation
 """
 import json
@@ -25,7 +25,7 @@ class MiniMaxAPI(BaseAPI):
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         key: str = None,
         api_base: str = None,
         retry: int = 10,

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -468,23 +468,16 @@ api_models = {
         retry=10,
     ),
     # MiniMax (set MINIMAX_API_KEY)
+    "MiniMax-M3": partial(
+        api.MiniMaxAPI,
+        model="MiniMax-M3",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
     "MiniMax-M2.7": partial(
         api.MiniMaxAPI,
         model="MiniMax-M2.7",
-        temperature=0,
-        max_tokens=2048,
-        retry=10,
-    ),
-    "MiniMax-M2.5": partial(
-        api.MiniMaxAPI,
-        model="MiniMax-M2.5",
-        temperature=0,
-        max_tokens=2048,
-        retry=10,
-    ),
-    "MiniMax-M2.5-highspeed": partial(
-        api.MiniMaxAPI,
-        model="MiniMax-M2.5-highspeed",
         temperature=0,
         max_tokens=2048,
         retry=10,


### PR DESCRIPTION
## Summary

Update the MiniMax API integration to support the latest flagship model `MiniMax-M3`:

- Add `MiniMax-M3` to the `api_models` registry in `vlmeval/config.py`, placed before older versions so it surfaces first.
- Switch the `MiniMaxAPI` default `model` argument from `MiniMax-M2.7` to `MiniMax-M3`.
- Drop the `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` registry entries to keep the supported list focused; `MiniMax-M2.7` is kept as a legacy-compatible option.
- Refresh the docstring in `vlmeval/api/minimax_api.py` so the documented model list matches the registry.

## Notes

- API base URL (`https://api.minimax.io/v1/chat/completions`), env vars, and unrelated providers (including the `abab*` GPT4V entries) are untouched.
- Existing users of `MiniMax-M2.7` are unaffected.

## Test plan

- [x] `python3 -m py_compile vlmeval/api/minimax_api.py vlmeval/config.py`
- [x] Spot-check that `MiniMax-M3` is now the default in `MiniMaxAPI` and registered in `api_models`.
- [x] Confirm `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` are removed; `MiniMax-M2.7` is still present.