### PR TITLE
[Benchmark] Add support for MMLongBench

### DIFF
--- a/run.py
+++ b/run.py
@@ -374,6 +374,10 @@ def get_judge_kwargs(dataset_name, dataset_type, args):
             if use_api_judger:
                 judge_kwargs['model'] = 'gpt-4o-mini'
         elif listinstr(
+            ['MMLongBench_32K', 'MMLongBench_128K', 'MMLongBench_256K', 'MMLongBench_512K'], dataset_name
+        ):
+            judge_kwargs['model'] = 'gpt-5.5-2026-04-24'
+        elif listinstr(
             ['MMLongBench', 'MMDU', 'DUDE', 'SLIDEVQA', 'MIA-Bench',
              'WildVision', 'MMAlignBench', 'MM-IFEval'], dataset_name
         ):

--- a/scripts/build_mmlongbench_tsv.py
+++ b/scripts/build_mmlongbench_tsv.py
@@ -1,0 +1,614 @@
+import argparse
+import json
+import os
+import os.path as osp
+import random
+import tarfile
+from copy import deepcopy
+
+import pandas as pd
+
+
+REPO_ID = 'ZhaoweiWang/MMLongBench'
+RAW_ARCHIVE = '0_mmlb_data.tar.gz'
+REFERENCE_TSVS = {
+    'MMLongBench_32K': 'vlmevalkit/MMLongBench_32K.tsv',
+    'MMLongBench_128K': 'vlmevalkit/MMLongBench_128K.tsv',
+    'MMLongBench_256K': 'vlmevalkit/MMLongBench_256K.tsv',
+    'MMLongBench_512K': 'vlmevalkit/MMLongBench_512K.tsv',
+}
+
+DEFAULT_DATASETS = ['MMLongBench_32K', 'MMLongBench_128K']
+
+DATASET_LENGTH = {
+    'MMLongBench_32K': 32,
+    'MMLongBench_128K': 128,
+    'MMLongBench_256K': 256,
+    'MMLongBench_512K': 512,
+}
+
+DATASET_SUBSETS = {
+    'MMLongBench_32K': {
+        'vrag': 'vrag_32',
+        'NIAH': 'NIAH_32',
+        'ICL': 'ICL_32',
+        'summ': 'summ_32',
+        'documentQA': 'documentQA_32',
+    },
+    'MMLongBench_128K': {
+        'vrag': 'vrag_128',
+        'NIAH': 'NIAH_128',
+        'ICL': 'ICL_128',
+        'summ': 'summ_128',
+        'documentQA': 'documentQA_128',
+    },
+    'MMLongBench_256K': {
+        'vrag': 'vrag_256_sr50',
+        'NIAH': 'NIAH_256_sr25',
+        'ICL': 'ICL_256_sr50',
+        'summ': 'summ_256_sr50',
+        'documentQA': 'documentQA_256_sr50',
+    },
+    'MMLongBench_512K': {
+        'vrag': 'vrag_512_sr50',
+        'NIAH': 'NIAH_512_sr25',
+        'ICL': 'ICL_512_sr50',
+        'summ': 'summ_512_sr50',
+        'documentQA': 'documentQA_512_sr50',
+    },
+}
+
+VRAG_SOURCES = {'infoseek': 3, 'viquae': 6}
+NIAH_SOURCES = {
+    'vh_single': ('vh_single_test_1000_K{k}_dep6.jsonl', 'visual_haystack'),
+    'vh_multi': ('vh_multi_test_1000_K{k}_dep3.jsonl', 'visual_haystack'),
+    'retrieval-text': ('retrieval-text_test_K{k}_dep6.jsonl', 'text'),
+    'counting-text': ('counting-text_test_K{k}_dep3.jsonl', 'text'),
+    'reasoning-text': ('reasoning-text_test_K{k}_dep3.jsonl', 'text'),
+    'retrieval-image': ('retrieval-image_test_K{k}_dep6.jsonl', 'image_mc'),
+    'counting-image': ('counting-image_test_K{k}_dep3.jsonl', 'image_count'),
+    'reasoning-image': ('reasoning-image_test_K{k}_dep6.jsonl', 'image_mc'),
+}
+ICL_SOURCES = ['cars196', 'sun397', 'inat2021', 'food101']
+SUMM_SOURCES = ['gov', 'lexsum']
+DOCQA_SOURCES = ['mmlongdoc', 'longdocurl', 'slidevqa']
+
+
+def safe_extract(tar, path):
+    root = osp.abspath(path)
+    for member in tar.getmembers():
+        target = osp.abspath(osp.join(root, member.name))
+        if not (target == root or target.startswith(root + os.sep)):
+            raise RuntimeError(f'Unsafe path in tar archive: {member.name}')
+    tar.extractall(root)
+
+
+def hf_download(filename, download_dir, token=None):
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as err:
+        raise ImportError(
+            'huggingface_hub is required to download MMLongBench assets. '
+            'Install it with `pip install huggingface_hub`, or pass local paths.'
+        ) from err
+
+    return hf_hub_download(
+        repo_id=REPO_ID,
+        filename=filename,
+        repo_type='dataset',
+        local_dir=download_dir,
+        token=token,
+    )
+
+
+def prepare_raw_data(raw_data_root, work_dir, token=None, skip_existing=False):
+    if raw_data_root:
+        return osp.abspath(raw_data_root)
+
+    os.makedirs(work_dir, exist_ok=True)
+    archive_path = osp.join(work_dir, RAW_ARCHIVE)
+    if skip_existing and osp.exists(archive_path):
+        tar_path = archive_path
+    else:
+        print(f'downloading {RAW_ARCHIVE} from {REPO_ID} ...')
+        tar_path = hf_download(RAW_ARCHIVE, work_dir, token=token)
+
+    extract_root = osp.join(work_dir, 'raw')
+    marker = osp.join(extract_root, 'mmlb_data')
+    if skip_existing and osp.exists(marker):
+        return marker
+
+    os.makedirs(extract_root, exist_ok=True)
+    print(f'extracting {tar_path} ...')
+    with tarfile.open(tar_path, 'r:gz') as tar:
+        safe_extract(tar, extract_root)
+
+    candidates = [
+        osp.join(extract_root, 'mmlb_data'),
+        osp.join(extract_root, 'MMLongBench', 'mmlb_data'),
+    ]
+    for candidate in candidates:
+        if osp.isdir(candidate):
+            return candidate
+    raise FileNotFoundError(f'Cannot find mmlb_data under {extract_root}')
+
+
+def prepare_reference_tsv(dataset, reference_tsv_root, work_dir, token=None, skip_existing=False):
+    if reference_tsv_root:
+        path = osp.join(reference_tsv_root, f'{dataset}.tsv')
+        if not osp.exists(path):
+            raise FileNotFoundError(f'Missing reference TSV: {path}')
+        return path
+
+    os.makedirs(work_dir, exist_ok=True)
+    filename = REFERENCE_TSVS[dataset]
+    local_path = osp.join(work_dir, filename)
+    if skip_existing and osp.exists(local_path):
+        return local_path
+    print(f'downloading {filename} from {REPO_ID} ...')
+    return hf_download(filename, work_dir, token=token)
+
+
+def read_jsonl(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def load_json(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def json_dumps(value):
+    return json.dumps(value, ensure_ascii=False)
+
+
+def row_key(row):
+    return (row['task'], row['source_dataset'], str(row['question_id']))
+
+
+def reference_id_map(reference):
+    id_map = {}
+    for _, row in reference.iterrows():
+        key = row_key(row)
+        id_map[key] = row
+    return id_map
+
+
+def task_ids(reference, task, source):
+    data = reference[(reference['task'] == task) & (reference['source_dataset'] == source)]
+    return {str(x) for x in data['question_id']}
+
+
+def read_selected_jsonl(path, ids):
+    if not ids:
+        return []
+    rows = []
+    missing = set(ids)
+    for sample in read_jsonl(path):
+        sample_id = str(sample['id'])
+        if sample_id in ids:
+            rows.append(sample)
+            missing.discard(sample_id)
+    if missing:
+        raise ValueError(f'{path} missing {len(missing)} ids, examples: {sorted(missing)[:5]}')
+    return rows
+
+
+def make_tsv_row(dataset, subset, task, source_dataset, question_id, question, answer, image_path,
+                 extra_info, tags):
+    return {
+        'index': None,
+        'question_id': question_id,
+        'question': question,
+        'answer': answer,
+        'image_path': json_dumps(image_path),
+        'mmlb_subset': subset,
+        'task': task,
+        'source_dataset': source_dataset,
+        'question_type': 'open',
+        'tags': json_dumps(tags),
+        'extra_info': json_dumps(extra_info),
+    }
+
+
+def add_row(rows, key, row):
+    rows.setdefault(key, []).append(row)
+
+
+def convert_vrag(dataset, raw_root, reference):
+    k = DATASET_LENGTH[dataset]
+    subset = DATASET_SUBSETS[dataset]['vrag']
+    rows = {}
+    user_template = (
+        'Use the given documents to write a concise and short answer to the question about the entity shown '
+        'in the image. Write your answer in the following format:\n'
+        'Answer: [answer]\n\n{context}\n\nQuestion: {question}'
+    )
+    passage_template = 'Document (Title: {title}): {text}'
+
+    for source, dep in VRAG_SOURCES.items():
+        ids = task_ids(reference, 'vrag', source)
+        path = osp.join(raw_root, 'vrag', f'{source}_K{k}_dep{dep}.jsonl')
+        for sample in read_selected_jsonl(path, ids):
+            sample = deepcopy(sample)
+            passage_text = '\n\n'.join([passage_template.format(**ctx) for ctx in sample['ctxs']])
+            question = '<image token>' + sample['question']
+            text = user_template.format(context=passage_text, question=question)
+            assert '<image>' not in text
+
+            question_id = str(sample.pop('id'))
+            ctxs = sample.pop('ctxs')
+            sample['question'] = question
+            sample['text'] = text
+            sample['image_list'] = [sample['image']]
+            sample['dataset_name'] = source
+
+            extra = deepcopy(sample)
+            extra.pop('text')
+            extra.pop('image_list')
+            extra.pop('ctxs', None)
+            extra['dataset_name'] = source
+            if 'positive_ctxs' not in extra and ctxs:
+                extra['positive_ctxs'] = []
+
+            row = make_tsv_row(
+                dataset, subset, 'vrag', source, question_id, text, str(sample['answer']),
+                [sample['image']], extra, ['单图']
+            )
+            add_row(rows, ('vrag', source, question_id), row)
+    return rows
+
+
+def context_from_paragraphs(paragraphs):
+    return '\n\n'.join([p['text'] if p['text'] != '<image>' else '<image token>' for p in paragraphs])
+
+
+def convert_niah(dataset, raw_root, reference):
+    k = DATASET_LENGTH[dataset]
+    subset = DATASET_SUBSETS[dataset]['NIAH']
+    rows = {}
+    vh_template = (
+        'You are given a set of images. Please answer the question in Yes or No based on the given images. '
+        'Write your answer in the following format:\nAnswer: [answer]\n\n{context}\n\nQuestion: {question}'
+    )
+    text_template = (
+        'You are given interleaved text and images. Please answer the question based on the given text and images. '
+        'Write your answer in the following format:\nAnswer: [answer]\n\n{context}\n\nQuestion: {question}'
+    )
+    image_mc_template = (
+        "You are given interleaved text and images. Please answer the question with the option's letter "
+        '(A, B, etc.) based on the given text and images. Write your answer in the following format:\n'
+        'Answer: [answer]\n\n{context}\n\nQuestion: {question}'
+    )
+
+    for source, (filename_tpl, kind) in NIAH_SOURCES.items():
+        ids = task_ids(reference, 'NIAH', source)
+        path = osp.join(raw_root, 'NIAH', filename_tpl.format(k=k))
+        for sample in read_selected_jsonl(path, ids):
+            sample = deepcopy(sample)
+            question_id = str(sample.pop('id'))
+            original_ctxs = sample.pop('ctxs')
+
+            if kind == 'visual_haystack':
+                image_list = sample['ctxs'] if 'ctxs' in sample else original_ctxs
+                image_list = [x if isinstance(x, str) else x.get('image', x.get('text')) for x in image_list]
+                passage_text = '\n'.join(['<image token>'] * len(image_list))
+                question = sample['question']
+                text = vh_template.format(context=passage_text, question=question)
+            elif kind == 'text':
+                image_list = sample['image_list']
+                passage_text = context_from_paragraphs(original_ctxs)
+                question = sample['question']
+                text = text_template.format(context=passage_text, question=question)
+            elif kind == 'image_count':
+                image_list = sample['image_list'] + sample['needle_image_list']
+                passage_text = context_from_paragraphs(original_ctxs)
+                question = sample['question'].replace('<image>', '<image token>')
+                text = text_template.format(context=passage_text, question=question)
+                for ctx in sample.get('positive_ctxs', []):
+                    if ctx.get('type') == 'image':
+                        ctx['text'] = ctx['text'].replace('<image>', '<image token>')
+            elif kind == 'image_mc':
+                passage_text = context_from_paragraphs(original_ctxs)
+                question = sample['question']
+                question += ''.join([f'\n{chr(i + ord("A"))}. <image token>' for i in range(len(sample['choices_image']))])
+                text = image_mc_template.format(context=passage_text, question=question)
+                image_list = sample['image_list'] + sample['choices_image']
+                for ctx in sample.get('positive_ctxs', []):
+                    if ctx.get('type') == 'image':
+                        ctx['text'] = ctx['text'].replace('<image>', '<image token>')
+            else:
+                raise ValueError(f'Unknown NIAH kind: {kind}')
+
+            assert '<image>' not in text
+            sample['text'] = text
+            sample['image_list'] = image_list
+            sample['dataset_name'] = source
+            if kind in {'image_count', 'image_mc'}:
+                sample['question'] = question
+
+            extra = deepcopy(sample)
+            extra.pop('text')
+            extra.pop('image_list')
+            row = make_tsv_row(
+                dataset, subset, 'NIAH', source, question_id, text, str(sample['answer']),
+                image_list, extra, ['多图']
+            )
+            add_row(rows, ('NIAH', source, question_id), row)
+    return rows
+
+
+def convert_icl(dataset, raw_root, reference):
+    k = DATASET_LENGTH[dataset]
+    subset = DATASET_SUBSETS[dataset]['ICL']
+    rows = {}
+    rng = random.Random(42)
+    user_template = (
+        'You need to recognize entities in images. Use the provided mapping from the image to label to assign '
+        'a label to the test image. Only output "label: {{label}}" and nothing else.\n\n'
+        'Training examples:\n{context}\n\nNow classify this image: {question}'
+    )
+    item_template = '<image token>\nlabel: {label}'
+
+    for source in ICL_SOURCES:
+        ids = task_ids(reference, 'ICL', source)
+        if not ids:
+            continue
+        path = osp.join(raw_root, 'ICL', f'{source}_K{k}.json')
+        data = load_json(path)
+        exemplar_by_domain = {domain: data_dict['exemplar_list'] for domain, data_dict in data.items()}
+        test_examples = [
+            {'domain': domain, 'example': example}
+            for domain, data_dict in data.items()
+            for example in data_dict['test_example']
+            if str(example['id']) in ids
+        ]
+        found = {str(x['example']['id']) for x in test_examples}
+        missing = ids - found
+        if missing:
+            raise ValueError(f'{path} missing {len(missing)} ids, examples: {sorted(missing)[:5]}')
+
+        for sample in test_examples:
+            domain = sample['domain']
+            example = sample['example']
+            sampled_exemplar = deepcopy(rng.choice(exemplar_by_domain[domain]))
+            for round_items in sampled_exemplar:
+                rng.shuffle(round_items)
+            exemplars = [item for round_items in sampled_exemplar for item in round_items]
+
+            question = '<image token>'
+            context = '\n\n'.join([item_template.format(label=item['id']) for item in exemplars])
+            text = user_template.format(context=context, question=question)
+            image_list = [item['image'] for item in exemplars] + [example['image']]
+
+            question_id = str(example['id'])
+            extra = {
+                'domain': domain,
+                'example': example,
+                'text': text,
+                'image_list': image_list,
+                'answer': example['answer'],
+                'question': question,
+                'dataset_name': source,
+            }
+            extra.pop('text')
+            extra.pop('image_list')
+            row = make_tsv_row(
+                dataset, subset, 'ICL', source, question_id, text, str(example['answer']),
+                image_list, extra, ['多图']
+            )
+            add_row(rows, ('ICL', source, question_id), row)
+    return rows
+
+
+def convert_summ(dataset, raw_root, reference):
+    k = DATASET_LENGTH[dataset]
+    subset = DATASET_SUBSETS[dataset]['summ']
+    rows = {}
+    gov_template = (
+        'You are given a government report from U.S. Government Accountability Office (GAO), and you are tasked '
+        'to summarize the report. Write a concise summary (around 550 words) organized in multiple paragraphs. '
+        'Where applicable, the summary should contain a short description of why GAO did this study, what GAO found, '
+        'and what GAO recommends.\n\nGovernment Report:\n{context}\n\nNow please summarize the report.'
+    )
+    lexsum_template = (
+        'You are given the legal documents in a civil rights lawsuit, and you are tasked to summarize the case. '
+        'Write a concise summary of one paragraph (200 to 250 words). The summary should contain a short description '
+        'of the background, the parties involved, and the outcomes of the case.\n\nLegal documents:\n{context}\n\n'
+        'Now please summarize the case.'
+    )
+    item_template = 'Document {doc_id:.15} (page {page_id}): <image token>'
+
+    for source in SUMM_SOURCES:
+        ids = task_ids(reference, 'summ', source)
+        path = osp.join(raw_root, 'summ', f'{source}_K{k}.jsonl')
+        for sample in read_selected_jsonl(path, ids):
+            sample = deepcopy(sample)
+            question_id = str(sample.pop('id'))
+            page_prompt_list = [
+                item_template.format(
+                    doc_id=image_path.split('/')[-2],
+                    page_id=image_path.split('page')[1].split('.')[0],
+                )
+                for image_path in sample['image_list']
+            ]
+            passage_text = '\n\n'.join(page_prompt_list)
+            if source == 'gov':
+                text = gov_template.format(context=passage_text)
+                answer = '\n\n'.join([
+                    aspect['section_title'] + ':\n' + '\n'.join(aspect['paragraphs'])
+                    for aspect in sample['summary']
+                ])
+            elif source == 'lexsum':
+                text = lexsum_template.format(context=passage_text)
+                answer = sample['summary']
+            else:
+                raise ValueError(f'Unknown summarization source: {source}')
+
+            sample['text'] = text
+            sample['answer'] = answer
+            sample['dataset_name'] = source
+            extra = deepcopy(sample)
+            extra.pop('text')
+            extra.pop('image_list')
+            row = make_tsv_row(
+                dataset, subset, 'summ', source, question_id, text, answer,
+                sample['image_list'], extra, ['多图']
+            )
+            add_row(rows, ('summ', source, question_id), row)
+    return rows
+
+
+def convert_docqa(dataset, raw_root, reference):
+    k = DATASET_LENGTH[dataset]
+    subset = DATASET_SUBSETS[dataset]['documentQA']
+    rows = {}
+    user_template = (
+        "You are given a document with text and images, and a question. Answer the question as concisely as you can, "
+        "using a single phrase or sentence if possible. If the question cannot be answered based on the information "
+        "in the article, write 'Not answerable.' Write your answer in the following format:\n"
+        'Answer: [answer]\n\n{context}\n\nQuestion: {question}'
+    )
+    item_template = 'Document {doc_id:.15}: <image token>'
+
+    for source in DOCQA_SOURCES:
+        ids = task_ids(reference, 'documentQA', source)
+        path = osp.join(raw_root, 'documentQA', f'{source}_K{k}.jsonl')
+        for sample in read_selected_jsonl(path, ids):
+            sample = deepcopy(sample)
+            question_id = str(sample.pop('id'))
+            image_list = sample.pop('page_list')
+            page_prompt_list = [
+                item_template.format(doc_id=image_path.split('/')[-2])
+                for image_path in image_list
+            ]
+            passage_text = '\n\n'.join(page_prompt_list)
+            question = (
+                'Based on Document {doc_id:.15}, answer the following question. '.format(doc_id=sample['doc_name'])
+                + sample['question']
+            )
+            text = user_template.format(context=passage_text, question=question)
+
+            sample['text'] = text
+            sample['image_list'] = image_list
+            sample['question'] = question
+            sample['dataset_name'] = source
+            extra = deepcopy(sample)
+            extra.pop('text')
+            extra.pop('image_list')
+            row = make_tsv_row(
+                dataset, subset, 'documentQA', source, question_id, text, sample['answer'],
+                image_list, extra, ['多图']
+            )
+            add_row(rows, ('documentQA', source, question_id), row)
+    return rows
+
+
+def build_dataset(dataset, raw_root, reference):
+    converters = [convert_vrag, convert_niah, convert_icl, convert_summ, convert_docqa]
+    generated = {}
+    for converter in converters:
+        generated.update(converter(dataset, raw_root, reference))
+
+    ordered_rows = []
+    missing = []
+    cursor = {}
+    for _, ref_row in reference.iterrows():
+        key = row_key(ref_row)
+        variants = generated.get(key)
+        pos = cursor.get(key, 0)
+        if variants is None or pos >= len(variants):
+            missing.append(key)
+            continue
+        cursor[key] = pos + 1
+        row = variants[pos]
+        row = row.copy()
+        row['index'] = ref_row['index']
+        # ICL prompts include randomly selected few-shot exemplars. The released
+        # TSVs already publish this split-specific exemplar order, so preserve it
+        # instead of re-sampling and producing a different public benchmark.
+        if key[0] == 'ICL':
+            row['question'] = ref_row['question']
+            row['image_path'] = ref_row['image_path']
+        ordered_rows.append(row)
+    if missing:
+        raise ValueError(f'Missing {len(missing)} generated rows, examples: {missing[:5]}')
+    return pd.DataFrame(ordered_rows, columns=list(reference.columns))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Build MMLongBench VLMEvalKit TSVs from the public MMLongBench raw format. '
+            'The released VLMEvalKit TSVs are used as the public split ID/order reference. '
+            'The public raw archive contains the 32K/128K raw files; 256K/512K can be built '
+            'only when matching extended raw files are provided via --raw-data-root.'
+        )
+    )
+    parser.add_argument(
+        '--raw-data-root',
+        default=None,
+        help='Path to extracted mmlb_data. If omitted, 0_mmlb_data.tar.gz is downloaded from Hugging Face.',
+    )
+    parser.add_argument(
+        '--reference-tsv-root',
+        default=None,
+        help='Directory containing released MMLongBench_*.tsv files. If omitted, they are downloaded from Hugging Face.',
+    )
+    parser.add_argument(
+        '--output-root',
+        required=True,
+        help='Directory where rebuilt TSV files will be written.',
+    )
+    parser.add_argument(
+        '--work-dir',
+        default=None,
+        help='Download/extraction cache directory. Defaults to <output-root>/mmlongbench_downloads.',
+    )
+    parser.add_argument(
+        '--dataset',
+        nargs='+',
+        default=DEFAULT_DATASETS,
+        choices=list(DATASET_LENGTH),
+        help='Datasets to build. Defaults to public-raw-archive splits: MMLongBench_32K MMLongBench_128K.',
+    )
+    parser.add_argument(
+        '--token',
+        default=os.environ.get('HF_TOKEN'),
+        help='Optional Hugging Face token. Defaults to HF_TOKEN.',
+    )
+    parser.add_argument(
+        '--skip-existing',
+        action='store_true',
+        help='Reuse local downloads/extractions when present.',
+    )
+    args = parser.parse_args()
+
+    output_root = osp.abspath(args.output_root)
+    work_dir = osp.abspath(args.work_dir or osp.join(output_root, 'mmlongbench_downloads'))
+    os.makedirs(output_root, exist_ok=True)
+
+    raw_root = prepare_raw_data(args.raw_data_root, work_dir, token=args.token, skip_existing=args.skip_existing)
+    print(f'using raw data root: {raw_root}')
+
+    for dataset in args.dataset:
+        ref_path = prepare_reference_tsv(
+            dataset,
+            args.reference_tsv_root,
+            work_dir,
+            token=args.token,
+            skip_existing=args.skip_existing,
+        )
+        reference = pd.read_csv(ref_path, sep='\t')
+        data = build_dataset(dataset, raw_root, reference)
+        out_file = osp.join(output_root, f'{dataset}.tsv')
+        data.to_csv(out_file, sep='\t', index=False)
+        print(f'wrote {out_file}: {len(data)} rows')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/package_mmlongbench_images.py
+++ b/scripts/package_mmlongbench_images.py
@@ -1,0 +1,118 @@
+import argparse
+import os
+import os.path as osp
+import tarfile
+
+
+REPO_ID = 'ZhaoweiWang/MMLongBench'
+IMAGE_ARCHIVES = [
+    '1_vrag_image.tar.gz',
+    '2_vh_image.tar.gz',
+    '2_mm-niah_image.tar.gz',
+    '3_icl_image.tar.gz',
+    '4_summ_image.tar.gz',
+    '5_docqa_image.tar.gz',
+]
+
+
+def safe_extract(tar, path):
+    root = osp.abspath(path)
+    for member in tar.getmembers():
+        target = osp.abspath(osp.join(root, member.name))
+        if not (target == root or target.startswith(root + os.sep)):
+            raise RuntimeError(f'Unsafe path in tar archive: {member.name}')
+    tar.extractall(root)
+
+
+def tar_has_top_level_mmlb_image(tar_path):
+    with tarfile.open(tar_path, 'r:gz') as tar:
+        for member in tar.getmembers():
+            name = member.name.lstrip('./')
+            if not name:
+                continue
+            return name.split('/', 1)[0] == 'mmlb_image'
+    return False
+
+
+def extract_archive(tar_path, output_root):
+    has_root = tar_has_top_level_mmlb_image(tar_path)
+    extract_root = output_root if has_root else osp.join(output_root, 'mmlb_image')
+    os.makedirs(extract_root, exist_ok=True)
+    with tarfile.open(tar_path, 'r:gz') as tar:
+        safe_extract(tar, extract_root)
+    return extract_root
+
+
+def download_archive(filename, download_dir, token=None):
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as err:
+        raise ImportError(
+            'huggingface_hub is required. Install it with `pip install huggingface_hub`.'
+        ) from err
+
+    return hf_hub_download(
+        repo_id=REPO_ID,
+        filename=filename,
+        repo_type='dataset',
+        local_dir=download_dir,
+        token=token,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Download and extract official MMLongBench image tarballs from Hugging Face.'
+    )
+    parser.add_argument(
+        '--output-root',
+        required=True,
+        help='Directory that will contain mmlb_image/. For VLMEvalKit, use $LMUData/images.',
+    )
+    parser.add_argument(
+        '--download-dir',
+        default=None,
+        help='Where to store downloaded tar.gz files. Defaults to <output-root>/downloads.',
+    )
+    parser.add_argument(
+        '--token',
+        default=os.environ.get('HF_TOKEN'),
+        help='Optional Hugging Face token. Defaults to HF_TOKEN.',
+    )
+    parser.add_argument(
+        '--archive',
+        nargs='+',
+        default=IMAGE_ARCHIVES,
+        choices=IMAGE_ARCHIVES,
+        help='Subset of official image archives to download and extract.',
+    )
+    parser.add_argument(
+        '--skip-existing',
+        action='store_true',
+        help='Reuse local tar.gz files when present instead of downloading again.',
+    )
+    args = parser.parse_args()
+
+    output_root = osp.abspath(args.output_root)
+    download_dir = osp.abspath(args.download_dir or osp.join(output_root, 'downloads'))
+    os.makedirs(output_root, exist_ok=True)
+    os.makedirs(download_dir, exist_ok=True)
+
+    for archive in args.archive:
+        local_tar = osp.join(download_dir, archive)
+        if args.skip_existing and osp.exists(local_tar):
+            tar_path = local_tar
+            print(f'use existing: {tar_path}')
+        else:
+            print(f'downloading {archive} from {REPO_ID} ...')
+            tar_path = download_archive(archive, download_dir, token=args.token)
+            print(f'downloaded: {tar_path}')
+
+        extract_root = extract_archive(tar_path, output_root)
+        print(f'extracted {archive} under: {extract_root}')
+
+    print(f'done. mmlb_image root should be: {osp.join(output_root, "mmlb_image")}')
+
+
+if __name__ == '__main__':
+    main()

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -84,6 +84,7 @@ from .mmgenbench import MMGenBench
 from .mmhelix import MMHELIX
 from .mmifeval import MMIFEval
 from .mmlongbench import MMLongBench
+from .mmlongbenchdoc import MMLongBenchDoc
 from .mmmath import MMMath
 from .mmoral_opg_closed import MMOral_OPG_CLOSED
 from .mmoral_opg_open import MMOral_OPG_OPEN
@@ -277,7 +278,7 @@ class ConcatDataset(ImageBaseDataset):
 IMAGE_DATASET = [
     ImageCaptionDataset, ImageYORNDataset, ImageMCQDataset, ImageVQADataset,
     MathVision, LENS, MMMUDataset, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet,  # noqa: E501
-    MTVQADataset, TableVQABench, MMLongBench, VCRDataset, MMDUDataset, DUDE,
+    MTVQADataset, TableVQABench, MMLongBench, MMLongBenchDoc, VCRDataset, MMDUDataset, DUDE,
     SlideVQA, MUIRDataset, CCOCRDataset, GMAIMMBenchDataset, MMERealWorld,
     HRBenchDataset, CRPE, MathVerse, NaturalBenchDataset, MIABench,
     OlympiadBench, SeePhys, WildVision, MMMath, QSpatial, Dynamath, GSM8KVDataset, MMGenBench, VizWiz,  # noqa: E501

--- a/vlmeval/dataset/dude.py
+++ b/vlmeval/dataset/dude.py
@@ -15,7 +15,7 @@ from vlmeval.smp import (LMUDataRoot, decode_base64_to_image_file, download_file
                          encode_image_to_base64, get_intermediate_file_path, get_logger, listinstr,
                          load, md5, read_ok, toliststr)
 from .image_base import ImageBaseDataset
-from .mmlongbench import MMLongBench_auxeval, anls_compute, concat_images
+from .mmlongbenchdoc import MMLongBench_auxeval, anls_compute, concat_images
 from .utils.judge_util import build_judge
 
 logger = get_logger(__name__)

--- a/vlmeval/dataset/mmlongbench.py
+++ b/vlmeval/dataset/mmlongbench.py
@@ -1,594 +1,408 @@
-import base64
-import io
-import logging
-import math
+import json
 import os
 import os.path as osp
 import re
-from urllib.request import urlopen
+import tarfile
 
 import pandas as pd
-import torchvision.transforms as transforms
-from PIL import Image, ImageDraw, ImageFont
-from tqdm import tqdm
 
-from vlmeval.dataset.utils import build_judge, levenshtein_distance
-from vlmeval.smp import (decode_base64_to_image_file, dump, encode_image_to_base64,
-                         get_intermediate_file_path, get_logger, listinstr, load, read_ok,
-                         toliststr)
 from .image_base import ImageBaseDataset
-
-logger = get_logger(__name__)
-
-FAIL_MSG = 'Failed to obtain answer via API.'
-
-
-def get_gpt4_ICE():
-    example_1 = """
----
-Question: List the primary questions asked about the services in this report.
-Analysis:  The primary questions asked about the services in the report for The Limes Residential Home are:\n\n
-1. Is the service safe?\n
-2. Is the service effective?\n
-3. Is the service caring?\n
-4. Is the service responsive?\n
-5. Is the service well-led?
-Extracted answer: [
-    'Is the servife safe?',
-    'Is the service effective',
-    'Is the serve caring?',
-    'Is the service responsive?',
-    'Is the service well-led?'
-]
-Answer format: List\n
-"""
-
-    example_2 = """
----
-Question: How many regulations of the HSCA 2008 are breached in all according to this report?
-Analysis: According to the report, the provider breached 10 Health and Social Care Act 2008 (Regulated Activities)
-Regulations in total. Here are the specifics:\n\n1. Regulation 13: Safeguarding service users from abuse and
-improper treatment\n2. Regulation 12: Safe care and treatment\n3. Regulation 18: Staffing\n4. Regulation 11:
-Need for consent\n5. Regulation 10: Dignity and respect\n6. Regulation 9: Person-centred care\n7. Regulation 17:
-Good governance\n8. Regulation 18 (CQC Registration Regulations 2009): Notification of other incidents\n9.
-Regulation 18: Failure to maintain an accurate and up-to-date care plan\n10. Regulation 11: Failure to implement
-the Mental Capacity Act 2005 code of practice effectively\n\nThese breaches involve issues concerning staffing,
-safeguarding, medicines management, dignity and respect, consent, care planning, governance, and failure to
-notify the CQC of incidents.
-Extracted answer: 10
-Answer format: Integer\n
-"""
-
-    example_3 = """
----
-Question: According to the survey that is the percentage of Chinese who are paying more or
-about the same attention to politics after Trump's election?
-Analysis: The survey provided does not specify the percentage of Chinese individuals specifically who are paying
-more or about the same attention to politics after Trump's election. The report focuses primarily on American
-demographics and does not include specific details about the Chinese population in relation to this question. If
-you need information about a different demographic or a summary of the findings from the American demographic,
-I can certainly help with that!
-Extracted answer: Not answerable
-Answer format: String\n
-"""
-
-    example_4 = """
----
-Question: How many quotations from male respondent over 50 years old are included in this report?
-Analysis: The image you've provided appears to be a screenshot of a document with multiple charts. However, the
-text is too small and blurry to read accurately. If you can provide a clearer image or more context, I might be
-able to help you with your question.
-Extracted answer: Fail to answer
-Answer format: String\n
-"""
-
-    return [example_1, example_2, example_3, example_4]
-
-
-def build_mmlongbench_gpt4_prompt(line):
-    task_description = """
-Given the question and analysis, you are tasked to extract answers with required formats from the free-form analysis.
-- Your extracted answers should be one of the following formats: (1) Integer, (2) Float, (3) String and (4) List.
-If you find the analysis the question can not be answered from the given documents, type "Not answerable".
-Exception: If the analysis only tells you that it can not read/understand the images or documents,
-type "Fail to answer".
-- Please make your response as concise as possible. Also note that your response should be formatted as below:
-```
-Extracted answer: [answer]
-Answer format: [answer format]
-```
-Please read the following example, then extract the answer from the model response
-and type it at the end of the prompt.\n
-"""
-    question = line['question']
-    prediction = str(line['prediction'])
-    prompt = task_description
-    examples = get_gpt4_ICE()
-    for example in examples:
-        prompt += example
-    prompt += '---\nQuestion:' + question + '\n'
-    prompt += 'Analysis: ' + prediction
-    return prompt
-
-
-def anls_compute(groundtruth, prediction, threshold=0.5):
-    dist = levenshtein_distance(groundtruth, prediction)
-    length = max(len(groundtruth.upper()), len(prediction.upper()))
-    value = 0.0 if length == 0 else float(dist) / float(length)
-    anls = 1.0 - value
-    if anls <= threshold:
-        anls = 0.0
-    return anls
-
-
-def is_float_equal(reference, prediction, include_percentage: bool = False, is_close: float = False) -> bool:
-    def get_precision(gt_ans: float) -> int:
-        precision = 3
-        if '.' in str(gt_ans):
-            precision = len(str(gt_ans).split('.')[-1])
-        return precision
-
-    reference = float(str(reference).strip().rstrip('%').strip())
-    try:
-        prediction = float(str(prediction).strip().rstrip('%').strip())
-    except Exception:
-        return False
-
-    if include_percentage:
-        gt_result = [reference / 100, reference, reference * 100]
-    else:
-        gt_result = [reference]
-    for item in gt_result:
-        try:
-            if is_close:
-                if math.isclose(item, prediction, rel_tol=0.01):
-                    return True
-            precision = max(min(get_precision(prediction), get_precision(item)), 2)
-            if round(prediction, precision) == round(item, precision):
-                return True
-        except Exception:
-            continue
-    return False
-
-
-def get_clean_string(s):
-    s = str(s).lower().strip()
-    if s.endswith('mile'):
-        s.rstrip('mile').strip()
-    if s.endswith('miles'):
-        s.rstrip('miles').strip()
-    if s.endswith('million'):
-        s.rstrip('million').strip()
-    # remove parenthesis
-    s = re.sub(r'\s*\([^)]*\)', '', s).strip()
-    # remove quotes
-    s = re.sub(r"^['\"]|['\"]$", '', s).strip()
-    s = s.strip().lstrip('$').strip()
-    s = s.strip().rstrip('%').strip()
-    return s
-
-
-def is_exact_match(s):
-    flag = False
-    # Website
-    if 'https://' in s:
-        flag = True
-    # code file
-    if s.endswith('.py') or s.endswith('ipynb'):
-        flag = True
-    if s.startswith('page'):
-        flag = True
-    # telephone number
-    if re.fullmatch(r'\b\d+(-\d+|\s\d+)?\b', s):
-        flag = True
-    # time
-    if 'a.m.' in s or 'p.m.' in s:
-        flag = True
-    # YYYY-MM-DD
-    if re.fullmatch(r'\b\d{4}[-\s]\d{2}[-\s]\d{2}\b', s):
-        flag = True
-    # YYYY-MM
-    if re.fullmatch(r'\b\d{4}[-\s]\d{2}\b', s):
-        flag = True
-    # Email address
-    if re.fullmatch(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}', s):
-        flag = True
-    return flag
-
-
-def isfloat(num):
-    try:
-        float(num)
-        return True
-    except ValueError:
-        return False
-
-
-def get_font():
-    try:
-        truetype_url = "https://opencompass.openxlab.space/utils/Fonts/SimHei.ttf"
-        ff = urlopen(truetype_url)
-        font = ImageFont.truetype(ff, size=40)
-    except Exception as e:
-        logging.warning(f'{type(e)}: {e}')
-        logging.warning("Fail to download the font. Use the default one.")
-        font = ImageFont.load_default(size=40)
-    return font
-
-
-def frame2img(img_path_list, font, save_path=None, idx_start=0):
-    imgs = [Image.open(img_path) for img_path in img_path_list]
-
-    new_imgs = []
-    for img in imgs:
-        w, h = img.size
-        scale = w / h
-        if w > h:
-            new_w = 560 * 2
-            new_h = int(560 * 2 / scale)
-        else:
-            new_w = int(560 * 2 * scale)
-            new_h = 560 * 2
-        img = transforms.functional.resize(img, [new_h, new_w],)
-        new_imgs.append(img)
-    imgs = new_imgs
-    new_w = 0
-    new_h = 0
-    pad = 40
-    if w > h:
-        for im in imgs:
-            w, h = im.size
-            new_w = max(new_w, w)
-            new_h += h + 10 + pad
-        new_img = Image.new("RGB", (new_w, new_h), "white")
-        draw = ImageDraw.Draw(new_img)
-        curr_h = 0
-        for idx, im in enumerate(imgs):
-            w, h = im.size
-            new_img.paste(im, (0, pad + curr_h))
-            draw.text((0, curr_h), f"<IMAGE {idx + idx_start}>", font=font, fill="black")
-            if idx + 1 < len(imgs):
-                draw.line([(0, pad + curr_h + h + 5), (new_w, pad + curr_h + h + 5)], fill='black', width=2)
-            curr_h += h + 10 + pad
-    else:
-        for im in imgs:
-            w, h = im.size
-            new_w += w + 10
-            new_h = max(new_h, h)
-        new_h += pad
-        new_img = Image.new('RGB', (new_w, new_h), 'white')
-        draw = ImageDraw.Draw(new_img)
-        curr_w = 0
-        for idx, im in enumerate(imgs):
-            w, h = im.size
-            new_img.paste(im, (curr_w, pad))
-            draw.text((curr_w, 0), f"<IMAGE {idx + idx_start}>", font=font, fill='black')
-            if idx + 1 < len(imgs):
-                draw.line([(curr_w + w + 5, 0), (curr_w + w + 5, new_h)], fill='black', width=2)
-            curr_w += w + 10
-
-    if save_path is not None:
-        new_img.save(save_path)
-
-    return new_img
-
-
-def concat_images(image_list, max_concat=1, column_num=1):
-    concatenated_images = []
-    if column_num == -1:
-        MAX_COLUMN_NUM = 20
-        max_concat = 1
-        while len(image_list) / max_concat > MAX_COLUMN_NUM:
-            max_concat += 1
-        interval = max(math.ceil(len(image_list) / max_concat), 1)
-        for i in range(0, len(image_list), interval):
-            batch_images = image_list[i:i + interval]
-            concatenated_image = frame2img(batch_images, font=get_font(), idx_start=i)
-            concatenated_images.append(concatenated_image)
-    else:
-        interval = max(math.ceil(len(image_list) / max_concat), 1)
-        for i in range(0, len(image_list), interval):
-            batch_images = [Image.open(filename) for filename in image_list[i:i + interval]]
-            if column_num == 1:
-                total_height = batch_images[0].height * len(batch_images)
-            else:
-                total_height = batch_images[0].height * ((len(batch_images) - 1) // column_num + 1)
-            concatenated_image = Image.new('RGB', (batch_images[0].width * column_num, total_height), 'white')
-
-            x_offset, y_offset = 0, 0
-            for count, image in enumerate(batch_images):
-                concatenated_image.paste(image, (x_offset, y_offset))
-                x_offset += image.width
-                if (count + 1) % column_num == 0:
-                    y_offset += image.height
-                    x_offset = 0
-            concatenated_images.append(concatenated_image)
-    return concatenated_images
-
-
-def eval_score(gt, pred, answer_type):
-    if answer_type == 'Int':
-        try:
-            gt, pred = int(gt), int(float(pred))
-        except Exception:
-            pred = ''
-        score = (gt == pred)
-    elif answer_type == 'Float':
-        try:
-            gt = float(get_clean_string(str(gt)))
-            pred = float(get_clean_string(str(pred)))
-        except Exception:
-            pred = ''
-        score = is_float_equal(gt, pred, include_percentage=True, is_close=True)
-    elif answer_type == 'Str':
-        gt = get_clean_string(gt)
-        pred = get_clean_string(pred)
-        if is_exact_match(gt):
-            score = (gt == pred)
-        else:
-            score = anls_compute(gt, pred)
-    else:
-        if isinstance(gt, str) and gt.startswith('['):
-            gt = eval(gt)
-        if not isinstance(gt, list):
-            gt = [gt]
-        if isinstance(pred, str) and pred.startswith('['):
-            pred = eval(pred)
-        if not isinstance(pred, list):
-            pred = [pred]
-        print(len(gt), len(pred))
-        if len(gt) != len(pred):
-            score = 0.0
-        else:
-            gt = sorted([get_clean_string(a) for a in gt])
-            pred = sorted([get_clean_string(a) for a in pred])
-            print(gt, pred)
-            if isfloat(gt[0]) or is_exact_match(gt[0]):
-                score = ('-'.join(gt) == '-'.join(pred))
-            else:
-                score = min([anls_compute(gt_v, pred_v) for gt_v, pred_v in zip(gt, pred)])
-
-    return float(score)
-
-
-def MMLongBench_auxeval(model, line):
-    prompt = build_mmlongbench_gpt4_prompt(line)
-    log = ''
-    retry = 5
-
-    for i in range(retry):
-        prediction = line['prediction']
-        res = model.generate(prompt, temperature=i * 0.5)
-
-        if FAIL_MSG in res:
-            log += f'Try {i}: output is {prediction}, failed to parse.\n'
-        else:
-            log += 'Succeed'
-            try:
-                pred = res.split('Answer format:')[0].split('Extracted answer:')[1].strip()
-            except Exception:
-                pred = ''
-            return dict(log=log, res=res, pred=pred)
-    log += 'All 5 retries failed.\n'
-    return dict(log=log, res='', pred='')
-
-
-def get_f1(data):
-    gt_pos_data = data[data.apply(lambda k: k['answer'] != 'Not answerable', axis=1)]
-    pred_pos_data = data[data.apply(lambda k: k['pred'] != 'Not answerable', axis=1)]
-    recall = sum(gt_pos_data['score'].tolist()) / len(gt_pos_data)
-    precision = sum(pred_pos_data['score'].tolist()) / len(pred_pos_data)
-    return 2 * recall * precision / (recall + precision)
-
-
-def MMLongBench_acc(result_file):
-    data = load(result_file)
-    overall_score = 0.0
-    score_list = list()
-    for i in range(len(data)):
-        item = data.iloc[i]
-        try:
-            score = eval_score(item['answer'], item['pred'], item['answer_format'])
-        except Exception:
-            score = 0.0
-        score_list.append(score)
-        overall_score += score
-
-    data['score'] = score_list
-    dump(data, result_file)
-
-    data_chart = data[data.apply(lambda k: 'Chart' in eval(k['evidence_sources']), axis=1)]
-    data_table = data[data.apply(lambda k: 'Table' in eval(k['evidence_sources']), axis=1)]
-    data_image = data[data.apply(lambda k: 'Figure' in eval(k['evidence_sources']), axis=1)]
-    data_text = data[data.apply(lambda k: 'Pure-text (Plain-text)' in eval(k['evidence_sources']), axis=1)]
-    data_layout = data[data.apply(lambda k: 'Generalized-text (Layout)' in eval(k['evidence_sources']), axis=1)]
-
-    data_single = data[data.apply(lambda k: len(eval(k['evidence_pages'])) == 1, axis=1)]
-    data_multi = data[data.apply(lambda k: len(eval(k['evidence_pages'])) > 1, axis=1)]
-    data_unans = data[data.apply(lambda k: len(eval(k['evidence_pages'])) == 0, axis=1)]
-
-    res = dict()
-    res['category'] = [
-        'overall_f1', 'overall_acc', 'text', 'layout', 'table', 'chart',
-        'image', 'single-page', 'multi-page', 'unanswerable'
-    ]
-    res['num'] = [
-        len(data), len(data), len(data_text), len(data_layout), len(data_table),
-        len(data_chart), len(data_image), len(data_single), len(data_multi), len(data_unans)
-    ]
-    res['avg_score'] = [
-        get_f1(data),
-        overall_score / len(data),
-        sum(data_text['score'].tolist()) / len(data_text) if len(data_text) > 0 else 0.0,
-        sum(data_layout['score'].tolist()) / len(data_layout) if len(data_layout) > 0 else 0.0,
-        sum(data_table['score'].tolist()) / len(data_table) if len(data_table) > 0 else 0.0,
-        sum(data_chart['score'].tolist()) / len(data_chart) if len(data_chart) > 0 else 0.0,
-        sum(data_image['score'].tolist()) / len(data_image) if len(data_image) > 0 else 0.0,
-        sum(data_single['score'].tolist()) / len(data_single) if len(data_single) > 0 else 0.0,
-        sum(data_multi['score'].tolist()) / len(data_multi) if len(data_multi) > 0 else 0.0,
-        sum(data_unans['score'].tolist()) / len(data_unans) if len(data_unans) > 0 else 0.0,
-    ]
-    res = pd.DataFrame(res)
-    return res
+from .utils import build_judge
+from .utils.mmlongbench_metrics import calculate_metrics, parse_output
+from ..smp import dump, get_logger, load, toliststr
+from ..smp.file import get_intermediate_file_path
+from ..smp.file import LMUDataRoot
 
 
 class MMLongBench(ImageBaseDataset):
+    """MMLongBench full benchmark downsampled to selected context lengths."""
 
     TYPE = 'VQA'
-
+    MODALITY = 'IMAGE'
+    DEFAULT_JUDGE = 'gpt-5.5-2026-04-24'
+    JUDGE_FORMAT = None
+    RATING_FORMAT = '{model_name}_{dataset_name}_score.csv'
+    HF_REPO_ID = 'ZhaoweiWang/MMLongBench'
     DATASET_URL = {
-        'MMLongBench_DOC': 'https://opencompass.openxlab.space/utils/VLMEval/MMLongBench_DOC.tsv',
+        'MMLongBench_32K': 'https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/resolve/main/vlmevalkit/MMLongBench_32K.tsv',  # noqa: E501
+        'MMLongBench_128K': 'https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/resolve/main/vlmevalkit/MMLongBench_128K.tsv',  # noqa: E501
+        'MMLongBench_256K': 'https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/resolve/main/vlmevalkit/MMLongBench_256K.tsv',  # noqa: E501
+        'MMLongBench_512K': 'https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/resolve/main/vlmevalkit/MMLongBench_512K.tsv',  # noqa: E501
     }
-    DATASET_MD5 = {
-        'MMLongBench_DOC': '75f5d29965d0db68254993f6170da7c2',
-    }
+    DATASET_MD5 = {}
 
-    SUPPORTED_MODELS = {
-        'GPT4': (1, 1),
-        'GPT4V': (1, 1),
-        'GPT4V_HIGH': (1, 1),
-        'GPT4o': (1, 1),
-        'GPT4o_HIGH': (1, 1),
-        'GPT4o_MINI': (1, 1),
-        'MiniCPM-Llama3-V-2_5': (1, 5),
-        'InternVL-Chat-V1-5': (5, 2),
-        'XComposer2_4KHD': (1, 5),
-        'XComposer2d5': (1, -1),
+    DATASET_SETS = {
+        'MMLongBench_32K': ['vrag_32', 'NIAH_32', 'ICL_32', 'summ_32', 'documentQA_32'],
+        'MMLongBench_128K': ['vrag_128', 'NIAH_128', 'ICL_128', 'summ_128', 'documentQA_128'],
+        'MMLongBench_256K': ['vrag_256_sr50', 'NIAH_256_sr25', 'ICL_256_sr50', 'summ_256_sr50', 'documentQA_256_sr50'],  # noqa: E501
+        'MMLongBench_512K': ['vrag_512_sr50', 'NIAH_512_sr25', 'ICL_512_sr50', 'summ_512_sr50', 'documentQA_512_sr50'],  # noqa: E501
     }
 
-    def __init__(self, dataset, **kwargs):
-        self.model_list = list(self.SUPPORTED_MODELS.keys())
-        model_name = kwargs['model']
-        if not listinstr(self.model_list, model_name):
-            raise AssertionError("{} doesn't support the evaluation on MMLongBench_DOC.".format(model_name))
-        super(MMLongBench, self).__init__(dataset)
+    DEFAULT_ANSWER = [0, 1, 1, 0]
+    IMAGE_ARCHIVES = {
+        'MMLongBench_32K': ['vlmevalkit/MMLongBench_32K_images.tar.gz'],
+        'MMLongBench_128K': ['vlmevalkit/MMLongBench_128K_images.tar.gz'],
+        'MMLongBench_256K': ['vlmevalkit/MMLongBench_256K_images.tar.gz'],
+        'MMLongBench_512K': ['vlmevalkit/MMLongBench_512K_images.tar.gz'],
+    }
 
-        self.is_api = True if listinstr(['GPT4'], model_name) else False
-        self.max_pages = 120
-        concat_num, column_num = self.SUPPORTED_MODELS.get(model_name)
-        self.concat_num = concat_num
-        self.column_num = column_num
-
-    def dump_image(self, origin_line):
-        os.makedirs(self.img_root, exist_ok=True)
-        try:
-            import fitz
-        except Exception as e:
-            logging.critical(f'{type(e)}: {e}')
-            logging.critical('Please use `pip install pymupdf` to parse PDF files.')
-
-        line = origin_line.copy()
-        line['image_path'] = line['image_path'][:self.max_pages]
-        skip_pdf_parse = True
-        for im_name in line['image_path']:
-            path = osp.join(self.img_root, im_name)
-            if not read_ok(path):
-                skip_pdf_parse = False
-                break
-
-        # Just for being compatible with the zooped loop: zip(line['image'], line['image_path'])
-        if skip_pdf_parse:
-            line['image'] = line['image_path']
-        else:
-            pdf_data = base64.b64decode(line['image'])
-            pdf_file = io.BytesIO(pdf_data)
-            encoded_images = []
-            with fitz.open(stream=pdf_file, filetype='pdf') as doc:
-                doc = doc[:self.max_pages]
-                for page in doc:
-                    image = page.get_pixmap(dpi=144)
-                    image_file = io.BytesIO(image.tobytes(output='png'))
-                    image = Image.open(image_file)
-                    encoded_image = encode_image_to_base64(image)
-                    encoded_images.append(encoded_image)
-            line['image'] = encoded_images
-            print('process {}'.format(line['doc_id']))
-
-        if 'image' in line:
-            if isinstance(line['image'], list):
-                tgt_path = []
-                assert 'image_path' in line
-                for img, im_name in zip(line['image'], line['image_path']):
-                    path = osp.join(self.img_root, im_name)
-                    if not read_ok(path):
-                        decode_base64_to_image_file(img, path)
-                    tgt_path.append(path)
-            else:
-                tgt_path = osp.join(self.img_root, f"{line['index']}.jpg")
-                if not read_ok(tgt_path):
-                    decode_base64_to_image_file(line['image'], tgt_path)
-                tgt_path = [tgt_path]
-        else:
-            assert 'image_path' in line
-            tgt_path = toliststr(line['image_path'])
-
-        if self.concat_num > 0 and not self.is_api:
-            concatenated_images = concat_images(tgt_path, max_concat=self.concat_num, column_num=self.column_num)
-
-            old_tgt_path = tgt_path
-            assert isinstance(old_tgt_path, list)
-            if self.column_num != -1:
-                tgt_path = [
-                    '_'.join(old_tgt_path[0].split('_')[:-1]) + '_concat{}_{}.jpg'.format(self.concat_num, i)
-                    for i in range(len(concatenated_images))
-                ]
-            else:
-                tgt_path = [
-                    '_'.join(old_tgt_path[0].split('_')[:-1]) + '_concat_all_{}.jpg'.format(i)
-                    for i in range(len(concatenated_images))
-                ]
-
-            for path, concatenated_image in zip(tgt_path, concatenated_images):
-                if not read_ok(path):
-                    decode_base64_to_image_file(encode_image_to_base64(concatenated_image), path)
-                    num_images, image_size = len(old_tgt_path), concatenated_image.size
-                    print('concat {} images to a new one with size {}. save at {}'.format(num_images, image_size, path))
-        return tgt_path
+    def __init__(self, dataset='MMLongBench_32K', **kwargs):
+        super().__init__(dataset=dataset, skip_noimg=False)
+        if os.environ.get('MMLB_AUTO_DOWNLOAD_IMAGES', '1') == '1':
+            self.prepare_images()
 
     @classmethod
-    def evaluate(self, eval_file, **judge_kwargs):
-        model = judge_kwargs['model']
+    def supported_datasets(cls):
+        return list(cls.DATASET_SETS)
 
-        storage = get_intermediate_file_path(eval_file, f'_{model}')
-        tmp_file = get_intermediate_file_path(eval_file, f'_{model}', 'pkl')
+    @staticmethod
+    def _parse_extra_info(extra_info):
+        if isinstance(extra_info, dict):
+            return extra_info
+        if isinstance(extra_info, str) and extra_info.strip():
+            try:
+                return json.loads(extra_info)
+            except Exception:
+                return {}
+        return {}
 
-        if osp.exists(storage):
-            logger.warning(f'GPT scoring file {storage} already exists, will reuse it in MMLongBench_eval. ')
-        else:
-            data = load(eval_file)
-            model = build_judge(max_tokens=128, **judge_kwargs)
-            lt = len(data)
-            lines = [data.iloc[i] for i in range(lt)]
-            tups = [(model, line) for line in lines]
-            indices = [line['index'] for line in lines]
+    @staticmethod
+    def _json_dumps(value):
+        return json.dumps(value, ensure_ascii=False)
 
-            ans = {}
-            if osp.exists(tmp_file):
-                ans = load(tmp_file)
-            tups = [x for x, i in zip(tups, indices) if i not in ans]
-            indices = [i for i in indices if i not in ans]
+    @classmethod
+    def _standard_tsv_path(cls, dataset):
+        root = os.environ.get('MMLB_TSV_ROOT', LMUDataRoot())
+        return osp.join(root, f'{dataset}.tsv')
 
-            if len(indices):
-                new_results = list()
-                for model, line in tqdm(tups):
-                    res = MMLongBench_auxeval(model, line)
-                    new_results.append(res)
+    @classmethod
+    def _normalize_tsv_data(cls, data):
+        if 'image_path' in data:
+            data['image_path'] = [toliststr(x) for x in data['image_path']]
+        if 'extra_info' in data:
+            data['extra_info'] = [
+                cls._json_dumps(cls._parse_extra_info(x)) for x in data['extra_info']
+            ]
+        return data
 
-            log_map, res_map, pred_map = {}, {}, {}
-            all_inds = [line['index'] for line in lines]
-            for k, v in zip(all_inds, new_results):
-                log_map[k] = v['log']
-                res_map[k] = v['res']
-                pred_map[k] = v['pred']
-            data['res'] = [res_map[idx] for idx in data['index']]
-            data['log'] = [log_map[idx] for idx in data['index']]
-            data['pred'] = [pred_map[idx] for idx in data['index']]
-            dump(data, storage)
+    def load_data(self, dataset):
+        if dataset not in self.DATASET_SETS:
+            raise KeyError(f'Unsupported MMLongBench split: {dataset}')
 
-        score = MMLongBench_acc(storage)
-        score_pth = get_intermediate_file_path(storage, '_score', 'csv')
+        tsv_path = self._standard_tsv_path(dataset)
+        if osp.exists(tsv_path):
+            return self._normalize_tsv_data(load(tsv_path))
 
-        dump(score, score_pth)
-        logger.info(f'MMLongBench_eval successfully finished evaluating {eval_file}, results saved in {score_pth}')
-        logger.info('Score: ')
-        logger.info(score)
+        url = self.DATASET_URL.get(dataset, '')
+        if url:
+            file_md5 = self.DATASET_MD5.get(dataset, None)
+            return self._normalize_tsv_data(self.prepare_tsv(url, file_md5))
+
+        raise FileNotFoundError(
+            f'MMLongBench requires a standard TSV file for {dataset}. '
+            f'Expected local file: {tsv_path}. '
+            'Alternatively, publish the TSV and set MMLongBench.DATASET_URL/MD5.'
+        )
+
+    @staticmethod
+    def _safe_extract(tar, path):
+        root = osp.abspath(path)
+        for member in tar.getmembers():
+            target = osp.abspath(osp.join(root, member.name))
+            if not (target == root or target.startswith(root + os.sep)):
+                raise RuntimeError(f'Unsafe path in tar archive: {member.name}')
+        tar.extractall(root)
+
+    @staticmethod
+    def _tar_has_top_level_mmlb_image(tar_path):
+        with tarfile.open(tar_path, 'r:gz') as tar:
+            for member in tar.getmembers():
+                name = member.name.lstrip('./')
+                if not name:
+                    continue
+                return name.split('/', 1)[0] == 'mmlb_image'
+        return False
+
+    @classmethod
+    def _extract_image_archive(cls, tar_path, output_root):
+        has_root = cls._tar_has_top_level_mmlb_image(tar_path)
+        extract_root = output_root if has_root else osp.join(output_root, 'mmlb_image')
+        os.makedirs(extract_root, exist_ok=True)
+        with tarfile.open(tar_path, 'r:gz') as tar:
+            cls._safe_extract(tar, extract_root)
+
+    @classmethod
+    def _download_image_archive(cls, filename, download_dir):
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as err:
+            raise ImportError(
+                'huggingface_hub is required to auto-download MMLongBench images. '
+                'Install it with `pip install huggingface_hub`, or set '
+                'MMLB_AUTO_DOWNLOAD_IMAGES=0 and prepare $LMUData/images/mmlb_image manually.'
+            ) from err
+
+        return hf_hub_download(
+            repo_id=cls.HF_REPO_ID,
+            filename=filename,
+            repo_type='dataset',
+            local_dir=download_dir,
+            token=os.environ.get('HF_TOKEN'),
+        )
+
+    def _image_ready(self):
+        if 'image_path' not in self.data:
+            return True
+        checked = 0
+        for _, line in self.data.iterrows():
+            for image_path in toliststr(line['image_path']):
+                checked += 1
+                if not osp.exists(self._resolve_image_path(line, image_path)):
+                    return False
+                if checked >= 32:
+                    return True
+        return True
+
+    def prepare_images(self):
+        if self._image_ready():
+            return
+
+        logger = get_logger('MMLongBench')
+        output_root = osp.join(LMUDataRoot(), 'images')
+        download_dir = osp.join(output_root, 'mmlb_image_downloads')
+        os.makedirs(download_dir, exist_ok=True)
+        logger.warning(
+            'MMLongBench images are missing. Downloading official image archives from Hugging Face. '
+            'This can take a long time and requires substantial disk space.'
+        )
+        for archive in self.IMAGE_ARCHIVES.get(self.dataset_name, []):
+            tar_path = self._download_image_archive(archive, download_dir)
+            self._extract_image_archive(tar_path, output_root)
+
+        if not self._image_ready():
+            raise FileNotFoundError(
+                f'MMLongBench images are still missing after extraction. '
+                f'Expected images under {osp.join(output_root, "mmlb_image")}.'
+            )
+
+    def _resolve_image_path(self, line, image_path):
+        if osp.isabs(image_path):
+            return image_path
+        subset = line.get('mmlb_subset', '')
+        length = self.dataset_name.rsplit('_', 1)[-1]
+        env_img_root = os.environ.get('MMLB_IMAGE_ROOT', '')
+        candidates = [
+            osp.join(env_img_root, length, image_path) if env_img_root else '',
+            osp.join(env_img_root, image_path) if env_img_root else '',
+            osp.join(self.img_root, length, image_path),
+            osp.join(self.img_root, image_path),
+            osp.join(LMUDataRoot(), 'images', 'mmlb_image', length, image_path),
+            osp.join(LMUDataRoot(), 'images', 'mmlb_image', image_path),
+            osp.join(LMUDataRoot(), 'images', self.dataset_name, image_path),
+            osp.join(LMUDataRoot(), 'images', subset, image_path),
+            osp.join(LMUDataRoot(), 'images', 'MMLongBench', subset, image_path),
+            osp.join(LMUDataRoot(), 'images', 'MMLongBench', image_path),
+        ]
+        for candidate in candidates:
+            if candidate and osp.exists(candidate):
+                return candidate
+        return candidates[1]
+
+    def dump_image(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+        images = toliststr(line['image_path']) if 'image_path' in line else []
+        return [self._resolve_image_path(line, p) for p in images]
+
+    @staticmethod
+    def _append_text(msgs, text):
+        if text:
+            msgs.append(dict(type='text', value=text))
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        images = self.dump_image(line)
+        text = str(line['question'])
+        token_pattern = r'(<image token>|<image>)'
+        parts = re.split(token_pattern, text)
+        msgs = []
+        image_idx = 0
+
+        for part in parts:
+            if part in ['<image token>', '<image>']:
+                if image_idx < len(images):
+                    msgs.append(dict(type='image', value=images[image_idx]))
+                    image_idx += 1
+            else:
+                self._append_text(msgs, part)
+
+        if image_idx == 0 and images:
+            msgs = [dict(type='image', value=p) for p in images] + msgs
+        elif image_idx < len(images):
+            msgs.extend(dict(type='image', value=p) for p in images[image_idx:])
+
+        return [m for m in msgs if m['value']]
+
+    @staticmethod
+    def _metric_for(row):
+        task = row['task']
+        source = row.get('source_dataset', '')
+        if task == 'vrag':
+            return 'sub_em'
+        if task == 'NIAH':
+            if source.startswith('vh_'):
+                return 'binary_acc'
+            if 'counting' in source:
+                return 'soft_acc'
+            if 'retrieval' in source or 'reasoning' in source:
+                # image variants are multiple-choice, text variants are open-ended
+                return 'mc_acc' if 'image' in source else 'sub_em'
+        if task == 'ICL':
+            return 'cls_acc'
+        if task == 'summ':
+            return 'rouge'
+        if task == 'documentQA':
+            return 'doc_qa_llm'
+        raise KeyError(f'Cannot infer MMLongBench metric for task={task}, source_dataset={source}')
+
+    @staticmethod
+    def _prefix_for(task):
+        if task == 'summ':
+            return 'Summary:'
+        if task == 'ICL':
+            return 'label:'
+        return 'Answer:'
+
+    @classmethod
+    def _score_one(cls, row, row_id, judge_model=None):
+        prediction = str(row.get('prediction', ''))
+        extra = cls._parse_extra_info(row.get('extra_info'))
+        # extra_info keeps the typed answer (int / list / str); the TSV column is stringified.
+        answer = extra.get('answer', row['answer'])
+        task = row['task']
+        prefix = cls._prefix_for(task)
+
+        # documentQA is always scored by the LLM judge (doc_qa_llm).
+        if task == 'documentQA':
+            if judge_model is None:
+                raise ValueError('documentQA requires an LLM judge for doc_qa_llm scoring.')
+            parsed = parse_output(prediction, prefix=prefix)
+            parsed_pred = parsed if parsed is not None else prediction
+            answer_format = extra.get('answer_format', 'String')
+            metric = 'doc_qa_llm'
+            extra_info = {
+                'llm_judge_client': judge_model,
+                'answer_format': answer_format,
+                'question': extra.get('question', ''),
+            }
+            try:
+                mets = calculate_metrics(parsed_pred, answer, 'doc_qa_llm', extra_info=extra_info)
+                judge_result = mets['doc_qa_llm']['judge_result']
+                mets = {
+                    'doc_qa_llm': float(mets['doc_qa_llm']['final_score']),
+                    'judge_raw': judge_result.get('raw_output', ''),
+                }
+            except Exception as err:
+                mets = {'doc_qa_llm': 0.0, 'metric_error': f'{type(err).__name__}: {err}'}
+
+            return metric, parsed_pred, mets
+
+        metric = cls._metric_for(row)
+
+        # binary_acc (visual haystack): uses the RAW prediction + a rotating default answer.
+        if metric == 'binary_acc':
+            default_answer = cls.DEFAULT_ANSWER[row_id % len(cls.DEFAULT_ANSWER)]
+            try:
+                mets = calculate_metrics((prediction, default_answer), answer, 'binary_acc')
+            except Exception as err:
+                mets = {'acc': 0, 'metric_error': f'{type(err).__name__}: {err}'}
+            return metric, prediction, mets
+
+        # default_post_process: score both the raw and parsed prediction, keep the max.
+        try:
+            mets = calculate_metrics(prediction, answer, metric)
+            parsed = parse_output(prediction, prefix=prefix)
+            if parsed is not None:
+                new_mets = calculate_metrics(parsed, answer, metric)
+                mets = {k: max(v, new_mets[k]) for k, v in mets.items()}
+            parsed_pred = parsed if parsed is not None else prediction
+        except Exception as err:
+            mets = {metric: 0.0, 'metric_error': f'{type(err).__name__}: {err}'}
+            parsed_pred = prediction
+        return metric, parsed_pred, mets
+
+    @staticmethod
+    def _mean(values):
+        return sum(values) / len(values) if values else 0.0
+
+    @staticmethod
+    def _score_key_for(metric):
+        if metric == 'rouge':
+            return 'rougeLsum_f1'
+        if metric == 'binary_acc':
+            return 'acc'
+        return metric
+
+    @classmethod
+    def evaluate(cls, eval_file, **judge_kwargs):
+        logger = get_logger('Evaluation')
+        data = load(eval_file)
+
+        # documentQA is scored only by an LLM judge (doc_qa_llm).
+        judge_model = None
+        has_docqa = 'task' in data.columns and (data['task'] == 'documentQA').any()
+        if has_docqa:
+            judge_name = judge_kwargs.get('model', None)
+            if judge_name is None:
+                raise ValueError('MMLongBench documentQA requires a judge model for doc_qa_llm scoring.')
+            else:
+                judge_model = build_judge(max_tokens=1024, **judge_kwargs)
+                if judge_model is None or (hasattr(judge_model, 'working') and not judge_model.working()):
+                    raise RuntimeError(f'Judge {judge_name} is not available for doc_qa_llm scoring.')
+
+        detail_rows = []
+        for row_id, (_, row) in enumerate(data.iterrows()):
+            jm = judge_model if row['task'] == 'documentQA' else None
+            metric, parsed_prediction, metric_res = cls._score_one(row, row_id, judge_model=jm)
+            detail = row.to_dict()
+            detail.pop('image_path', None)
+            detail['metric'] = metric
+            detail['parsed_prediction'] = parsed_prediction
+            for key, value in metric_res.items():
+                detail[key] = value
+            score_key = cls._score_key_for(metric)
+            detail['score'] = metric_res.get(score_key, 0.0)
+            detail_rows.append(detail)
+
+        detail = pd.DataFrame(detail_rows)
+        detail_file = get_intermediate_file_path(eval_file, '_mmlb_eval', 'tsv')
+        dump(detail, detail_file)
+
+        overall_scores = [float(x) for x in detail['score']]
+        overall_score = cls._mean(overall_scores)
+        rows = [{
+            'task': 'overall',
+            'metric': 'avg',
+            'num': len(overall_scores),
+            'score': overall_score,
+        }]
+        task_order = ['vrag', 'NIAH', 'ICL', 'summ', 'documentQA']
+        for task in task_order:
+            task_detail = detail[detail['task'] == task]
+            if len(task_detail) == 0:
+                continue
+            scores = [float(x) for x in task_detail['score']]
+            rows.append({
+                'task': task,
+                'metric': 'avg',
+                'num': len(scores),
+                'score': cls._mean(scores),
+            })
+
+        score = pd.DataFrame(rows)
+        score_file = get_intermediate_file_path(eval_file, '_score', 'csv')
+        dump(score, score_file)
+        logger.info(f'MMLongBench evaluation finished for {eval_file}; scores saved to {score_file}')
+        return score

--- a/vlmeval/dataset/mmlongbenchdoc.py
+++ b/vlmeval/dataset/mmlongbenchdoc.py
@@ -1,0 +1,594 @@
+import base64
+import io
+import logging
+import math
+import os
+import os.path as osp
+import re
+from urllib.request import urlopen
+
+import pandas as pd
+import torchvision.transforms as transforms
+from PIL import Image, ImageDraw, ImageFont
+from tqdm import tqdm
+
+from vlmeval.dataset.utils import build_judge, levenshtein_distance
+from vlmeval.smp import (decode_base64_to_image_file, dump, encode_image_to_base64,
+                         get_intermediate_file_path, get_logger, listinstr, load, read_ok,
+                         toliststr)
+from .image_base import ImageBaseDataset
+
+logger = get_logger(__name__)
+
+FAIL_MSG = 'Failed to obtain answer via API.'
+
+
+def get_gpt4_ICE():
+    example_1 = """
+---
+Question: List the primary questions asked about the services in this report.
+Analysis:  The primary questions asked about the services in the report for The Limes Residential Home are:\n\n
+1. Is the service safe?\n
+2. Is the service effective?\n
+3. Is the service caring?\n
+4. Is the service responsive?\n
+5. Is the service well-led?
+Extracted answer: [
+    'Is the servife safe?',
+    'Is the service effective',
+    'Is the serve caring?',
+    'Is the service responsive?',
+    'Is the service well-led?'
+]
+Answer format: List\n
+"""
+
+    example_2 = """
+---
+Question: How many regulations of the HSCA 2008 are breached in all according to this report?
+Analysis: According to the report, the provider breached 10 Health and Social Care Act 2008 (Regulated Activities)
+Regulations in total. Here are the specifics:\n\n1. Regulation 13: Safeguarding service users from abuse and
+improper treatment\n2. Regulation 12: Safe care and treatment\n3. Regulation 18: Staffing\n4. Regulation 11:
+Need for consent\n5. Regulation 10: Dignity and respect\n6. Regulation 9: Person-centred care\n7. Regulation 17:
+Good governance\n8. Regulation 18 (CQC Registration Regulations 2009): Notification of other incidents\n9.
+Regulation 18: Failure to maintain an accurate and up-to-date care plan\n10. Regulation 11: Failure to implement
+the Mental Capacity Act 2005 code of practice effectively\n\nThese breaches involve issues concerning staffing,
+safeguarding, medicines management, dignity and respect, consent, care planning, governance, and failure to
+notify the CQC of incidents.
+Extracted answer: 10
+Answer format: Integer\n
+"""
+
+    example_3 = """
+---
+Question: According to the survey that is the percentage of Chinese who are paying more or
+about the same attention to politics after Trump's election?
+Analysis: The survey provided does not specify the percentage of Chinese individuals specifically who are paying
+more or about the same attention to politics after Trump's election. The report focuses primarily on American
+demographics and does not include specific details about the Chinese population in relation to this question. If
+you need information about a different demographic or a summary of the findings from the American demographic,
+I can certainly help with that!
+Extracted answer: Not answerable
+Answer format: String\n
+"""
+
+    example_4 = """
+---
+Question: How many quotations from male respondent over 50 years old are included in this report?
+Analysis: The image you've provided appears to be a screenshot of a document with multiple charts. However, the
+text is too small and blurry to read accurately. If you can provide a clearer image or more context, I might be
+able to help you with your question.
+Extracted answer: Fail to answer
+Answer format: String\n
+"""
+
+    return [example_1, example_2, example_3, example_4]
+
+
+def build_mmlongbench_gpt4_prompt(line):
+    task_description = """
+Given the question and analysis, you are tasked to extract answers with required formats from the free-form analysis.
+- Your extracted answers should be one of the following formats: (1) Integer, (2) Float, (3) String and (4) List.
+If you find the analysis the question can not be answered from the given documents, type "Not answerable".
+Exception: If the analysis only tells you that it can not read/understand the images or documents,
+type "Fail to answer".
+- Please make your response as concise as possible. Also note that your response should be formatted as below:
+```
+Extracted answer: [answer]
+Answer format: [answer format]
+```
+Please read the following example, then extract the answer from the model response
+and type it at the end of the prompt.\n
+"""
+    question = line['question']
+    prediction = str(line['prediction'])
+    prompt = task_description
+    examples = get_gpt4_ICE()
+    for example in examples:
+        prompt += example
+    prompt += '---\nQuestion:' + question + '\n'
+    prompt += 'Analysis: ' + prediction
+    return prompt
+
+
+def anls_compute(groundtruth, prediction, threshold=0.5):
+    dist = levenshtein_distance(groundtruth, prediction)
+    length = max(len(groundtruth.upper()), len(prediction.upper()))
+    value = 0.0 if length == 0 else float(dist) / float(length)
+    anls = 1.0 - value
+    if anls <= threshold:
+        anls = 0.0
+    return anls
+
+
+def is_float_equal(reference, prediction, include_percentage: bool = False, is_close: float = False) -> bool:
+    def get_precision(gt_ans: float) -> int:
+        precision = 3
+        if '.' in str(gt_ans):
+            precision = len(str(gt_ans).split('.')[-1])
+        return precision
+
+    reference = float(str(reference).strip().rstrip('%').strip())
+    try:
+        prediction = float(str(prediction).strip().rstrip('%').strip())
+    except Exception:
+        return False
+
+    if include_percentage:
+        gt_result = [reference / 100, reference, reference * 100]
+    else:
+        gt_result = [reference]
+    for item in gt_result:
+        try:
+            if is_close:
+                if math.isclose(item, prediction, rel_tol=0.01):
+                    return True
+            precision = max(min(get_precision(prediction), get_precision(item)), 2)
+            if round(prediction, precision) == round(item, precision):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def get_clean_string(s):
+    s = str(s).lower().strip()
+    if s.endswith('mile'):
+        s.rstrip('mile').strip()
+    if s.endswith('miles'):
+        s.rstrip('miles').strip()
+    if s.endswith('million'):
+        s.rstrip('million').strip()
+    # remove parenthesis
+    s = re.sub(r'\s*\([^)]*\)', '', s).strip()
+    # remove quotes
+    s = re.sub(r"^['\"]|['\"]$", '', s).strip()
+    s = s.strip().lstrip('$').strip()
+    s = s.strip().rstrip('%').strip()
+    return s
+
+
+def is_exact_match(s):
+    flag = False
+    # Website
+    if 'https://' in s:
+        flag = True
+    # code file
+    if s.endswith('.py') or s.endswith('ipynb'):
+        flag = True
+    if s.startswith('page'):
+        flag = True
+    # telephone number
+    if re.fullmatch(r'\b\d+(-\d+|\s\d+)?\b', s):
+        flag = True
+    # time
+    if 'a.m.' in s or 'p.m.' in s:
+        flag = True
+    # YYYY-MM-DD
+    if re.fullmatch(r'\b\d{4}[-\s]\d{2}[-\s]\d{2}\b', s):
+        flag = True
+    # YYYY-MM
+    if re.fullmatch(r'\b\d{4}[-\s]\d{2}\b', s):
+        flag = True
+    # Email address
+    if re.fullmatch(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}', s):
+        flag = True
+    return flag
+
+
+def isfloat(num):
+    try:
+        float(num)
+        return True
+    except ValueError:
+        return False
+
+
+def get_font():
+    try:
+        truetype_url = "https://opencompass.openxlab.space/utils/Fonts/SimHei.ttf"
+        ff = urlopen(truetype_url)
+        font = ImageFont.truetype(ff, size=40)
+    except Exception as e:
+        logging.warning(f'{type(e)}: {e}')
+        logging.warning("Fail to download the font. Use the default one.")
+        font = ImageFont.load_default(size=40)
+    return font
+
+
+def frame2img(img_path_list, font, save_path=None, idx_start=0):
+    imgs = [Image.open(img_path) for img_path in img_path_list]
+
+    new_imgs = []
+    for img in imgs:
+        w, h = img.size
+        scale = w / h
+        if w > h:
+            new_w = 560 * 2
+            new_h = int(560 * 2 / scale)
+        else:
+            new_w = int(560 * 2 * scale)
+            new_h = 560 * 2
+        img = transforms.functional.resize(img, [new_h, new_w],)
+        new_imgs.append(img)
+    imgs = new_imgs
+    new_w = 0
+    new_h = 0
+    pad = 40
+    if w > h:
+        for im in imgs:
+            w, h = im.size
+            new_w = max(new_w, w)
+            new_h += h + 10 + pad
+        new_img = Image.new("RGB", (new_w, new_h), "white")
+        draw = ImageDraw.Draw(new_img)
+        curr_h = 0
+        for idx, im in enumerate(imgs):
+            w, h = im.size
+            new_img.paste(im, (0, pad + curr_h))
+            draw.text((0, curr_h), f"<IMAGE {idx + idx_start}>", font=font, fill="black")
+            if idx + 1 < len(imgs):
+                draw.line([(0, pad + curr_h + h + 5), (new_w, pad + curr_h + h + 5)], fill='black', width=2)
+            curr_h += h + 10 + pad
+    else:
+        for im in imgs:
+            w, h = im.size
+            new_w += w + 10
+            new_h = max(new_h, h)
+        new_h += pad
+        new_img = Image.new('RGB', (new_w, new_h), 'white')
+        draw = ImageDraw.Draw(new_img)
+        curr_w = 0
+        for idx, im in enumerate(imgs):
+            w, h = im.size
+            new_img.paste(im, (curr_w, pad))
+            draw.text((curr_w, 0), f"<IMAGE {idx + idx_start}>", font=font, fill='black')
+            if idx + 1 < len(imgs):
+                draw.line([(curr_w + w + 5, 0), (curr_w + w + 5, new_h)], fill='black', width=2)
+            curr_w += w + 10
+
+    if save_path is not None:
+        new_img.save(save_path)
+
+    return new_img
+
+
+def concat_images(image_list, max_concat=1, column_num=1):
+    concatenated_images = []
+    if column_num == -1:
+        MAX_COLUMN_NUM = 20
+        max_concat = 1
+        while len(image_list) / max_concat > MAX_COLUMN_NUM:
+            max_concat += 1
+        interval = max(math.ceil(len(image_list) / max_concat), 1)
+        for i in range(0, len(image_list), interval):
+            batch_images = image_list[i:i + interval]
+            concatenated_image = frame2img(batch_images, font=get_font(), idx_start=i)
+            concatenated_images.append(concatenated_image)
+    else:
+        interval = max(math.ceil(len(image_list) / max_concat), 1)
+        for i in range(0, len(image_list), interval):
+            batch_images = [Image.open(filename) for filename in image_list[i:i + interval]]
+            if column_num == 1:
+                total_height = batch_images[0].height * len(batch_images)
+            else:
+                total_height = batch_images[0].height * ((len(batch_images) - 1) // column_num + 1)
+            concatenated_image = Image.new('RGB', (batch_images[0].width * column_num, total_height), 'white')
+
+            x_offset, y_offset = 0, 0
+            for count, image in enumerate(batch_images):
+                concatenated_image.paste(image, (x_offset, y_offset))
+                x_offset += image.width
+                if (count + 1) % column_num == 0:
+                    y_offset += image.height
+                    x_offset = 0
+            concatenated_images.append(concatenated_image)
+    return concatenated_images
+
+
+def eval_score(gt, pred, answer_type):
+    if answer_type == 'Int':
+        try:
+            gt, pred = int(gt), int(float(pred))
+        except Exception:
+            pred = ''
+        score = (gt == pred)
+    elif answer_type == 'Float':
+        try:
+            gt = float(get_clean_string(str(gt)))
+            pred = float(get_clean_string(str(pred)))
+        except Exception:
+            pred = ''
+        score = is_float_equal(gt, pred, include_percentage=True, is_close=True)
+    elif answer_type == 'Str':
+        gt = get_clean_string(gt)
+        pred = get_clean_string(pred)
+        if is_exact_match(gt):
+            score = (gt == pred)
+        else:
+            score = anls_compute(gt, pred)
+    else:
+        if isinstance(gt, str) and gt.startswith('['):
+            gt = eval(gt)
+        if not isinstance(gt, list):
+            gt = [gt]
+        if isinstance(pred, str) and pred.startswith('['):
+            pred = eval(pred)
+        if not isinstance(pred, list):
+            pred = [pred]
+        print(len(gt), len(pred))
+        if len(gt) != len(pred):
+            score = 0.0
+        else:
+            gt = sorted([get_clean_string(a) for a in gt])
+            pred = sorted([get_clean_string(a) for a in pred])
+            print(gt, pred)
+            if isfloat(gt[0]) or is_exact_match(gt[0]):
+                score = ('-'.join(gt) == '-'.join(pred))
+            else:
+                score = min([anls_compute(gt_v, pred_v) for gt_v, pred_v in zip(gt, pred)])
+
+    return float(score)
+
+
+def MMLongBench_auxeval(model, line):
+    prompt = build_mmlongbench_gpt4_prompt(line)
+    log = ''
+    retry = 5
+
+    for i in range(retry):
+        prediction = line['prediction']
+        res = model.generate(prompt, temperature=i * 0.5)
+
+        if FAIL_MSG in res:
+            log += f'Try {i}: output is {prediction}, failed to parse.\n'
+        else:
+            log += 'Succeed'
+            try:
+                pred = res.split('Answer format:')[0].split('Extracted answer:')[1].strip()
+            except Exception:
+                pred = ''
+            return dict(log=log, res=res, pred=pred)
+    log += 'All 5 retries failed.\n'
+    return dict(log=log, res='', pred='')
+
+
+def get_f1(data):
+    gt_pos_data = data[data.apply(lambda k: k['answer'] != 'Not answerable', axis=1)]
+    pred_pos_data = data[data.apply(lambda k: k['pred'] != 'Not answerable', axis=1)]
+    recall = sum(gt_pos_data['score'].tolist()) / len(gt_pos_data)
+    precision = sum(pred_pos_data['score'].tolist()) / len(pred_pos_data)
+    return 2 * recall * precision / (recall + precision)
+
+
+def MMLongBench_acc(result_file):
+    data = load(result_file)
+    overall_score = 0.0
+    score_list = list()
+    for i in range(len(data)):
+        item = data.iloc[i]
+        try:
+            score = eval_score(item['answer'], item['pred'], item['answer_format'])
+        except Exception:
+            score = 0.0
+        score_list.append(score)
+        overall_score += score
+
+    data['score'] = score_list
+    dump(data, result_file)
+
+    data_chart = data[data.apply(lambda k: 'Chart' in eval(k['evidence_sources']), axis=1)]
+    data_table = data[data.apply(lambda k: 'Table' in eval(k['evidence_sources']), axis=1)]
+    data_image = data[data.apply(lambda k: 'Figure' in eval(k['evidence_sources']), axis=1)]
+    data_text = data[data.apply(lambda k: 'Pure-text (Plain-text)' in eval(k['evidence_sources']), axis=1)]
+    data_layout = data[data.apply(lambda k: 'Generalized-text (Layout)' in eval(k['evidence_sources']), axis=1)]
+
+    data_single = data[data.apply(lambda k: len(eval(k['evidence_pages'])) == 1, axis=1)]
+    data_multi = data[data.apply(lambda k: len(eval(k['evidence_pages'])) > 1, axis=1)]
+    data_unans = data[data.apply(lambda k: len(eval(k['evidence_pages'])) == 0, axis=1)]
+
+    res = dict()
+    res['category'] = [
+        'overall_f1', 'overall_acc', 'text', 'layout', 'table', 'chart',
+        'image', 'single-page', 'multi-page', 'unanswerable'
+    ]
+    res['num'] = [
+        len(data), len(data), len(data_text), len(data_layout), len(data_table),
+        len(data_chart), len(data_image), len(data_single), len(data_multi), len(data_unans)
+    ]
+    res['avg_score'] = [
+        get_f1(data),
+        overall_score / len(data),
+        sum(data_text['score'].tolist()) / len(data_text) if len(data_text) > 0 else 0.0,
+        sum(data_layout['score'].tolist()) / len(data_layout) if len(data_layout) > 0 else 0.0,
+        sum(data_table['score'].tolist()) / len(data_table) if len(data_table) > 0 else 0.0,
+        sum(data_chart['score'].tolist()) / len(data_chart) if len(data_chart) > 0 else 0.0,
+        sum(data_image['score'].tolist()) / len(data_image) if len(data_image) > 0 else 0.0,
+        sum(data_single['score'].tolist()) / len(data_single) if len(data_single) > 0 else 0.0,
+        sum(data_multi['score'].tolist()) / len(data_multi) if len(data_multi) > 0 else 0.0,
+        sum(data_unans['score'].tolist()) / len(data_unans) if len(data_unans) > 0 else 0.0,
+    ]
+    res = pd.DataFrame(res)
+    return res
+
+
+class MMLongBenchDoc(ImageBaseDataset):
+
+    TYPE = 'VQA'
+
+    DATASET_URL = {
+        'MMLongBench_DOC': 'https://opencompass.openxlab.space/utils/VLMEval/MMLongBench_DOC.tsv',
+    }
+    DATASET_MD5 = {
+        'MMLongBench_DOC': '75f5d29965d0db68254993f6170da7c2',
+    }
+
+    SUPPORTED_MODELS = {
+        'GPT4': (1, 1),
+        'GPT4V': (1, 1),
+        'GPT4V_HIGH': (1, 1),
+        'GPT4o': (1, 1),
+        'GPT4o_HIGH': (1, 1),
+        'GPT4o_MINI': (1, 1),
+        'MiniCPM-Llama3-V-2_5': (1, 5),
+        'InternVL-Chat-V1-5': (5, 2),
+        'XComposer2_4KHD': (1, 5),
+        'XComposer2d5': (1, -1),
+    }
+
+    def __init__(self, dataset, **kwargs):
+        self.model_list = list(self.SUPPORTED_MODELS.keys())
+        model_name = kwargs['model']
+        if not listinstr(self.model_list, model_name):
+            raise AssertionError("{} doesn't support the evaluation on MMLongBench_DOC.".format(model_name))
+        super(MMLongBenchDoc, self).__init__(dataset)
+
+        self.is_api = True if listinstr(['GPT4'], model_name) else False
+        self.max_pages = 120
+        concat_num, column_num = self.SUPPORTED_MODELS.get(model_name)
+        self.concat_num = concat_num
+        self.column_num = column_num
+
+    def dump_image(self, origin_line):
+        os.makedirs(self.img_root, exist_ok=True)
+        try:
+            import fitz
+        except Exception as e:
+            logging.critical(f'{type(e)}: {e}')
+            logging.critical('Please use `pip install pymupdf` to parse PDF files.')
+
+        line = origin_line.copy()
+        line['image_path'] = line['image_path'][:self.max_pages]
+        skip_pdf_parse = True
+        for im_name in line['image_path']:
+            path = osp.join(self.img_root, im_name)
+            if not read_ok(path):
+                skip_pdf_parse = False
+                break
+
+        # Just for being compatible with the zooped loop: zip(line['image'], line['image_path'])
+        if skip_pdf_parse:
+            line['image'] = line['image_path']
+        else:
+            pdf_data = base64.b64decode(line['image'])
+            pdf_file = io.BytesIO(pdf_data)
+            encoded_images = []
+            with fitz.open(stream=pdf_file, filetype='pdf') as doc:
+                doc = doc[:self.max_pages]
+                for page in doc:
+                    image = page.get_pixmap(dpi=144)
+                    image_file = io.BytesIO(image.tobytes(output='png'))
+                    image = Image.open(image_file)
+                    encoded_image = encode_image_to_base64(image)
+                    encoded_images.append(encoded_image)
+            line['image'] = encoded_images
+            print('process {}'.format(line['doc_id']))
+
+        if 'image' in line:
+            if isinstance(line['image'], list):
+                tgt_path = []
+                assert 'image_path' in line
+                for img, im_name in zip(line['image'], line['image_path']):
+                    path = osp.join(self.img_root, im_name)
+                    if not read_ok(path):
+                        decode_base64_to_image_file(img, path)
+                    tgt_path.append(path)
+            else:
+                tgt_path = osp.join(self.img_root, f"{line['index']}.jpg")
+                if not read_ok(tgt_path):
+                    decode_base64_to_image_file(line['image'], tgt_path)
+                tgt_path = [tgt_path]
+        else:
+            assert 'image_path' in line
+            tgt_path = toliststr(line['image_path'])
+
+        if self.concat_num > 0 and not self.is_api:
+            concatenated_images = concat_images(tgt_path, max_concat=self.concat_num, column_num=self.column_num)
+
+            old_tgt_path = tgt_path
+            assert isinstance(old_tgt_path, list)
+            if self.column_num != -1:
+                tgt_path = [
+                    '_'.join(old_tgt_path[0].split('_')[:-1]) + '_concat{}_{}.jpg'.format(self.concat_num, i)
+                    for i in range(len(concatenated_images))
+                ]
+            else:
+                tgt_path = [
+                    '_'.join(old_tgt_path[0].split('_')[:-1]) + '_concat_all_{}.jpg'.format(i)
+                    for i in range(len(concatenated_images))
+                ]
+
+            for path, concatenated_image in zip(tgt_path, concatenated_images):
+                if not read_ok(path):
+                    decode_base64_to_image_file(encode_image_to_base64(concatenated_image), path)
+                    num_images, image_size = len(old_tgt_path), concatenated_image.size
+                    print('concat {} images to a new one with size {}. save at {}'.format(num_images, image_size, path))
+        return tgt_path
+
+    @classmethod
+    def evaluate(self, eval_file, **judge_kwargs):
+        model = judge_kwargs['model']
+
+        storage = get_intermediate_file_path(eval_file, f'_{model}')
+        tmp_file = get_intermediate_file_path(eval_file, f'_{model}', 'pkl')
+
+        if osp.exists(storage):
+            logger.warning(f'GPT scoring file {storage} already exists, will reuse it in MMLongBench_eval. ')
+        else:
+            data = load(eval_file)
+            model = build_judge(max_tokens=128, **judge_kwargs)
+            lt = len(data)
+            lines = [data.iloc[i] for i in range(lt)]
+            tups = [(model, line) for line in lines]
+            indices = [line['index'] for line in lines]
+
+            ans = {}
+            if osp.exists(tmp_file):
+                ans = load(tmp_file)
+            tups = [x for x, i in zip(tups, indices) if i not in ans]
+            indices = [i for i in indices if i not in ans]
+
+            if len(indices):
+                new_results = list()
+                for model, line in tqdm(tups):
+                    res = MMLongBench_auxeval(model, line)
+                    new_results.append(res)
+
+            log_map, res_map, pred_map = {}, {}, {}
+            all_inds = [line['index'] for line in lines]
+            for k, v in zip(all_inds, new_results):
+                log_map[k] = v['log']
+                res_map[k] = v['res']
+                pred_map[k] = v['pred']
+            data['res'] = [res_map[idx] for idx in data['index']]
+            data['log'] = [log_map[idx] for idx in data['index']]
+            data['pred'] = [pred_map[idx] for idx in data['index']]
+            dump(data, storage)
+
+        score = MMLongBench_acc(storage)
+        score_pth = get_intermediate_file_path(storage, '_score', 'csv')
+
+        dump(score, score_pth)
+        logger.info(f'MMLongBench_eval successfully finished evaluating {eval_file}, results saved in {score_pth}')
+        logger.info('Score: ')
+        logger.info(score)

--- a/vlmeval/dataset/slidevqa.py
+++ b/vlmeval/dataset/slidevqa.py
@@ -12,7 +12,7 @@ from vlmeval.smp import (decode_base64_to_image_file, dump, encode_image_to_base
                          get_intermediate_file_path, get_logger, listinstr, load, read_ok,
                          toliststr)
 from .image_base import ImageBaseDataset
-from .mmlongbench import MMLongBench_auxeval, anls_compute, concat_images
+from .mmlongbenchdoc import MMLongBench_auxeval, anls_compute, concat_images
 
 logger = get_logger(__name__)
 

--- a/vlmeval/dataset/utils/mmlongbench_judge_prompt.py
+++ b/vlmeval/dataset/utils/mmlongbench_judge_prompt.py
@@ -1,0 +1,206 @@
+DOC_QA_JUDGE_PROMPT = """Now your role is a grading teacher. Your task is to review and score student answers based on reference standard answers. You need to notice the following key points:
+- First, extract the final answer from the student's solution, then analyze and judge whether the answer is correct.
+- Scoring should only refer to the final answer obtained by the student; there is no need to examine whether the intermediate problem-solving steps are correct.
+- When analyzing and judging whether the answer is correct, you need to write down the scoring rationale, organize it into clear statements that follow the logical flow. The summary of the scoring rationale should be placed at the end, using the following format: "In summary, the student's answer deserves x points" (where x represents the student's specific score).
+- Keep the whole process concise, within 150 words.
+- Provide the score based on your analysis and display it in a code block in "JSON" format.
+- An item is covered if it is strictly mentioned or unambiguously implied by a semantic equivalence. This includes numerical equivalence (e.g., 10% and 0.1), synonyms (e.g., UK and United Kingdom), and plural/singular forms (e.g., "apple" and "apples"). However, do not accept loosely related concepts.
+Your output format is:
+[Scoring Rationale]:
+[Score]: x points
+[JSON]:
+{"answer_score": <integer_value>}
+
+Below is the grading rubric:
+[Scores]:
+The scoring scale consists of 2 levels in total, from highest to lowest: 1 point, 0 points (the minimum is 0 points; if a situation arises where points need to be deducted beyond 0, simply assign 0 points).
+[Tier Details]:
+1 point: Assign 1 point if the student's final answer matches the standard answer.
+If the question has multiple sub-questions, all sub-questions must be answered correctly to assign 1 point.
+0 points:
+Assign 0 points if the student's final answer does not match the standard answer.
+
+[Example 1]
+<Question>: Based on Document 4153823, answer the following question. What is the total revenue for the organization?
+<Standard Answer>: 64933961
+<Student Answer>: Answer: 64,933,961.
+
+[Scoring Rationale]: The student's final conclusion is that the total revenue is 64,933,961.
+The standard answer is 64933961.
+The two numerical values are identical.
+In summary, the student's answer deserves 1 point.
+[Score]: 1 point
+[JSON]:
+{
+  "answer_score": 1
+}
+
+[Example 2]
+<Question>: Based on Document aguidetoindones, answer the following question. What is Indonesia's GDP in billions of dollars?
+<Standard Answer>: 868.3
+<Student Answer>: Answer: $868.3 billion
+
+[Scoring Rationale]: The student's final answer is "$868.3 billion".
+The standard answer is "868.3".
+While the student included the unit and currency symbol, the numerical value matches the standard answer exactly. As the question asks for the value in billions of dollars, the student's answer is semantically equivalent to the standard answer.
+In summary, the student's answer deserves 1 point.
+[Score]: 1 point
+[JSON]:
+{
+  "answer_score": 1
+}
+
+[Example 3]
+<Question>: Based on Document 4027862, answer the following question. What was the total retail value(in B$ million) of primary crops, livestock and agrifood processing in 2020 according to the target & trajectory data?
+<Standard Answer>: 470.85
+<Student Answer>: Answer: 470.86
+
+[Scoring Rationale]: The student's final answer is "470.86".
+The standard answer is "470.85".
+The student's answer does not match the standard answer numerically. Even though the difference is small, the values are not identical or semantically equivalent.
+In summary, the student's answer deserves 0 points.
+[Score]: 0 points
+[JSON]:
+{
+  "answer_score": 0
+}
+
+[Example 4]
+<Question>: Based on Document 21qualitymaker-, answer the following question. When did C/M Application take place?
+<Standard Answer>: SEP,10
+<Student Answer>: Answer: Sep,10 and Nov,10
+
+[Scoring Rationale]: The student's final answer is "Sep,10 and Nov,10".
+The standard answer is "SEP,10".
+Although the student included the correct date, they also provided an additional date ("Nov,10") that is not part of the standard answer. Therefore, the student's answer does not match the standard answer.
+In summary, the student's answer deserves 0 points.
+[Score]: 0 points
+[JSON]:
+{
+  "answer_score": 0
+}
+
+"""
+
+CURRENT_CASE_PROMPT = """[Current Case]
+<Question>: {question}
+<Standard Answer>: {reference}
+<Student Answer>: {prediction}
+
+"""
+ASSISTANT_PROMPT = """[Scoring Rationale]:"""
+
+
+DOC_QA_LIST_JUDGE_PROMPT = """Now your role is a grading teacher. Your task is to review and score student answers for LIST-style questions, where the standard answer is a list of required items. You need to notice the following key points:
+- Analyze and match required items against the student's full response
+- Scoring should only refer to the student's answer content; there is no need to examine whether the intermediate problem-solving steps are correct.
+- The standard answer is a JSON-like list of items with each item as one required element. Determine whether each item is covered by the student's answer content.
+- When analyzing and judging whether each item is covered by the student's answer content, you need to write down the scoring rationale, organize it into clear statements that follow the logical flow. The summary of the scoring rationale should be placed at the end, using the following format: "In summary, the student's answer covers x items" (where x represents the student's specific covered item count).
+- Keep the whole process concise, within 200 words.
+- Provide the covered item count based on your analysis and display it in a code block in "JSON" format.
+- An item is covered if it is strictly mentioned or unambiguously implied by a semantic equivalence. This includes numerical equivalence (e.g., 10% and 0.1), synonyms (e.g., UK and United Kingdom), and plural/singular forms (e.g., "apple" and "apples"). However, do not accept loosely related concepts.
+Your output format is:
+[Count Rationale]:
+[Count]: x
+[JSON]:
+{"count": [[count]]}
+
+[Example 1]
+<Question>: Based on Document 4041252, answer the following question. What are the three top finishes for the Foil Racing Model Freestyle Men's event at the Wind and Water National Kitesurfing Championships 2021?
+<Standard Answer>: ["Ahmed Talaat", "Ashraf Luxer", "Ahmed Shaker"]
+<Student Answer>: First place: Ahmed Talaat; Second place: Ashraf Luxer; Third place: Ahmed Shaker
+
+[Count Rationale]: The standard answer requires three items: "Ahmed Talaat", "Ashraf Luxer", and "Ahmed Shaker". The student's response lists "Ahmed Talaat" as first place, "Ashraf Luxer" as second place, and "Ahmed Shaker" as third place. All three required names are strictly mentioned in the student's answer. In summary, the student's answer covers 3 items.
+[Count]: 3
+[JSON]:
+{"count": [[3]]}
+
+[Example 2]
+<Question>: Based on Document digitalmeasurem, answer the following question. In the Slide that mentioned Qualitative vs Quantitative Measurement, what are the colors of the text "Qualitative" and the background color of it? Please list the colors in list with alphabetical order, e.g., ["black","red"]
+<Standard Answer>: ["black", "white"]
+<Student Answer>: Got it, let's look at the slide about Qualitative vs Quantitative Measurement. The text "Qualitative" is on a black background, and the text color is white. So the colors are black (background) and white (text). Now, list them in alphabetical order: black, white. The answer is ["black", "white"]
+
+[Count Rationale]: The standard answer requires two items: "black" and "white". The student's response explicitly identifies "black" (background) and "white" (text), and concludes with the correct list ["black", "white"]. Both required items are strictly mentioned and match the standard answer. In summary, the student's answer covers 2 items.
+[Count]: 2
+[JSON]:
+{"count": [[2]]}
+
+[Example 3]
+<Question>: Based on Document ddoseattle-1506, answer the following question. According to the chart "Levels of Analytics", what are the four business analystics activities?
+<Standard Answer>: ["OPTIMISATION", "PREDICTIVE MODELING", "FORECASTING", "STATISTICAL ANALYSIS"]
+<Student Answer>: Statistical Analysis, Forecasting, and Predictive Modelling
+
+[Count Rationale]: The standard answer requires four items: "OPTIMISATION", "PREDICTIVE MODELING", "FORECASTING", and "STATISTICAL ANALYSIS". The student's response covers "Statistical Analysis", "Forecasting", and "Predictive Modelling", but does not include "OPTIMISATION". These correspond to three of the four required items. In summary, the student's answer covers 3 items.
+[Count]: 3
+[JSON]:
+{"count": [[3]]}
+
+"""
+
+DOC_QA_LIST_F1_JUDGE_PROMPT = """Now your role is a grading teacher. Your task is to review and score student answers for LIST-style questions, where the standard answer is a list of required items.
+- First, extract the specific list of items from the <Student Answer>. Ignore conversational filler (e.g., "The answer is...").
+- Then, compare the [Extracted List] against the <Standard Answer> (Ground Truth).
+Here are some extra key points:
+- The standard answer is a JSON-like list of items with each item as one required element. Determine whether each item is covered by the student's answer list.
+- An item is covered if it is strictly mentioned or unambiguously implied by a semantic equivalence. This includes numerical equivalence (e.g., 10% and 0.1), synonyms (e.g., UK and United Kingdom), and plural/singular forms (e.g., "apple" and "apples"). However, do not accept loosely related concepts.
+- You need to write down the extraction and comparing rationale, organize it into clear statements that follow the logical flow. The summary of the rationale should be placed at the end, using the following format: "In summary, the student's answer list has X items, covering Y items from the reference list."
+- Keep the whole process concise, within 200 words.
+- Provide the student's answer item count and covered item count in a code block in "JSON" format.
+Your output format is:
+[Rationale]:
+[JSON]:
+{
+    "student_answer_count": <integer_value>,
+    "covered_count": <integer_value>
+}
+
+[Example 1]
+<Question>: Based on Document 4041252, answer the following question. What are the three top finishes for the Foil Racing Model Freestyle Men's event at the Wind and Water National Kitesurfing Championships 2021?
+<Standard Answer>: ["Ahmed Talaat", "Ashraf Luxer", "Ahmed Shaker"]
+<Student Answer>: First place: Ahmed Talaat; Second place: Ashraf Luxer; Third place: Ahmed Shaker
+
+[Rationale]: The standard answer requires three items: "Ahmed Talaat", "Ashraf Luxer", and "Ahmed Shaker".
+The student's response lists "Ahmed Talaat" as first place, "Ashraf Luxer" as second place, and "Ahmed Shaker" as third place. All three required names are strictly mentioned in the student's answer.
+In summary, the student's answer list has 3 items, covering 3 items from the reference list.
+[JSON]:
+{
+    "student_answer_count": 3,
+    "covered_count": 3
+}
+
+[Example 2]
+<Question>: Based on Document digitalmeasurem, answer the following question. In the Slide that mentioned Qualitative vs Quantitative Measurement, what are the colors of the text "Qualitative" and the background color of it? Please list the colors in list with alphabetical order, e.g., ["black","red"]
+<Standard Answer>: ["black", "white"]
+<Student Answer>: Got it, let's look at the slide about Qualitative vs Quantitative Measurement. The text "Qualitative" is on a black background, and the text color is white. So the colors are black (background) and white (text). Now, list them in alphabetical order: black, white. The answer is ["black", "white"]
+
+[Rationale]: The standard answer requires two items: "black" and "white".
+The student's response explicitly identifies "black" (background) and "white" (text), and concludes with the correct list ["black", "white"]. Both required items are strictly mentioned and match the standard answer.
+In summary, the student's answer list has 2 items, covering 2 items from the reference list.
+[JSON]:
+{
+    "student_answer_count": 2,
+    "covered_count": 2
+}
+
+[Example 3]
+<Question>: Based on Document ddoseattle-1506, answer the following question. According to the chart "Levels of Analytics", what are the four business analytics activities?
+<Standard Answer>: ["OPTIMISATION", "PREDICTIVE MODELING", "FORECASTING", "STATISTICAL ANALYSIS"]
+<Student Answer>: Statistical Analysis, Forecasting, Predictive Parameter
+
+[Rationale]: The reference list contains four required items: "OPTIMISATION", "PREDICTIVE MODELING", "FORECASTING", and "STATISTICAL ANALYSIS".
+The student's answer list includes three items: "Statistical Analysis", "Forecasting", and "Predictive Parameter". These correspond directly to two of the required items: "STATISTICAL ANALYSIS" and "FORECASTING". However, "Predictive Parameter" does not match or unambiguously imply "PREDICTIVE MODELING". The student also did not mention "OPTIMISATION". In summary, the student's answer list has 3 items, covering 2 items from the reference list.
+[JSON]:
+{
+    "student_answer_count": 3,
+    "covered_count": 2
+}
+
+"""
+
+CURRENT_LIST_CASE_PROMPT = """[Current Case]
+<Question>: {question}
+<Standard Answer>: {reference}
+<Student Answer>: {prediction}
+
+"""
+

--- a/vlmeval/dataset/utils/mmlongbench_metrics.py
+++ b/vlmeval/dataset/utils/mmlongbench_metrics.py
@@ -1,0 +1,561 @@
+"""
+Adopted from https://github.com/princeton-nlp/DensePhrases/blob/main/densephrases/utils/eval_utils.py
+"""
+
+import re
+import string
+import json
+import math
+import unicodedata
+from math import isclose
+from collections import Counter
+from rouge_score import rouge_scorer
+from functools import partial
+from tqdm import tqdm
+
+import torch
+import logging
+logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
+                    datefmt='%m/%d/%Y %H:%M:%S')
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def remove_articles(text):
+    return re.sub(r'\b(a|an|the)\b', ' ', text)
+
+
+def white_space_fix(text):
+    return ' '.join(text.split())
+
+
+def remove_punc(text):
+    exclude = set(string.punctuation)
+    return ''.join(ch for ch in text if ch not in exclude)
+
+
+def lower(text):
+    return text.lower()
+
+
+def normalize_answer(s):
+    return white_space_fix(remove_articles(remove_punc(lower(s))))
+
+
+def normalize_answer_with_punc(s):
+    return white_space_fix(remove_articles(lower(s)))
+
+
+def remove_citations(sent):
+    return re.sub(r"\[\d+", "", re.sub(r" \[\d+", "", sent)).replace(" |", "").replace("]", "")
+
+
+def f1_score(prediction, ground_truth):
+    normalized_prediction = normalize_answer(prediction)
+    normalized_ground_truth = normalize_answer(ground_truth)
+
+    ZERO_METRIC = (0, 0, 0)
+
+    prediction_tokens = normalized_prediction.split()
+    ground_truth_tokens = normalized_ground_truth.split()
+    common = Counter(prediction_tokens) & Counter(ground_truth_tokens)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return ZERO_METRIC
+    precision = 1.0 * num_same / len(prediction_tokens)
+    recall = 1.0 * num_same / len(ground_truth_tokens)
+    f1 = (2 * precision * recall) / (precision + recall)
+    return f1, precision, recall
+
+
+def drqa_normalize(text):
+    """Resolve different type of unicode encodings."""
+    return unicodedata.normalize('NFD', text)
+
+
+def drqa_exact_match_score(prediction, ground_truth):
+    """Check if the prediction is a (soft) exact match with the ground truth."""
+    return normalize_answer(prediction) == normalize_answer(ground_truth)
+
+
+def substring_exact_match_score(prediction, ground_truth):
+    """Check if the ground truth is a (soft) exact match substring of the prediction."""
+    return normalize_answer(ground_truth) in normalize_answer(prediction)
+
+
+def drqa_metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
+    """Given a prediction and multiple valid answers, return the score of
+    the best prediction-answer_n pair given a metric function.
+    """
+    # ground truth could be a string or a list of strings or a list of list of strings
+    if isinstance(ground_truths, str):
+        ground_truths = [ground_truths]
+    elif isinstance(ground_truths[0], list):
+        ground_truths = [ground_truth for ground_truths_list in ground_truths for ground_truth in ground_truths_list]
+
+    scores_for_ground_truths = []
+    for ground_truth in ground_truths:
+        score = metric_fn(prediction, ground_truth)
+        scores_for_ground_truths.append(score)
+    return max(scores_for_ground_truths)
+
+
+def get_max_memory():
+    """Get the maximum memory available for the current GPU for loading models."""
+    free_in_GB = int(torch.cuda.mem_get_info()[0]/1024**3)
+    max_memory = f'{free_in_GB-6}GB'
+    n_gpus = torch.cuda.device_count()
+    max_memory = {i: max_memory for i in range(n_gpus)}
+    return max_memory
+
+
+def get_top_tokens(logits, tokenizer, top_k=10):
+    """Get the top tokens and their probabilities from the logits."""
+    top_tokens = []
+    for logit in logits:
+        a, b = torch.topk(torch.softmax(logit, dim=-1), top_k, dim=-1)
+        l = [(y, f"{x*100:.02f}") for x, y in zip(a[0], tokenizer.convert_ids_to_tokens(b[0]))]
+        top_tokens.append(l)
+    return top_tokens
+
+
+def parse_output(output, prefix="Answer:"):
+    def lstrip_string(s, sub):
+        return re.sub(f'^{re.escape(sub)}', '', s, flags=re.IGNORECASE)
+    patterns = [re.compile(f"(?:{prefix})(.*)", flags=re.IGNORECASE | re.DOTALL),  # prefix + answer + sentence end
+                re.compile(r"(?:^)(.*)", flags=re.IGNORECASE | re.DOTALL)] # the beginning + answer + sentence end
+    for pat in patterns:
+        matches = pat.search(output)
+        if matches is not None:
+            return lstrip_string(matches[1].strip(), prefix).strip() # 0 index includes the non-capturing group # lstrip again because for chat models sometimes it will repeat the prefix
+    # if still not found, return None, but should actually never get this case...
+    return None
+
+
+def extract_binary_label(prediction):
+    prediction = normalize_answer_with_punc(prediction)
+    pattern = r"\b(?:yes|no)\b(?!.*\b(?:yes|no)\b)"
+
+    match = re.search(pattern, prediction, re.IGNORECASE | re.DOTALL)
+    label_map = {"yes": 1, "no": 0}
+    if match:
+        return label_map[match.group(0)]
+    else:
+        if prediction.strip().isdigit():
+            return int(prediction.strip())
+        return -1
+
+def turn_int_list(curr_list):
+    new_list = []
+    for item in curr_list:
+        try:
+            item = int(item)
+            new_list.append(item)
+        except:
+            pass
+    return new_list
+
+
+def extract_cnt_list(prediction):
+    prediction = normalize_answer_with_punc(prediction)
+
+    pattern1 = r'\[[\d\s,]+\]' # r'\[[\d\s,]+\](?!.*\[[\d\s,]+\])'
+    match = re.findall(pattern1, prediction, re.IGNORECASE | re.DOTALL)
+    if match:
+        try:
+            return json.loads(match[-1])
+        except json.JSONDecodeError:
+            pass
+
+    pattern2 = r'\[.*?\]' # r'\[.*?\](?!.*\[.*\])'
+    match = re.findall(pattern2, prediction, re.IGNORECASE | re.DOTALL)
+    if match:
+        try:
+            return turn_int_list(json.loads(match[-1]))
+        except json.JSONDecodeError:
+            pass
+
+    numbers = re.findall(r'\d+', prediction)
+    num_list = [int(x) for x in numbers]
+    return num_list
+
+
+def extract_choice_letter(prediction):
+    prediction = white_space_fix(prediction)
+    pattern1 = r"answer is \(?([A-J])\)?"
+    match = re.search(pattern1, prediction)
+    if match:
+        choice = match.group(1)
+        return ord(choice) - ord("A")
+
+    pattern2 = r'[aA]nswer:\s*([A-J])'
+    match = re.search(pattern2, prediction)
+    if match:
+        choice = match.group(1)
+        return ord(choice) - ord("A")
+
+    pattern3 = r"\b[A-J]\b(?!.*\b[A-J]\b)"
+    match = re.search(pattern3, prediction, re.DOTALL)
+    if match:
+        choice = match.group(0)
+        return ord(choice) - ord("A")
+
+    return -1
+
+
+def extract_class_num(prediction):
+    prediction = white_space_fix(prediction)
+    # pattern 1: "label: X" format
+    pattern1 = r"label:\s*(\d+)"
+    match = re.search(pattern1, prediction, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    # pattern 2: Last number in the text
+    pattern2 = r"\b(\d+)\b(?!.*\b\d+\b)"
+    match = re.search(pattern2, prediction)
+    if match:
+        return int(match.group(1))
+    # pattern 3: First number as fallback
+    numbers = re.findall(r'\d+', prediction)
+    if numbers:
+        return int(numbers[0])
+    return -1
+
+
+# NOTE: we replace soft_acc with the sum of a list for robust evaluation
+# NOTE: we still use the name soft_acc to distinguish it with other metrics in the code
+def get_soft_acc(prediction, answer):
+    return sum(prediction) == sum(answer)
+
+
+def get_docqa_clean_string(s):
+    s = str(s).lower().strip()
+    s = s.replace(",", "")
+
+    suffix_list = ["kg", "meters", "acres", "minutes", "miles", "mile",
+                   "feet",
+                   "million", "thousand", "billion", "mm", "m"]
+
+    for suffix in suffix_list:
+        s = re.sub(re.escape(suffix) + r'$', '', s).strip()
+
+    # remove parenthesis
+    # s = re.sub(r'\s*\([^)]*\)', "", s).strip()
+    # remove quotes
+    s = re.sub(r"^['\"]|['\"]$", "", s).strip()
+    s = s.strip().strip("$").strip()
+    s = s.strip().strip("£").strip()
+    s = s.strip().strip("%").strip()
+    return s
+
+
+def is_float_equal(reference, prediction, include_percentage=False) -> bool:
+    if include_percentage:
+        gt_result = [reference / 100, reference, reference * 100]
+    else:
+        gt_result = [reference]
+    for item in gt_result:
+        if isclose(item, prediction, rel_tol=0.01):
+            return True
+    return False
+
+
+def need_exact_match_check(s):
+    patterns = [
+        r'https://',
+        r'.*\.(py|ipynb)$',
+        r'^page',
+        r'^\d+(-\d+|\s\d+)?$',
+        r'(a\.m\.|p\.m\.)',
+        r'^\d{4}[-/\s]\d{1,2}[-/\s]\d{1,2}$',  # YYYY-MM-DD, YYYY/MM/DD
+        r'^\d{1,2}[-/\s]\d{1,2}[-/\s]\d{2,4}$',  # DD-MM-YYYY, MM/DD/YYYY
+        r'^\d{4}[-/\s]\d{1,2}$',  # YYYY-MM, YYYY/MM
+        r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    ]
+
+    return any(re.search(pattern, s) for pattern in patterns)
+
+
+def extract_number_list(pred):
+    pred_clean = pred.replace(',', '')
+    num_pattern = r'(-?\d+(\.\d*)?|-?\.\d+)' # r'-?(\d+(\.\d*)?|\.\d+)'
+    matches = re.findall(num_pattern, pred_clean)
+    numbers = []
+    for match_tuple in matches:
+        match = match_tuple[0]
+        try: # TODO filter inf number. Note this is added at the end of the experiment. previous is numers.append(float(match))
+            num = float(match)
+            if math.isfinite(num):
+                numbers.append(num)
+        except ValueError:
+            continue
+    return numbers
+
+
+def get_str_type(num_str):
+    try:
+        num = float(get_docqa_clean_string(num_str))
+        if num == int(num) and "%" not in num_str:
+            return "Integer"
+        else:
+            return "Float"
+    except:
+        return "String"
+
+
+def eval_docqa_score(gt, pred, answer_type):
+    if answer_type == "Integer":
+        gt = float(get_docqa_clean_string(str(gt)))
+        assert int(gt) == gt
+        gt = int(gt)
+        pred = get_docqa_clean_string(str(pred))
+        pred_num_list = [int(num) for num in extract_number_list(pred) if int(num) == num]
+        score = any(gt == pred_num for pred_num in pred_num_list)
+    elif answer_type == "Float":
+        gt = float(get_docqa_clean_string(str(gt)))
+        pred = get_docqa_clean_string(str(pred))
+        pred_num_list = extract_number_list(pred)
+        score = any(is_float_equal(gt, pred_num, include_percentage=True)
+                    for pred_num in pred_num_list)
+    elif answer_type in ["String", "None"]:
+        if need_exact_match_check(gt):
+            score = gt in pred
+        else:
+            score = f1_score(pred, gt)[0]
+    elif answer_type == "List":
+        gt_list = json.loads(gt)
+        # merge f1 score text to prevent low precision
+        merge_flag = [True if isinstance(item, str) and get_str_type(item) == "String" and not
+                              need_exact_match_check(item)
+                      else False for item in gt_list] # we merge all answers that are string and don't need EM for better recall
+        merged_str = " ".join([item for item, m_flag in zip(gt_list, merge_flag) if m_flag]).strip()
+        if merged_str:
+            new_gt_list = [merged_str] + [item for item, m_flag in zip(gt_list, merge_flag) if not m_flag]
+            gt_list = new_gt_list
+
+        gt_score_list = [] # This is the greedy score similar to that used in LongDocURL
+        for gt in gt_list:
+            assert not isinstance(gt, list)
+            if isinstance(gt, int):
+                gt_type = "Integer"
+            elif isinstance(gt, float):
+                gt_type = "Float"
+            else: # String answers can also represent int and float
+                gt_type = get_str_type(gt)
+            gt_score = eval_docqa_score(gt, pred, gt_type)
+            gt_score_list.append(gt_score)
+        score = sum(gt_score_list) / len(gt_list)
+    else:
+        raise KeyError("Wrong answer type:", answer_type)
+    return float(score)
+
+
+def parse_judge_output(model_output):
+    result = {
+        "scoring_rationale": "",
+        "score": None,
+        "json_data": None,
+        "raw_output": model_output
+    }
+
+    try:
+        rationale_match = re.search(r'\[Scoring Rationale\]:(.*?)(?=\[Score\]:|\[JSON\]:|$)',
+                                   model_output, re.DOTALL)
+        if rationale_match:
+            result["scoring_rationale"] = rationale_match.group(1).strip()
+    except Exception as e:
+        print(f"解析rationale错误: {e}")
+        result["scoring_rationale"] = None
+
+    try:
+        score_match = re.search(r'\[Score\]:\s*(\d+)\s*points?', model_output)
+        if score_match:
+            result["score"] = int(score_match.group(1))
+
+    except Exception as e:
+        print(f"解析score错误: {e}")
+        result["score"] = None
+
+    result["json_data"] = robust_json_extraction(model_output, ["answer_score"])
+
+    return result
+
+
+def parse_list_judge_output(model_output):
+    result = {
+        "rationale": "",
+        "json_data": None,
+        "raw_output": model_output
+    }
+    try:
+        rationale_match = re.search(r'\[Rationale\]:(.*?)(?=\[JSON\]:|$)',
+                                   model_output, re.DOTALL)
+        if rationale_match:
+            result["rationale"] = rationale_match.group(1).strip()
+    except Exception as e:
+        print(f"解析Rationale错误: {e}")
+        result["rationale"] = None
+
+    result["json_data"] = robust_json_extraction(model_output, ["student_answer_count", "covered_count"])
+    return result
+
+def robust_json_extraction(text, key_list):
+    try:
+        match = re.search(r'\[JSON\]:.*?(\{)', text, re.DOTALL)
+        if match:
+            start_index = match.start(1)
+            decoder = json.JSONDecoder()
+            obj, _ = decoder.raw_decode(text[start_index:])
+            return obj
+    except Exception as e:
+        print(f"标准JSON解析失败: {e}。将尝试按key列表进行正则匹配: {key_list}。")
+
+    extracted_data = {}
+    for key in key_list:
+        try:
+            pattern = rf'"{key}"\s*:\s*(-?\d+(?:\.\d+)?)'
+
+            match = re.search(pattern, text)
+            if match:
+                value_str = match.group(1)
+                extracted_data[key] = float(value_str)
+        except Exception as e:
+            print(f"按key列表正则匹配{key}时发生错误: {e}")
+
+    return extracted_data
+
+
+def cover_key(json_data, key_list):
+    for key in key_list:
+        if key not in json_data:
+            return False
+    return True
+
+
+from .mmlongbench_judge_prompt import DOC_QA_JUDGE_PROMPT, CURRENT_CASE_PROMPT
+from .mmlongbench_judge_prompt import DOC_QA_LIST_F1_JUDGE_PROMPT, CURRENT_LIST_CASE_PROMPT
+
+
+def eval_docqa_score_with_llm_judge(gt, pred, extra_info):
+    question = extra_info["question"]
+    prompt = DOC_QA_JUDGE_PROMPT + CURRENT_CASE_PROMPT.format(question=question, reference=gt, prediction=pred)
+    llm_judge_client = extra_info["llm_judge_client"]
+
+    response = llm_judge_client.generate(prompt)
+
+    judge_result = parse_judge_output(response)
+
+    if judge_result["score"] is not None:
+        score = judge_result["score"]
+    elif judge_result["json_data"] is not None and "answer_score" in judge_result["json_data"]:
+        score = judge_result["json_data"]["answer_score"]
+    else:
+        score = 0.0
+
+    return {"final_score": score, "judge_result": judge_result}
+
+
+def eval_docqa_list_score_with_llm_judge(gt, pred, extra_info):
+    question = extra_info["question"]
+    prompt = DOC_QA_LIST_F1_JUDGE_PROMPT + CURRENT_LIST_CASE_PROMPT.format(question=question, reference=gt, prediction=pred)
+    llm_judge_client = extra_info["llm_judge_client"]
+
+    response = llm_judge_client.generate(prompt)
+
+    judge_result = parse_list_judge_output(response)
+    if judge_result["json_data"] is not None and cover_key(judge_result["json_data"], ["student_answer_count", "covered_count"]):
+        student_answer_count = judge_result["json_data"]["student_answer_count"]
+        count = judge_result["json_data"]["covered_count"]
+        if count > 0:
+            recall = count / len(json.loads(gt))
+            precision = count / student_answer_count
+            score = max(min((2 * recall * precision) / (recall + precision), 1.0), 0.0)
+        else:
+            score = 0.0
+    else:
+        score = 0.0
+
+    return {"final_score": score, "judge_result": judge_result}
+
+
+def levenshtein_distance(s1, s2):
+    if len(s1) > len(s2):
+        s1, s2 = s2, s1
+
+    distances = range(len(s1) + 1)
+    for i2, c2 in tqdm(enumerate(s2), desc="iterating s2"):
+        distances_ = [i2 + 1]
+        for i1, c1 in enumerate(s1):
+            if c1 == c2:
+                distances_.append(distances[i1])
+            else:
+                distances_.append(1 + min((distances[i1], distances[i1 + 1], distances_[-1])))
+        distances = distances_
+    return distances[-1]
+
+
+def anls_compute(prediction, groundtruth, threshold=-1):
+    dist = levenshtein_distance(groundtruth, prediction)
+    length = max(len(groundtruth.upper()), len(prediction.upper()))
+    value = 0.0 if length == 0 else float(dist) / float(length)
+    anls = 1.0 - value
+    if anls<=threshold:
+        anls = 0.0
+    return anls
+
+
+r_scorer = rouge_scorer.RougeScorer(['rougeL', 'rougeLsum'], use_stemmer=True)
+def calculate_metrics(prediction, answers, metrics, extra_info=None):
+    metric_list = [m.strip() for m in metrics.split(",")]
+    metric_res = {}
+    if "sub_em" in metric_list:
+        sub_em = drqa_metric_max_over_ground_truths(substring_exact_match_score, prediction, answers)
+        metric_res["sub_em"] = sub_em
+
+    if "binary_acc" in metric_list:
+        prediction, default_answer = prediction
+        label = extract_binary_label(prediction)
+        if label == -1:
+            label = default_answer
+        gt_label = extract_binary_label(answers)
+        metric_res["acc"] = int(label == gt_label)
+
+    # NOTE: We replace soft_acc with the sum of a list for robust evaluation
+    # NOTE: We still use the name soft_acc to distinguish it with other metrics in the code
+    if "soft_acc" in metric_list:
+        cnt_list = extract_cnt_list(prediction)
+        metric_res["soft_acc"] = get_soft_acc(cnt_list, answers)
+
+    if "mc_acc" in metric_list:
+        choice = extract_choice_letter(prediction)
+        metric_res["mc_acc"] = int(choice == answers)
+
+    if "cls_acc" in metric_list:
+        class_num = extract_class_num(prediction)
+        metric_res["cls_acc"] = int(class_num == answers)
+
+    if "rouge" in metric_list:
+        if isinstance(answers, str):
+            answers = [answers]
+        elif isinstance(answers[0], list):
+            answers = [ground_truth for ground_truths_list in answers for ground_truth in ground_truths_list]
+
+        rouges = [r_scorer.score(target=a, prediction=prediction) for a in answers]
+        for k in r_scorer.rouge_types:
+            metric_res[k + "_f1"] = max([r[k].fmeasure for r in rouges])
+            metric_res[k + "_recall"] = max([r[k].recall for r in rouges])
+
+    if "doc_qa" in metric_list:
+        metric_res["doc_qa"] = eval_docqa_score(answers, prediction, extra_info["answer_format"])
+
+    if "doc_qa_llm" in metric_list:
+        if extra_info["answer_format"] == "List":
+            metric_res["doc_qa_llm"] = eval_docqa_list_score_with_llm_judge(answers, prediction, extra_info=extra_info)
+        else:
+            metric_res["doc_qa_llm"] = eval_docqa_score_with_llm_judge(answers, prediction, extra_info=extra_info)
+        print("judge finished")
+
+    if "anls" in metric_list:
+        metric_res["anls"] = anls_compute(prediction, answers, threshold=-1)
+
+    return metric_res

--- a/vlmeval/tools.py
+++ b/vlmeval/tools.py
@@ -450,6 +450,10 @@ def EVAL(dataset_name, data_file, **kwargs):
             judge_kwargs['model'] = 'chatgpt-0125'
         elif listinstr(['MMVet', 'LLaVABench', 'MMBench-Video'], dataset_name):
             judge_kwargs['model'] = 'gpt-4-turbo'
+        elif listinstr(
+            ['MMLongBench_32K', 'MMLongBench_128K', 'MMLongBench_256K', 'MMLongBench_512K'], dataset_name
+        ):
+            judge_kwargs['model'] = 'gpt-5.5-2026-04-24'
         elif listinstr(['MMLongBench', 'MMDU'], dataset_name):
             judge_kwargs['model'] = 'gpt-4o'
         elif listinstr(['DynaMath', 'MathVerse', 'MathVista', 'MathVision'], dataset_name):


### PR DESCRIPTION
## Summary

This PR adds support for the new long-context MMLongBench benchmark.

- Move the original document-image MMLongBench implementation from `mmlongbench.py` to `mmlongbenchdoc.py`, and register it as `MMLongBenchDoc`.
- Add the new long-context `MMLongBench` implementation in `mmlongbench.py`, including scoring metrics and LLM-judge prompts.
- Support lengths beyond 128K: `MMLongBench_32K`, `MMLongBench_128K`, `MMLongBench_256K`, and `MMLongBench_512K`.
- Add public data preparation scripts to build VLMEvalKit TSVs from the released Hugging Face raw data and reference TSV IDs/order.
- Release the public VLMEvalKit TSVs at [https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/tree/main/vlmevalkit](https://huggingface.co/datasets/ZhaoweiWang/MMLongBench/tree/main/vlmevalkit)

## Validation

- Verified non-DocumentQA scores match private results exactly for `vrag`, `NIAH`, `ICL`, and `summ`.
- Verified public `MMLongBench.evaluate()` runs successfully on `MMLongBench_32K`.