### PR TITLE
[Fix] Correct LOCAL_RANK default value to 0 in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -33,7 +33,7 @@ def get_gpu_list():
 RANK = int(os.environ.get('RANK', 0))
 WORLD_SIZE = int(os.environ.get('WORLD_SIZE', 1))
 LOCAL_WORLD_SIZE = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
-LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 1))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 0))
 
 GPU_LIST = get_gpu_list()
 if LOCAL_WORLD_SIZE > 1 and len(GPU_LIST):


### PR DESCRIPTION
Fixes #1589

### Description
In `run.py`, `LOCAL_RANK` was being read from the environment with an incorrect default value of `1`. If `LOCAL_WORLD_SIZE` is set but `LOCAL_RANK` is not, this default causes the GPU assignment block to skip the first GPU partition (`DEVICE_START_IDX = GPU_PER_PROC * 1`). 

This PR corrects the default value of `LOCAL_RANK` to `0`.

### Root Cause & Justification
- **Conventions:** PyTorch `torchrun` conventions state that `LOCAL_RANK` always starts at `0`.
- **Consistency:** The `RANK` variable in `run.py:33` correctly defaults to `0`, and `LOCAL_RANK` shares the exact same semantic concept.
- **Codebase Alignment:** Every other `LOCAL_RANK` read across this codebase correctly defaults to `0` (see `vlmeval/vlm/emu.py:76`, `vlmeval/vlm/parrot.py:61`, and `vlmeval/vlm/parrot.py:188`).

### Verification
- `pre-commit run --all-files` passed successfully.
- `flake8` checks on `run.py` passed cleanly (ignoring `W503` as per `setup.cfg` / `.pre-commit-config.yaml`).
- Verified `git diff` shows exactly one line changed.