### PR TITLE
[Feature] Opt-in LLM-judge rescoring for string-metric VQA benchmarks (ChartQA/DocVQA/InfoVQA/TextVQA/OCRBench)

### DIFF
--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -71,8 +71,16 @@ class ImageVQADataset(ImageBaseDataset):
     def evaluate(self, eval_file, **judge_kwargs):
         if judge_kwargs.get('use_verifier', False):
             return self.evaluate_verifier(eval_file, **judge_kwargs)
-        else:
-            return self.evaluate_heuristic(eval_file, **judge_kwargs)
+        # Opt-in LLM-judge rescoring (pass --judge <model>): the default string /
+        # numeric metrics count format-only variants (e.g. '27%' vs '0.27') as
+        # wrong. With a judge configured, strict-failed samples are re-checked
+        # for semantic equivalence; strict scores are reported unchanged and
+        # '<split>_judge' columns are appended.
+        if (listinstr(['TextVQA', 'ChartQA', 'DocVQA', 'InfoVQA'], self.dataset_name)
+                and judge_kwargs.get('model')
+                and judge_kwargs.get('model') != 'exact_matching'):
+            return self.evaluate_with_llm_judge(eval_file, **judge_kwargs)
+        return self.evaluate_heuristic(eval_file, **judge_kwargs)
 
     # It returns a DataFrame
     def evaluate_heuristic(self, eval_file, **judge_kwargs):
@@ -127,6 +135,108 @@ class ImageVQADataset(ImageBaseDataset):
                     # [np.mean(x['match']) >= full_score_weight for x in sub]
                     hit = hit_calculate(sub, dataset)
                     ret[c] = np.mean(hit) * 100
+        ret = d2df(ret)
+        ret.round(2)
+
+        result_file = get_intermediate_file_path(eval_file, '_acc')
+        dump(ret, result_file)
+        return ret
+
+    def evaluate_with_llm_judge(self, eval_file, **judge_kwargs):
+        """Strict metric + LLM-judge rescoring of strict-failed samples.
+
+        The strict columns are identical to evaluate_heuristic's output. A
+        sample counts as correct in the appended '<split>_judge' columns when
+        strict passed (per-sample score >= 0.5) or the judge marked the answer
+        semantically equivalent to the ground truth. Only strict-failed
+        samples are sent to the judge.
+        """
+        from .utils.llm_judge_vqa import LLMJudge_auxeval
+        from .utils.vqa_eval import hit_calculate, process_line
+
+        data = load(eval_file)
+        dataset = self.dataset_name
+        assert 'answer' in data and 'prediction' in data
+        data['prediction'] = [str(x) for x in data['prediction']]
+        data['answer'] = [str(x) for x in data['answer']]
+        lt = len(data)
+        pool = mp.Pool(16)
+        lines = [data.iloc[i] for i in range(lt)]
+        if listinstr(['TextVQA'], dataset):
+            res = pool.map(partial(process_line, method='vqa_score'), lines)
+        elif listinstr(['ChartQA'], dataset):
+            res = pool.map(partial(process_line, method='relaxed_accuracy'), lines)
+        elif listinstr(['DocVQA', 'InfoVQA'], dataset):
+            res = pool.map(partial(process_line, method='anls'), lines)
+        else:
+            res = pool.map(process_line, lines)
+
+        # Per-sample strict score; >= 0.5 counts as pass and skips the judge.
+        sample_hit = hit_calculate(res, dataset)
+        strict_match = [bool(h >= 0.5) for h in sample_hit]
+
+        judge_name = judge_kwargs['model']
+        tmp_file = get_intermediate_file_path(eval_file, f'_llm_judge_{judge_name}', 'pkl')
+        ans = load(tmp_file) if osp.exists(tmp_file) else {}
+        todo, keys = [], []
+        for i in range(lt):
+            idx = lines[i]['index']
+            if not strict_match[i] and idx not in ans:
+                todo.append(lines[i])
+                keys.append(idx)
+        if len(todo):
+            nproc = judge_kwargs.pop('nproc', 4)
+            model = build_judge(max_tokens=16, **judge_kwargs)
+            assert model.working(), 'LLM-judge rescoring requires a working judge endpoint\n' + DEBUG_MESSAGE
+            tups = [(model, line, dataset) for line in todo]
+            track_progress_rich(
+                LLMJudge_auxeval,
+                tups,
+                nproc=nproc,
+                chunksize=nproc,
+                keys=keys,
+                save=tmp_file,
+            )
+            ans = load(tmp_file)
+            for k in keys:
+                assert k in ans
+        judge_flags = [
+            strict_match[i] or str(ans.get(lines[i]['index'], {}).get('res')) == '1'
+            for i in range(lt)
+        ]
+
+        data['eval_gt'] = [r['gt'] for r in res]
+        data['eval_pred'] = [r['pred'] for r in res]
+        data['eval_match'] = [r['match'] for r in res]
+        data['eval_score'] = [np.mean(r['match']) for r in res]
+        data['llm_judge_match'] = judge_flags
+        detailed_result_file = get_intermediate_file_path(eval_file, '_results')
+        dump(data, detailed_result_file)
+
+        # Strict aggregation identical to evaluate_heuristic; judged columns appended.
+        ret = dict()
+        judged = dict()
+        if 'split' in data:
+            splits = set(data['split'])
+            for sp in splits:
+                sub = [r for line, r in zip(lines, res) if line['split'] == sp]
+                ret[sp] = np.mean(hit_calculate(sub, dataset)) * 100
+                subj = [j for line, j in zip(lines, judge_flags) if line['split'] == sp]
+                judged[f'{sp}_judge'] = np.mean(subj) * 100
+            ret['Overall'] = np.mean(hit_calculate(res, dataset)) * 100
+            judged['Overall_judge'] = np.mean(judge_flags) * 100
+        else:
+            ret['Overall'] = np.mean(hit_calculate(res, dataset)) * 100
+            judged['Overall_judge'] = np.mean(judge_flags) * 100
+            if 'category' in data:
+                cates = list(set(data['category']))
+                cates.sort()
+                for c in cates:
+                    sub = [r for line, r in zip(lines, res) if line['category'] == c]
+                    ret[c] = np.mean(hit_calculate(sub, dataset)) * 100
+                    subj = [j for line, j in zip(lines, judge_flags) if line['category'] == c]
+                    judged[f'{c}_judge'] = np.mean(subj) * 100
+        ret.update(judged)
         ret = d2df(ret)
         ret.round(2)
 
@@ -523,11 +633,13 @@ class OCRBench(ImageBaseDataset):
         data = load(eval_file)
         lt = len(data)
         lines = [data.iloc[i] for i in range(lt)]
+        strict_flags = []
         for i in tqdm(range(len(lines))):
             line = lines[i]
             predict = str(line['prediction'])
             answers = eval(line['answer'])
             category = line['category']
+            hit = False
             if category == 'Handwritten Mathematical Expression Recognition':
                 for j in range(len(answers)):
                     answer = answers[j].strip().replace('\n',
@@ -535,15 +647,60 @@ class OCRBench(ImageBaseDataset):
                     predict = predict.strip().replace('\n',
                                                       ' ').replace(' ', '')
                     if answer in predict:
-                        OCRBench_score[category] += 1
+                        hit = True
                         break
             else:
                 for j in range(len(answers)):
                     answer = answers[j].lower().strip().replace('\n', ' ')
                     predict = predict.lower().strip().replace('\n', ' ')
                     if answer in predict:
-                        OCRBench_score[category] += 1
+                        hit = True
                         break
+            if hit:
+                OCRBench_score[category] += 1
+            strict_flags.append(hit)
+
+        # Opt-in LLM-judge rescoring (pass --judge <model>): substring matching
+        # misses paraphrased-but-correct readings; strict-failed samples are
+        # re-checked and '<key>_judge' aggregates appended below (strict scores
+        # reported unchanged).
+        judge_flags = None
+        if judge_kwargs.get('model') and judge_kwargs.get('model') != 'exact_matching':
+            from .utils.llm_judge_vqa import LLMJudge_auxeval
+            judge_name = judge_kwargs['model']
+            tmp_file = get_intermediate_file_path(eval_file, f'_llm_judge_{judge_name}', 'pkl')
+            ans = load(tmp_file) if osp.exists(tmp_file) else {}
+            todo = [
+                i for i in range(len(lines))
+                if not strict_flags[i] and lines[i]['index'] not in ans
+            ]
+            if len(todo):
+                nproc = judge_kwargs.pop('nproc', 4)
+                model = build_judge(max_tokens=16, **judge_kwargs)
+                assert model.working(), \
+                    'LLM-judge rescoring requires a working judge endpoint\n' + DEBUG_MESSAGE
+                tups, keys = [], []
+                for i in todo:
+                    line = lines[i]
+                    tups.append((model, dict(
+                        question=str(line['question']),
+                        answer='; '.join(str(a) for a in eval(line['answer'])),
+                        prediction=str(line['prediction']),
+                    ), self.dataset_name if hasattr(self, 'dataset_name') else 'OCRBench'))
+                    keys.append(line['index'])
+                track_progress_rich(
+                    LLMJudge_auxeval,
+                    tups,
+                    nproc=nproc,
+                    chunksize=nproc,
+                    keys=keys,
+                    save=tmp_file,
+                )
+                ans = load(tmp_file)
+            judge_flags = [
+                strict_flags[i] or str(ans.get(lines[i]['index'], {}).get('res')) == '1'
+                for i in range(len(lines))
+            ]
 
         final_score_dict = {}
         final_score_dict['Text Recognition'] = \
@@ -564,6 +721,31 @@ class OCRBench(ImageBaseDataset):
              + final_score_dict['Handwritten Mathematical Expression Recognition'])
         final_score_dict['Final Score Norm'] = (
             float(final_score_dict['Final Score']) / 10)
+        if judge_flags is not None:
+            judge_score = {k: 0 for k in OCRBench_score}
+            for i in range(len(lines)):
+                if judge_flags[i]:
+                    judge_score[lines[i]['category']] += 1
+            final_score_dict['Text Recognition_judge'] = \
+                (judge_score['Regular Text Recognition'] + judge_score['Irregular Text Recognition']
+                 + judge_score['Artistic Text Recognition'] + judge_score['Handwriting Recognition']
+                 + judge_score['Digit String Recognition'] + judge_score['Non-Semantic Text Recognition'])
+            final_score_dict['Scene Text-centric VQA_judge'] = judge_score[
+                'Scene Text-centric VQA']
+            final_score_dict['Doc-oriented VQA_judge'] = judge_score[
+                'Doc-oriented VQA']
+            final_score_dict['Key Information Extraction_judge'] = judge_score[
+                'Key Information Extraction']
+            final_score_dict['Handwritten Mathematical Expression Recognition_judge'] = \
+                (judge_score['Handwritten Mathematical Expression Recognition'])
+            final_score_dict['Final Score_judge'] = \
+                (final_score_dict['Text Recognition_judge']
+                 + final_score_dict['Scene Text-centric VQA_judge']
+                 + final_score_dict['Doc-oriented VQA_judge']
+                 + final_score_dict['Key Information Extraction_judge']
+                 + final_score_dict['Handwritten Mathematical Expression Recognition_judge'])
+            final_score_dict['Final Score Norm_judge'] = (
+                float(final_score_dict['Final Score_judge']) / 10)
         score_pth = get_intermediate_file_path(eval_file, '_score', 'json')
         dump(final_score_dict, score_pth)
         return final_score_dict

--- a/vlmeval/dataset/utils/llm_judge_vqa.py
+++ b/vlmeval/dataset/utils/llm_judge_vqa.py
@@ -1,0 +1,168 @@
+"""Unified LLM-judge re-scoring for VQA-style benchmarks whose default
+metric is a brittle string/numeric compare (ChartQA, OCRBench, DocVQA,
+InfoVQA, TextVQA).
+
+Behavior: each dataset's strict scoring runs first. For samples that
+strict marked wrong, this module asks an LLM judge whether the model's
+answer is semantically equivalent to the standard answer, using
+dataset-specific examples that explicitly accept unit/format variants.
+Output: '1' (consistent) or '0' (inconsistent).
+"""
+
+from vlmeval.constant import FAIL_MSG
+
+_CHARTQA = (
+    "You are grading a chart-question-answering task. Given the question, the "
+    "standard answer, and the model's answer, decide whether the model's "
+    "answer is semantically consistent with the standard answer.\n"
+    "\n"
+    "Rules:\n"
+    "- The standard answer is always correct; you are only checking the model.\n"
+    "- If the meaning is the same, the answer is CONSISTENT even when the "
+    "model adds units, currency symbols, magnitude words (million/billion), "
+    "whitespace, or wrapping prose. Examples of consistent answers:\n"
+    "    * standard='106', model='106 million'\n"
+    "    * standard='1.84', model='$1.84 billion U.S. dollars'\n"
+    "    * standard='6750', model='6 750'\n"
+    "    * standard='Poor', model='The category with the higher share is Poor.'\n"
+    "- If the numeric value differs by more than ~5% of the standard answer, "
+    "or the textual category is different, the answer is INCONSISTENT.\n"
+    "\n"
+    "Reply with a single character: '1' for consistent, '0' for inconsistent. "
+    "No other text.\n"
+    "\n"
+    "Question: {question}\n"
+    "Standard Answer: {answer}\n"
+    "Model Answer: {prediction}\n"
+    "Judgement:"
+)
+
+_OCRBENCH = (
+    "You are grading an OCR / text-from-image task. Given the question, the "
+    "standard answer (the correct text shown in the image), and the model's "
+    "answer, decide whether the model's answer contains or matches the "
+    "correct text.\n"
+    "\n"
+    "Rules:\n"
+    "- If the correct text appears in the model's response, even within a "
+    "sentence or with different case/spacing/punctuation, mark as CONSISTENT. "
+    "Examples:\n"
+    "    * standard='Coca-Cola', model='The brand shown is COCA COLA.'\n"
+    "    * standard='12.50', model='The price reads $12.50'\n"
+    "    * standard='STOP', model='It says stop on the sign.'\n"
+    "    * standard='hello world', model='The text in the image reads: Hello, World!'\n"
+    "- If the model output a different word, a wrong number, or missed the "
+    "correct text entirely, mark INCONSISTENT.\n"
+    "\n"
+    "Reply with a single character: '1' for consistent, '0' for inconsistent.\n"
+    "\n"
+    "Question: {question}\n"
+    "Standard Answer: {answer}\n"
+    "Model Answer: {prediction}\n"
+    "Judgement:"
+)
+
+_DOCVQA = (
+    "You are grading a document-question-answering task (forms, invoices, "
+    "letters, etc.). Given the question, the standard answer, and the model's "
+    "answer, decide whether the model's answer is semantically equivalent to "
+    "the standard answer in the document context.\n"
+    "\n"
+    "Rules:\n"
+    "- Same value with different formatting is CONSISTENT. Examples:\n"
+    "    * standard='$1,234', model='one thousand two hundred thirty-four dollars'\n"
+    "    * standard='May 12, 2020', model='12/05/2020'\n"
+    "    * standard='29.5%', model='29.5 percent' or '0.295'\n"
+    "    * standard='John Smith', model='The name is John Smith.'\n"
+    "- Different value, different entity, or wrong field → INCONSISTENT.\n"
+    "\n"
+    "Reply with a single character: '1' for consistent, '0' for inconsistent.\n"
+    "\n"
+    "Question: {question}\n"
+    "Standard Answer: {answer}\n"
+    "Model Answer: {prediction}\n"
+    "Judgement:"
+)
+
+_INFOVQA = (
+    "You are grading an infographic-question-answering task. Given the "
+    "question, the standard answer, and the model's answer, decide whether "
+    "the model's answer is semantically consistent with the standard answer.\n"
+    "\n"
+    "Rules:\n"
+    "- Same value with different formatting is CONSISTENT. Examples:\n"
+    "    * standard='45', model='45 million people'\n"
+    "    * standard='2.3 billion', model='2.3B'\n"
+    "    * standard='Asia', model='The continent is Asia.'\n"
+    "- Different value or different entity → INCONSISTENT.\n"
+    "\n"
+    "Reply with a single character: '1' for consistent, '0' for inconsistent.\n"
+    "\n"
+    "Question: {question}\n"
+    "Standard Answer: {answer}\n"
+    "Model Answer: {prediction}\n"
+    "Judgement:"
+)
+
+_TEXTVQA = (
+    "You are grading a scene-text VQA task (signs, packaging, screens). "
+    "Given the question, the standard answer, and the model's answer, "
+    "decide whether the model's answer is consistent with the standard "
+    "answer.\n"
+    "\n"
+    "Rules:\n"
+    "- If the correct word/number appears in the model response, even within "
+    "a sentence, mark CONSISTENT. Examples:\n"
+    "    * standard='stop', model=\"It says 'Stop'.\"\n"
+    "    * standard='5.99', model='The price tag reads $5.99.'\n"
+    "    * standard='exit', model='The sign says EXIT in red letters.'\n"
+    "- TextVQA answers are typically short (1-3 words). Be lenient on extra "
+    "context but strict on the actual target word/number.\n"
+    "- Different word or wrong number → INCONSISTENT.\n"
+    "\n"
+    "Reply with a single character: '1' for consistent, '0' for inconsistent.\n"
+    "\n"
+    "Question: {question}\n"
+    "Standard Answer: {answer}\n"
+    "Model Answer: {prediction}\n"
+    "Judgement:"
+)
+
+
+PROMPTS = {
+    'ChartQA_TEST': _CHARTQA,
+    'OCRBench': _OCRBENCH,
+    'OCRBench_MINI': _OCRBENCH,
+    'DocVQA_VAL': _DOCVQA,
+    'DocVQA_TEST': _DOCVQA,
+    'InfoVQA_VAL': _INFOVQA,
+    'InfoVQA_TEST': _INFOVQA,
+    'TextVQA_VAL': _TEXTVQA,
+    'TextVQA_TEST': _TEXTVQA,
+}
+
+
+def build_llm_judge_prompt(dataset_name, line):
+    tmpl = PROMPTS.get(dataset_name, _CHARTQA)
+    return tmpl.format(
+        question=str(line.get('question', '')).strip(),
+        answer=str(line.get('answer', '')).strip(),
+        prediction=str(line.get('prediction', '')).strip(),
+    )
+
+
+def LLMJudge_auxeval(model, line, dataset_name=None):
+    """Single LLM-judge call. Returns dict(log=..., res='1' or '0')."""
+    prompt = build_llm_judge_prompt(dataset_name, line)
+    log = ''
+    for i in range(3):
+        res = model.generate(prompt, temperature=0.0 if i == 0 else 0.3)
+        if FAIL_MSG in str(res):
+            log += f'Try {i}: API failed.\n'
+            continue
+        out = str(res).strip()
+        first = next((c for c in out if c in '01'), None)
+        if first is not None:
+            return dict(log=log + 'Succeed', res=first)
+        log += f'Try {i}: unparseable output: {out!r}\n'
+    return dict(log=log + 'All retries failed', res='0')


### PR DESCRIPTION
## Motivation

ChartQA / DocVQA / InfoVQA / TextVQA / OCRBench are scored with strict string /
numeric metrics (relaxed accuracy, ANLS, VQA score, substring matching). These
metrics mark answers wrong when the model's answer is semantically correct but
formatted differently from the ground truth. Real cases from a
LiquidAI/LFM2.5-VL-450M run with this repo (ground truth vs model answer, all
scored 0 by the strict metric):

| Benchmark | Ground truth | Model answer | Failure kind |
|---|---|---|---|
| ChartQA | `977633` | `977,633` | thousands separator |
| ChartQA | `1.4` | `1.4 billion` | magnitude word appended |
| ChartQA | `1` | `1 GPI` | unit suffix from the chart |
| InfoVQA | `27%` | `27 percent` | percent sign vs word |
| TextVQA | `10 years` | `10` | unit word |
| OCRBench | `begins.` | `begins` | trailing punctuation |
| OCRBench | `$161,886` | `161,886` | currency symbol |

How many points this costs depends on each model's answering style, so it
distorts cross-model comparisons rather than adding a constant offset.

MMVet and MathVista already rely on LLM judges. This PR adds an **optional**
semantic-equivalence pass to the five string-metric benchmarks — without
changing any default behavior or any existing number.

## Design

**Opt-in gate.** These datasets are assigned no judge model by default
(`get_judge_kwargs`), so without `--judge <model>` nothing changes — the
evaluation path and outputs are identical to `main`. The rescoring runs only
when a judge is explicitly configured:

```python
if (listinstr(['TextVQA', 'ChartQA', 'DocVQA', 'InfoVQA'], self.dataset_name)
        and judge_kwargs.get('model')
        and judge_kwargs.get('model') != 'exact_matching'):
    return self.evaluate_with_llm_judge(eval_file, **judge_kwargs)
return self.evaluate_heuristic(eval_file, **judge_kwargs)
```

**Strict scores are reported unchanged.** The strict metric is computed with
the exact same `process_line` / `hit_calculate` aggregation as
`evaluate_heuristic`, and the judge can never demote a strict-passed sample.
Judged results are appended as `<split>_judge` columns (OCRBench:
`<category>_judge` keys and `Final Score_judge` in the score JSON), so the
output is a strict superset:

```
# acc.csv on main, or on this branch without --judge
"test_augmented","test_human","Overall"
"90.16","59.92","75.04"

# this branch, with --judge
"test_augmented","test_human","Overall","test_augmented_judge","test_human_judge","Overall_judge"
"90.16","59.92","75.04","90.4","62.88","76.64"
```

**Judge cost scales with strict failures only.** Only strict-failed samples
(per-sample score < 0.5) are sent to the judge; verdicts are cached in a
resumable pkl like the other judge-based evaluators.

**Model-agnostic, dataset-specific prompts** (`utils/llm_judge_vqa.py`): the
equivalence rules are written down per dataset — percent/decimal and
magnitude-word variants, unit suffixes, thousands separators, ~5% numeric
tolerance for ChartQA (consistent with relaxed accuracy), answer-containment
for OCRBench. The judge replies with a single `1`/`0` token; a judge parsing
failure counts as wrong, so judge flakiness can never inflate scores.

## Results on a public model

LiquidAI/LFM2.5-VL-450M, predictions generated with this repo, judge =
Qwen3.6-27B-FP8 served locally (thinking disabled):

| Benchmark | Strict (unchanged) | +LLM judge | Δ |
|---|---:|---:|---:|
| ChartQA_TEST | 75.04 | 76.64 | +1.60 |
| DocVQA_VAL | 78.34 | 82.73 | +4.39 |
| InfoVQA_VAL | 43.30 | 48.80 | +5.50 |
| TextVQA_VAL | 69.82 | 78.64 | +8.82 |
| OCRBench | 679 | 710 | +31 (/1000) |

## Verification

- Without `--judge`: the evaluate path is unchanged, outputs are identical to
  `main` for all five benchmarks.
- With `--judge`: strict columns match the heuristic run exactly — verified on
  the LFM2.5-VL-450M outputs above at full float precision (e.g. DocVQA
  `78.33964128700651`); only the `*_judge` columns are added.
- `pre-commit run` passes on the changed files.

## Notes

Judged numbers naturally depend on the chosen judge model, so the strict
columns remain the primary metric and the judge columns are supplemental.
Happy to adjust the gating (e.g. a dedicated flag instead of judge presence),
column naming, or prompt wording if maintainers prefer.