### PR TITLE
[Fix] fix tqdm import in spatial457

### DIFF
--- a/vlmeval/dataset/spatial457.py
+++ b/vlmeval/dataset/spatial457.py
@@ -1,6 +1,6 @@
 import re
 
-import tqdm
+from import trange
 
 from vlmeval.smp import dump, get_intermediate_file_path, load
 from .image_base import ImageBaseDataset
@@ -53,7 +53,7 @@ class Spatial457(ImageBaseDataset):
             "L5_collision_correct": 0,
         }
 
-        for i in tqdm(range(len(lines))):
+        for i in trange(len(lines)):
 
             line = lines[i]
             index = int(line["index"])


### PR DESCRIPTION
Hey team!

Thanks for your work on VLMEvalKit. It is super useful!

This PR just fixes a small import bug with tqdm in the Spatial457 Benchmark.



replace

```
import tqdm
...
for i in tqdm(range(len(blah))):
```

with 

```
from tqdm import trange
...
for i in trange(len(blah)):
```