### PR TITLE
Fix video error. Add prepare_dataset method to ConcatVideoDataset.

### DIFF
--- a/vlmeval/dataset/video_concat_dataset.py
+++ b/vlmeval/dataset/video_concat_dataset.py
@@ -10,7 +10,10 @@ from .video_base import VideoBaseDataset
 class ConcatVideoDataset(VideoBaseDataset):
     # This dataset takes multiple dataset names as input and aggregate them into a single dataset.
     # Each single dataset should not have a field named `SUB_DATASET`
-
+    
+    def prepare_dataset(self, dataset):
+        pass
+        
     DATASET_SETS = {}
 
     def __init__(self, dataset, **kwargs):


### PR DESCRIPTION
Added a placeholder method 'prepare_dataset' to the ConcatVideoDataset class.  Fix “Can't instantiate abstract class QBench_Video with abstract method prepare_dataset“.   Several other videos also encountered this problem, and the issue was resolved after modification.