### PR TITLE
[Fix] Strip use_vllm/use_verifier eval flags from judge kwargs (OpenAI 400)

### DIFF
--- a/vlmeval/dataset/utils/judge_util.py
+++ b/vlmeval/dataset/utils/judge_util.py
@@ -9,6 +9,9 @@ def build_judge(**kwargs):
     from vlmeval.api import HFChatModel, OpenAIWrapper, SiliconFlowAPI
     model = kwargs.pop('model', None)
     kwargs.pop('nproc', None)
+    # eval-only flags, not API parameters
+    kwargs.pop('use_vllm', None)
+    kwargs.pop('use_verifier', None)
     load_env()
     LOCAL_LLM = os.environ.get('LOCAL_LLM', None)
     if LOCAL_LLM is None:


### PR DESCRIPTION
## Bug

`run.py` forwards the `--use-vllm` and `--use-verifier` CLI flags into
`judge_kwargs`:

```python
# run.py, get_judge_kwargs
if args.use_verifier:
    judge_kwargs['use_verifier'] = True
if args.use_vllm:
    judge_kwargs['use_vllm'] = True
```

`build_judge(**judge_kwargs)` only pops `model` and `nproc`; everything else
reaches the API wrapper, and `OpenAIWrapper.generate_inner` places unknown
kwargs directly into the request body:

```python
payload = dict(model=self.model, messages=input_msgs, n=1,
               temperature=temperature, **kwargs)
```

The real OpenAI API rejects unknown body fields:

```
400 - Unrecognized request argument supplied: use_vllm
```

Since even the `working()` health probe sends this payload, every judge-scored
evaluation fails up front (MMVet crashes on its `assert model.working()`;
MathVista reports 100% judge failure; MCQ answer extraction degrades) whenever
a model is evaluated with `--use-vllm` and an OpenAI judge.

vLLM-served local judges ignore unknown request fields, which is why the bug
is easy to miss when developing against a self-hosted judge.

## Fix

Pop the two eval-only flags in `build_judge()` before constructing the API
wrapper (+3 lines). This covers every `build_judge(**judge_kwargs)` call site
at once. The flags remain visible to the dataset `evaluate()` dispatch, which
reads them from `judge_kwargs` before `build_judge` is called — `**` expansion
passes a copy, so callers are unaffected.

## Reproduction

```bash
# any judge-scored benchmark + --use-vllm + a real OpenAI key
python run.py --data MMVet --model <any-vllm-capable-model> --use-vllm
# before: AssertionError: MMVet evaluation requires a working OPENAI API
#         (judge probe rejected with 400 'Unrecognized request argument supplied: use_vllm')
# after: judge calls succeed
```