### PR TITLE
[Fix] Preserve literal None text in MCQ options

### DIFF
--- a/tests/test_image_mcq.py
+++ b/tests/test_image_mcq.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from vlmeval.dataset.image_mcq import ImageMCQDataset
+
+
+def test_mcq_tsv_preserves_none_option_text(tmp_path, monkeypatch):
+    data_file = tmp_path / 'fixture.tsv'
+    data_file.write_text(
+        'index\timage_path\tquestion\tA\tB\thint\tanswer\n'
+        '1\timage.png\tHow many objects?\tNone\tTwo\t\tA\n'
+        '2\timage.png\tHow many objects?\t\tTwo\t\tB\n',
+        encoding='utf-8',
+    )
+    monkeypatch.setattr('vlmeval.dataset.image_base.LMUDataRoot', lambda: str(tmp_path))
+
+    dataset = ImageMCQDataset.__new__(ImageMCQDataset)
+    dataset.dataset_name = 'fixture'
+    dataset.meta_only = True
+    dataset.data = dataset.prepare_tsv('fixture.tsv')
+
+    assert dataset.data.loc[0, 'A'] == 'None'
+    assert pd.isna(dataset.data.loc[1, 'A'])
+    assert pd.isna(dataset.data.loc[0, 'hint'])
+
+    prompt = dataset.build_prompt(dataset.data.iloc[0])[-1]['value']
+    assert 'A. None' in prompt

--- a/vlmeval/dataset/image_base.py
+++ b/vlmeval/dataset/image_base.py
@@ -138,6 +138,7 @@ class ImageBaseDataset(metaclass=ABCMeta):
     MODALITY = 'IMAGE'
     DATASET_URL = {}
     DATASET_MD5 = {}
+    TSV_LOAD_KWARGS = {}
     DEFAULT_JUDGE_MODEL: str | None = None
 
     INFER_FAIL_MARKERS = (INFER_FAIL_MSG, )
@@ -260,7 +261,7 @@ class ImageBaseDataset(metaclass=ABCMeta):
                 from ..tools import LOCALIZE
                 LOCALIZE(data_path, local_path)
             data_path = local_path
-        return load(data_path)
+        return load(data_path, **self.TSV_LOAD_KWARGS)
 
     def dump_image(self, line):
         os.makedirs(self.img_root, exist_ok=True)

--- a/vlmeval/dataset/image_base.py
+++ b/vlmeval/dataset/image_base.py
@@ -138,6 +138,7 @@ class ImageBaseDataset(metaclass=ABCMeta):
     MODALITY = 'IMAGE'
     DATASET_URL = {}
     DATASET_MD5 = {}
+    TSV_LOAD_KWARGS = {}
     DEFAULT_JUDGE: str | list = 'gpt-4o-mini'
 
     INFER_FAIL_MARKERS = (INFER_FAIL_MSG, )
@@ -250,7 +251,7 @@ class ImageBaseDataset(metaclass=ABCMeta):
                 from ..tools import LOCALIZE
                 LOCALIZE(data_path, local_path)
             data_path = local_path
-        return load(data_path)
+        return load(data_path, **self.TSV_LOAD_KWARGS)
 
     def dump_image(self, line):
         os.makedirs(self.img_root, exist_ok=True)

--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -50,9 +50,19 @@ MTL_MMBench_MD5 = {
 }
 
 
+def _preserve_option_text(value):
+    return np.nan if value == '' else value
+
+
 class ImageMCQDataset(ImageBaseDataset):
 
     TYPE = 'MCQ'
+    TSV_LOAD_KWARGS = {
+        'converters': {
+            candidate: _preserve_option_text
+            for candidate in string.ascii_uppercase
+        }
+    }
 
     DATASET_URL = {
         # MMBench v1.0

--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -250,7 +250,7 @@ def _should_convert_to_dataframe(data):
     return False
 
 
-def load(f, fmt=None):
+def load(f, fmt=None, **kwargs):
     def load_pkl(pth):
         return pickle.load(open(pth, 'rb'))
 
@@ -266,13 +266,13 @@ def load(f, fmt=None):
         return data
 
     def load_xlsx(f):
-        return pd.read_excel(f)
+        return pd.read_excel(f, **kwargs)
 
     def load_csv(f):
-        return pd.read_csv(f)
+        return pd.read_csv(f, **kwargs)
 
     def load_tsv(f):
-        return pd.read_csv(f, sep='\t')
+        return pd.read_csv(f, sep='\t', **kwargs)
 
     import validators
     if validators.url(f):

--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -245,7 +245,7 @@ def _should_convert_to_dataframe(data):
     return False
 
 
-def load(f, fmt=None):
+def load(f, fmt=None, **kwargs):
     def load_pkl(pth):
         return pickle.load(open(pth, 'rb'))
 
@@ -261,13 +261,13 @@ def load(f, fmt=None):
         return data
 
     def load_xlsx(f):
-        return pd.read_excel(f)
+        return pd.read_excel(f, **kwargs)
 
     def load_csv(f):
-        return pd.read_csv(f)
+        return pd.read_csv(f, **kwargs)
 
     def load_tsv(f):
-        return pd.read_csv(f, sep='\t')
+        return pd.read_csv(f, sep='\t', **kwargs)
 
     import validators
     if validators.url(f):


### PR DESCRIPTION
## Summary

- allow tabular loaders to receive pandas reader options
- preserve literal strings such as `None` in image-MCQ option columns
- keep genuinely empty option cells and non-option metadata as missing values
- add a regression test that verifies the generated prompt contains `A. None`

## Root cause

Pandas treats the literal string `None` as a default NA value. `ImageMCQDataset.build_prompt()` then filters the resulting `NaN`, silently removing valid answer choices from SEEDBench_IMG and MMStar prompts.

The fix is scoped to MCQ option columns through pandas converters. It does not disable default NA parsing globally, so empty hints and other dataset metadata retain their existing behavior.

Fixes #1559.

## Validation

- rebased onto current upstream `main` and resolved the `DEFAULT_JUDGE_MODEL` migration cleanly
- isolated parser/prompt regression: passed (`A. None` is retained; empty option and hint cells remain missing)
- `python3 -m py_compile vlmeval/smp/file.py vlmeval/dataset/image_base.py vlmeval/dataset/image_mcq.py tests/test_image_mcq.py`: passed
- `git diff --check origin/main...HEAD`: passed

Full pytest collection is not available in the local minimal environment because VLMEvalKit eagerly imports optional benchmark dependencies that are not installed. The committed regression test remains self-contained under the repository's declared dependency set.
