### PR TITLE
[Refactor] Refactor dataset config aliases and video presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ data
 outputs/*
 demo.ipynb
 *json
+!tests/fixtures/predefined_video_shortcuts_manifest.json
 !vlmeval/dataset/utils/vgrpbench/configs/formating-prompt/**/*.json
 .vscode
 *.swp

--- a/docs/en/ConfigSystem.md
+++ b/docs/en/ConfigSystem.md
@@ -50,9 +50,9 @@ Explanation of the config json:
     - Tip: The defined model in the `supported_VLM` of `vlmeval/config.py` can be used as a shortcut, for example, `GPT4o_20241120: {}` is equivalent to `GPT4o_20241120: {'class': 'GPT4V', 'model': 'gpt-4o-2024-11-20', 'temperature': 0, 'img_size': -1, 'img_detail': 'high', 'retry': 10, 'verbose': False}`
 3. For the dictionary `data`, the key is an output alias. It only affects output-side names such as prediction files, status entries, reused artifacts, and symlinks. Dataset construction, post-processing, judge settings, and evaluation logic use the `dataset` field in the value. For items in `data`, the value is a dictionary containing the following keys:
     - `class`: The class name of the dataset, which should be a class name defined in `vlmeval/dataset/__init__.py`.
-    - `dataset`: The logical dataset name passed to the dataset class constructor. If omitted, the `data` key is used as the fallback.
+    - `dataset`: The logical dataset name passed to the dataset class constructor. It is required when `class` is set.
     - Other kwargs: Other kwargs are dataset-specific parameters, please refer to the definition of the dataset class for detailed usage. Typically, the `dataset` argument is required by most dataset classes. It's noteworthy that the `nframe` argument or `fps` argument is required by most video dataset classes.
-    - Tip: The defined dataset in the `supported_video_datasets` of `vlmeval/dataset/video_dataset_config.py` can be used as a shortcut, for example, `MMBench_Video_8frame_nopack: {}` is equivalent to `MMBench_Video_8frame_nopack: {'class': 'MMBenchVideo', 'dataset': 'MMBench-Video', 'nframe': 8, 'pack': False}`.
+    - Tip: Predefined video shortcuts can be launched directly with `--data MMBench_Video_8frame_nopack`. To reuse a shortcut under an output alias in config, write `my_alias: {'preset': 'MMBench_Video_8frame_nopack'}`. Empty dict shortcut configs such as `MMBench_Video_8frame_nopack: {}` are not supported.
 Saving the example config json to `config.json`, you can launch the evaluation by:
 
 ```bash

--- a/docs/en/ConfigSystem.md
+++ b/docs/en/ConfigSystem.md
@@ -30,7 +30,9 @@ To address this, VLMEvalKit provides a more flexible config system. The user can
             "class": "ImageMCQDataset",
             "dataset": "MMBench_DEV_EN_V11"
         },
-        "MMBench_Video_8frame_nopack":{},
+        "MMBench_Video_8frame_nopack": {
+            "preset": "MMBench_Video_8frame_nopack"
+        },
         "Video-MME_16frame_subs": {
             "class": "VideoMME",
             "dataset": "Video-MME",
@@ -43,7 +45,7 @@ To address this, VLMEvalKit provides a more flexible config system. The user can
 
 Explanation of the config json:
 
-1. Now we support two fields: `model` and `data`, each of which is a dictionary. The key of the `model` dictionary is the model name. The key of the `data` dictionary is an output alias.
+1. Now we support two fields: `model` and `data`, each of which is a dictionary. The key of the `model` dictionary is the model name. The key of the `data` dictionary is an output alias. Output aliases must be safe filename components: use only letters, digits, `.`, `_`, and `-`, and start with a letter or digit.
 2. For items in `model`, the value is a dictionary containing the following keys:
     - `class`: The class name of the model, which should be a class name defined in `vlmeval/vlm/__init__.py` (open-source models) or `vlmeval/api/__init__.py` (API models).
     - Other kwargs: Other kwargs are model-specific parameters, please refer to the definition of the model class for detailed usage. For example, `model`, `temperature`, `img_detail` are arguments of the `GPT4V` class. It's noteworthy that the `model` argument is required by most model classes.

--- a/docs/en/ConfigSystem.md
+++ b/docs/en/ConfigSystem.md
@@ -43,13 +43,14 @@ To address this, VLMEvalKit provides a more flexible config system. The user can
 
 Explanation of the config json:
 
-1. Now we support two fields: `model` and `data`, each of which is a dictionary. The key of the dictionary is the name of the model / dataset (set by the user), and the value is the setting of the model / dataset.
+1. Now we support two fields: `model` and `data`, each of which is a dictionary. The key of the `model` dictionary is the model name. The key of the `data` dictionary is an output alias.
 2. For items in `model`, the value is a dictionary containing the following keys:
     - `class`: The class name of the model, which should be a class name defined in `vlmeval/vlm/__init__.py` (open-source models) or `vlmeval/api/__init__.py` (API models).
     - Other kwargs: Other kwargs are model-specific parameters, please refer to the definition of the model class for detailed usage. For example, `model`, `temperature`, `img_detail` are arguments of the `GPT4V` class. It's noteworthy that the `model` argument is required by most model classes.
     - Tip: The defined model in the `supported_VLM` of `vlmeval/config.py` can be used as a shortcut, for example, `GPT4o_20241120: {}` is equivalent to `GPT4o_20241120: {'class': 'GPT4V', 'model': 'gpt-4o-2024-11-20', 'temperature': 0, 'img_size': -1, 'img_detail': 'high', 'retry': 10, 'verbose': False}`
-3. For the dictionary `data`, we suggest users to use the official dataset name as the key (or part of the key), since we frequently determine the post-processing / judging settings based on the dataset name. For items in `data`, the value is a dictionary containing the following keys:
+3. For the dictionary `data`, the key is an output alias. It only affects output-side names such as prediction files, status entries, reused artifacts, and symlinks. Dataset construction, post-processing, judge settings, and evaluation logic use the `dataset` field in the value. For items in `data`, the value is a dictionary containing the following keys:
     - `class`: The class name of the dataset, which should be a class name defined in `vlmeval/dataset/__init__.py`.
+    - `dataset`: The logical dataset name passed to the dataset class constructor. If omitted, the `data` key is used as the fallback.
     - Other kwargs: Other kwargs are dataset-specific parameters, please refer to the definition of the dataset class for detailed usage. Typically, the `dataset` argument is required by most dataset classes. It's noteworthy that the `nframe` argument or `fps` argument is required by most video dataset classes.
     - Tip: The defined dataset in the `supported_video_datasets` of `vlmeval/dataset/video_dataset_config.py` can be used as a shortcut, for example, `MMBench_Video_8frame_nopack: {}` is equivalent to `MMBench_Video_8frame_nopack: {'class': 'MMBenchVideo', 'dataset': 'MMBench-Video', 'nframe': 8, 'pack': False}`.
 Saving the example config json to `config.json`, you can launch the evaluation by:
@@ -58,7 +59,7 @@ Saving the example config json to `config.json`, you can launch the evaluation b
 python run.py --config config.json
 ```
 
-That will generate the following output files under the working directory `$WORK_DIR` (Following the format `{$WORK_DIR}/{$MODEL_NAME}/{$MODEL_NAME}_{$DATASET_NAME}_*`):
+That will generate the following output files under the working directory `$WORK_DIR` (Following the format `{$WORK_DIR}/{$MODEL_NAME}/{$MODEL_NAME}_{$DATA_ALIAS}_*`, where `$DATA_ALIAS` is the `data` key):
 
 - `$WORK_DIR/GPT4o_20240806_T00_HIGH/GPT4o_20240806_T00_HIGH_MME-RealWorld-Lite*`
 - `$WORK_DIR/GPT4o_20240806_T10_Low/GPT4o_20240806_T10_Low_MME-RealWorld-Lite*`

--- a/docs/zh-CN/ConfigSystem.md
+++ b/docs/zh-CN/ConfigSystem.md
@@ -51,9 +51,9 @@
     - Tip：在位于`vlmeval/config.py`的变量`supported_VLM`中的已经被定义的模型可以作为`model`的键，而不需要填对应的值即可启动。例如，`GPT4o_20240806_T00_HIGH: {}`是等价于`GPT4o_20240806_T00_HIGH: {'class': 'GPT4V', 'model': 'gpt-4o-2024-08-06', 'temperature': 0, 'img_size': -1, 'img_detail': 'high', 'retry': 10, 'verbose': False}`。
 3. 对于字典`data`，key 是输出别名，只影响预测文件、状态文件、复用产物和软链接等输出侧命名；数据集构造、后处理、判断设置和评测逻辑使用 value 中的 `dataset` 字段。对于`data`中的项目，值是一个包含以下键的字典：
     - `class`：数据集的类名，应该是`vlmeval/dataset/__init__.py`中定义的类名。
-    - `dataset`：真实数据集名称，也就是传给数据集类构造函数的名称。如果省略，则回退使用 `data` 的 key。
+    - `dataset`：真实数据集名称，也就是传给数据集类构造函数的名称。设置 `class` 时必须同时提供 `dataset`。
     - 其他kwargs：其他kwargs是数据集特定的参数，请参考数据集类的定义以获取详细用法。通常，大多数数据集类都需要`dataset`参数。大多数视频数据集类都需要 `nframe` 或 `fps` 参数。
-    - Tip：在位于`vlmeval/dataset/video_dataset_config.py`的变量`supported_video_dataset`中的已经被定义的数据集可以作为`data`的键，而不需要填对应的值即可启动。例如，`MMBench_Video_8frame_nopack: {}`是等价于`MMBench_Video_8frame_nopack: {'class': 'MMBenchVideo', 'dataset': 'MMBench-Video', 'nframe': 8, 'pack': False}`。
+    - Tip：预定义视频 shortcut 可以直接通过 `--data MMBench_Video_8frame_nopack` 启动。如果想在 config 中使用自定义输出别名复用 shortcut，应写成 `my_alias: {'preset': 'MMBench_Video_8frame_nopack'}`。不再支持 `MMBench_Video_8frame_nopack: {}` 这种空字典 shortcut config。
 
 将示例配置json保存为`config.json`，您可以通过以下命令启动评估：
 

--- a/docs/zh-CN/ConfigSystem.md
+++ b/docs/zh-CN/ConfigSystem.md
@@ -44,13 +44,14 @@
 
 配置json的解释：
 
-1. 现在我们支持两个字段：`model`和`data`，每个字段都是一个字典。字典的键是模型/数据集的名称（由用户设置），值是模型/数据集的设置。
+1. 现在我们支持两个字段：`model`和`data`，每个字段都是一个字典。`model` 字典的 key 是模型名称；`data` 字典的 key 是输出别名。
 2. 对于`model`中的项目，值是一个包含以下键的字典：
     - `class`：模型的类名，应该是`vlmeval/vlm/__init__.py`（开源模型）或`vlmeval/api/__init__.py`（API模型）中定义的类名。
     - 其他kwargs：其他kwargs是模型特定的参数，请参考模型类的定义以获取详细用法。例如，`model`、`temperature`、`img_detail`是`GPT4V`类的参数。值得注意的是，大多数模型类都需要`model`参数。
     - Tip：在位于`vlmeval/config.py`的变量`supported_VLM`中的已经被定义的模型可以作为`model`的键，而不需要填对应的值即可启动。例如，`GPT4o_20240806_T00_HIGH: {}`是等价于`GPT4o_20240806_T00_HIGH: {'class': 'GPT4V', 'model': 'gpt-4o-2024-08-06', 'temperature': 0, 'img_size': -1, 'img_detail': 'high', 'retry': 10, 'verbose': False}`。
-3. 对于字典`data`，我们建议用户使用官方数据集名称作为键（或键的一部分），因为我们经常根据数据集名称确定后处理/判断设置。对于`data`中的项目，值是一个包含以下键的字典：
+3. 对于字典`data`，key 是输出别名，只影响预测文件、状态文件、复用产物和软链接等输出侧命名；数据集构造、后处理、判断设置和评测逻辑使用 value 中的 `dataset` 字段。对于`data`中的项目，值是一个包含以下键的字典：
     - `class`：数据集的类名，应该是`vlmeval/dataset/__init__.py`中定义的类名。
+    - `dataset`：真实数据集名称，也就是传给数据集类构造函数的名称。如果省略，则回退使用 `data` 的 key。
     - 其他kwargs：其他kwargs是数据集特定的参数，请参考数据集类的定义以获取详细用法。通常，大多数数据集类都需要`dataset`参数。大多数视频数据集类都需要 `nframe` 或 `fps` 参数。
     - Tip：在位于`vlmeval/dataset/video_dataset_config.py`的变量`supported_video_dataset`中的已经被定义的数据集可以作为`data`的键，而不需要填对应的值即可启动。例如，`MMBench_Video_8frame_nopack: {}`是等价于`MMBench_Video_8frame_nopack: {'class': 'MMBenchVideo', 'dataset': 'MMBench-Video', 'nframe': 8, 'pack': False}`。
 
@@ -60,7 +61,7 @@
 python run.py --config config.json
 ```
 
-这将在工作目录`$WORK_DIR`下生成以下输出文件（格式为`{$WORK_DIR}/{$MODEL_NAME}/{$MODEL_NAME}_{$DATASET_NAME}_*`）：
+这将在工作目录`$WORK_DIR`下生成以下输出文件（格式为`{$WORK_DIR}/{$MODEL_NAME}/{$MODEL_NAME}_{$DATA_ALIAS}_*`，其中 `$DATA_ALIAS` 是 `data` 的 key）：
 
 - `$WORK_DIR/GPT4o_20240806_T00_HIGH/GPT4o_20240806_T00_HIGH_MME-RealWorld-Lite*`
 - `$WORK_DIR/GPT4o_20240806_T10_Low/GPT4o_20240806_T10_Low_MME-RealWorld-Lite*`

--- a/docs/zh-CN/ConfigSystem.md
+++ b/docs/zh-CN/ConfigSystem.md
@@ -31,7 +31,9 @@
             "class": "ImageMCQDataset",
             "dataset": "MMBench_DEV_EN_V11"
         },
-        "MMBench_Video_8frame_nopack":{},
+        "MMBench_Video_8frame_nopack": {
+            "preset": "MMBench_Video_8frame_nopack"
+        },
         "Video-MME_16frame_subs": {
             "class": "VideoMME",
             "dataset": "Video-MME",
@@ -44,7 +46,7 @@
 
 配置json的解释：
 
-1. 现在我们支持两个字段：`model`和`data`，每个字段都是一个字典。`model` 字典的 key 是模型名称；`data` 字典的 key 是输出别名。
+1. 现在我们支持两个字段：`model`和`data`，每个字段都是一个字典。`model` 字典的 key 是模型名称；`data` 字典的 key 是输出别名。输出别名必须是安全的文件名组件：只能使用字母、数字、`.`、`_`、`-`，并且必须以字母或数字开头。
 2. 对于`model`中的项目，值是一个包含以下键的字典：
     - `class`：模型的类名，应该是`vlmeval/vlm/__init__.py`（开源模型）或`vlmeval/api/__init__.py`（API模型）中定义的类名。
     - 其他kwargs：其他kwargs是模型特定的参数，请参考模型类的定义以获取详细用法。例如，`model`、`temperature`、`img_detail`是`GPT4V`类的参数。值得注意的是，大多数模型类都需要`model`参数。

--- a/run.py
+++ b/run.py
@@ -220,6 +220,12 @@ def build_dataset_from_spec(spec, extra_kwargs=None):
     return build_dataset(spec.dataset_name, **(extra_kwargs or {}))
 
 
+def get_effective_dataset_class_name(spec, dataset):
+    if dataset is not None:
+        return dataset.__class__.__name__
+    return spec.dataset_class_name
+
+
 def apply_supported_vlm_cli_overrides(args):
     """Apply CLI overrides (retry/verbose/stream) to supported_VLM entries."""
     for k, v in supported_VLM.items():
@@ -743,6 +749,7 @@ def run_local_mode(args):
                     dist.barrier()
 
                 dataset = build_dataset_from_spec(spec, extra_kwargs=dataset_kwargs)
+                dataset_class_name = get_effective_dataset_class_name(spec, dataset)
                 if dataset is None:
                     logger.error(f'Dataset {dataset_name} is not valid, will be skipped. ')
                     if RANK == 0:
@@ -780,6 +787,8 @@ def run_local_mode(args):
                         model_name=model_name,
                         dataset_name=dataset_alias_name,
                         resolved_dataset_name=dataset_name,
+                        dataset_alias_name=dataset_alias_name,
+                        dataset_class_name=dataset_class_name,
                         source_run=reuse_ctx['source_eval_id'],
                         judge_model=judge_model,
                         reuse_aux=args.reuse_aux,
@@ -1047,6 +1056,8 @@ def run_local_mode(args):
                         model_name=model_name,
                         dataset_name=dataset_alias_name,
                         resolved_dataset_name=dataset_name,
+                        dataset_alias_name=dataset_alias_name,
+                        dataset_class_name=dataset_class_name,
                         status='done',
                         error_message=str(e),
                     )
@@ -1154,6 +1165,7 @@ def run_api_mode(args):
         try:
             dataset_kwargs = get_dataset_build_kwargs(ds_name, model_name)
             dataset = build_dataset_from_spec(spec, extra_kwargs=dataset_kwargs)
+            dataset_class_name = get_effective_dataset_class_name(spec, dataset)
 
             if dataset is None:
                 logger.error(f'Dataset {ds_name} is not valid, will be skipped.')

--- a/run.py
+++ b/run.py
@@ -367,7 +367,7 @@ def get_judge_kwargs(dataset_name, dataset_type, args):
                 judge_kwargs['model'] = 'exact_matching'
             else:
                 judge_kwargs['model'] = 'gpt-4o-mini'
-        elif listinstr(['MMVet', 'LLaVABench', 'MMBench_Video'], dataset_name):
+        elif listinstr(['MMVet', 'LLaVABench', 'MMBench_Video', 'MMBench-Video'], dataset_name):
             if listinstr(['LLaVABench_KO'], dataset_name):
                 judge_kwargs['model'] = 'gpt-4o-0806'
             else:

--- a/run.py
+++ b/run.py
@@ -61,8 +61,8 @@ from vlmeval.inference_video import infer_data_job_video
 from vlmeval.smp import (MMBenchOfficialServer, build_eval_id, collect_run_benchmark_report,
                          get_eval_file_format, get_logger, get_pred_file_format,
                          get_pred_file_path, githash, is_prediction_complete, listinstr, load,
-                         load_env, prepare_reuse_files, proxy_set, setup_logger, timestr,
-                         upsert_dataset_status, upsert_run_status)
+                         load_env, prepare_reuse_files, proxy_set, resolve_dataset_alias,
+                         setup_logger, timestr, upsert_dataset_status, upsert_run_status)
 from vlmeval.utils.result_transfer import MMMU_result_transfer, MMTBench_result_transfer
 
 logger = get_logger(__name__)
@@ -237,16 +237,14 @@ def load_data_config(data_config):
 
 
 def get_data_config_dataset_name(dataset_name, data_config):
+    data_config = data_config or {}
     if dataset_name in data_config:
         return data_config[dataset_name].get('dataset', dataset_name)
     return dataset_name
 
 
 def get_judge_dataset_name(dataset_name, data_config):
-    base_name = get_data_config_dataset_name(dataset_name, data_config)
-    if base_name == dataset_name:
-        return dataset_name
-    return f'{dataset_name} {base_name} {base_name.replace("-", "_")}'
+    return get_data_config_dataset_name(dataset_name, data_config)
 
 
 def get_dataset_build_kwargs(dataset_name, model_name, data_config):
@@ -258,6 +256,7 @@ def get_dataset_build_kwargs(dataset_name, model_name, data_config):
 
 
 def build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
+    data_config = data_config or {}
     if dataset_name in data_config:
         return build_dataset_from_config(
             data_config,
@@ -452,10 +451,11 @@ You can launch the evaluation by setting either --data and --model or --config.
         or you can check the output of the command `vlmutil dlist all` in the terminal.
     To find all supported video dataset default settings, please refer to the \
         `vlmeval/dataset/video_dataset_config.py` file.
-    You can also pass --data-config to define custom dataset names used by --data:
+    You can also pass --data-config to define output aliases used by --data:
         --data Video-MME-custom \
         --data-config '{"Video-MME-custom": {"class": "VideoMME", "dataset": "Video-MME", "nframe": 16}}'
     The value of --data-config must be a JSON dict string so evaluation parameters are recorded in argv.
+    The custom name is only used for output artifacts; dataset logic uses the `dataset` field.
 
 --config:
     Launch the evaluation by specifying the path to the config json file. Sample Json Content:
@@ -500,8 +500,9 @@ You can launch the evaluation by setting either --data and --model or --config.
     - `class`: The class name of the model, which should be a class in `vlmeval.vlm` or `vlmeval.api`.
     - Other keys are specific to the model, please refer to the corresponding class.
     - Tip: The defined model in the `supported_VLM` of `vlmeval/config.py` can be used as a shortcut.
-    For `data`, the key is the name of the dataset (should be the same as the `dataset` field in most cases, \
-        except for video datasets), and the value is a dictionary containing the following keys:
+    For `data`, the key is an output alias. It is used for prediction files, status entries, reuse artifacts, \
+        and symlinks. Dataset logic uses the `dataset` field in the value, falling back to the key if it is omitted.
+        The value is a dictionary containing the following keys:
     - `class`: The class name of the dataset, which should be a class in `vlmeval.dataset`.
     - `dataset`: The name of the dataset, which should be a string that is accepted by the `dataset` argument of the \
         corresponding class.
@@ -509,7 +510,8 @@ You can launch the evaluation by setting either --data and --model or --config.
     - Tip: The defined dataset in the `supported_video_datasets` of `vlmeval/dataset/video_dataset_config.py` \
         can be used as a shortcut.
 
-    The keys in the `model` and `data` fields will be used for naming the prediction files and evaluation results.
+    The keys in the `model` field and output aliases in the `data` field will be used for naming the prediction \
+    files and evaluation results.
     When launching with `--config`, args for API VLMs, such as `--retry`, `--verbose`, will be ignored.
 
 --api-mode:
@@ -524,7 +526,7 @@ You can launch the evaluation by setting either --data and --model or --config.
     parser.add_argument('--model', type=str, nargs='+', help='Names of Models')
     parser.add_argument('--config', type=str, help='Path to the Config Json File')
     parser.add_argument('--data-config', type=str, default=None,
-                        help='Custom dataset configs as a JSON dict string. Keys must match names passed to --data.')
+                        help='Custom dataset configs as a JSON dict string. Keys are output aliases passed to --data.')
 
     # Work Dir & Mode
     parser.add_argument('--work-dir', type=str, default='./outputs', help='select the output directory')
@@ -694,8 +696,15 @@ def run_local_mode(args):
             model_args['model'] = model_name
             model = LMDeployAPI(**model_args)
 
-        for _, dataset_name in enumerate(args.data):
-            logger.info(f'----------- {dataset_name} -----------')
+        data_config_for_alias = cfg['data'] if use_config else args.data_config
+        for _, data_entry_name in enumerate(args.data):
+            data_ctx = resolve_dataset_alias(data_entry_name, data_config_for_alias)
+            dataset_name = data_ctx.dataset_name
+            dataset_alias_name = data_ctx.dataset_alias_name
+            if dataset_alias_name == dataset_name:
+                logger.info(f'----------- {dataset_name} -----------')
+            else:
+                logger.info(f'----------- {dataset_alias_name} ({dataset_name}) -----------')
             if WORLD_SIZE > 1:
                 dist.barrier()
 
@@ -705,12 +714,13 @@ def run_local_mode(args):
 
             try:
                 result_file = get_pred_file_path(
-                    str(pred_root), model_name, dataset_name, use_env_format=True)
+                    str(pred_root), model_name, dataset_alias_name, use_env_format=True)
                 if RANK == 0:
                     upsert_dataset_status(
                         run_dir=pred_root,
                         model_name=model_name,
-                        dataset_name=dataset_name,
+                        dataset_name=dataset_alias_name,
+                        logical_dataset_name=dataset_name,
                         prediction_file=result_file,
                         status='pending',
                     )
@@ -718,44 +728,45 @@ def run_local_mode(args):
                 if use_config:
                     if WORLD_SIZE > 1:
                         if RANK == 0:
-                            dataset = build_dataset_from_config(cfg['data'], dataset_name)
+                            dataset = build_dataset_from_config(cfg['data'], dataset_alias_name)
                         dist.barrier()
-                    dataset = build_dataset_from_config(cfg['data'], dataset_name)
+                    dataset = build_dataset_from_config(cfg['data'], dataset_alias_name)
                     if dataset is None:
                         logger.error(f'Dataset {dataset_name} is not valid, will be skipped. ')
                         if RANK == 0:
                             upsert_dataset_status(
                                 run_dir=pred_root,
                                 model_name=model_name,
-                                dataset_name=dataset_name,
+                                dataset_name=dataset_alias_name,
+                                logical_dataset_name=dataset_name,
                                 status='done',
                                 skip_reason='invalid_dataset',
                             )
                         continue
                 else:
-                    dataset_kwargs = get_dataset_build_kwargs(dataset_name, model_name, args.data_config)
+                    dataset_kwargs = get_dataset_build_kwargs(dataset_name, model_name, None)
 
                     # If distributed, first build the dataset on the main process for doing preparation works
                     if WORLD_SIZE > 1:
                         if RANK == 0:
-                            dataset = build_dataset_from_cli(dataset_name, args.data_config, dataset_kwargs)
+                            dataset = build_dataset_from_cli(dataset_alias_name, args.data_config, dataset_kwargs)
                         dist.barrier()
 
-                    dataset = build_dataset_from_cli(dataset_name, args.data_config, dataset_kwargs)
+                    dataset = build_dataset_from_cli(dataset_alias_name, args.data_config, dataset_kwargs)
                     if dataset is None:
                         logger.error(f'Dataset {dataset_name} is not valid, will be skipped. ')
                         if RANK == 0:
                             upsert_dataset_status(
                                 run_dir=pred_root,
                                 model_name=model_name,
-                                dataset_name=dataset_name,
+                                dataset_name=dataset_alias_name,
+                                logical_dataset_name=dataset_name,
                                 status='done',
                                 skip_reason='invalid_dataset',
                             )
                         continue
 
-                judge_dataset_name = get_judge_dataset_name(dataset_name, args.data_config)
-                judge_kwargs = get_judge_kwargs(judge_dataset_name, dataset.TYPE, args)
+                judge_kwargs = get_judge_kwargs(dataset_name, dataset.TYPE, args)
                 judge_model = judge_kwargs.get('model', '')
 
                 if RANK == 0:
@@ -763,7 +774,7 @@ def run_local_mode(args):
                         pred_root_meta=pred_root_meta,
                         eval_id=eval_id,
                         model_name=model_name,
-                        dataset_name=dataset_name,
+                        dataset_name=dataset_alias_name,
                         dataset=dataset,
                         result_file=result_file,
                         reuse=args.reuse,
@@ -775,7 +786,8 @@ def run_local_mode(args):
                     upsert_dataset_status(
                         run_dir=pred_root,
                         model_name=model_name,
-                        dataset_name=dataset_name,
+                        dataset_name=dataset_alias_name,
+                        logical_dataset_name=dataset_name,
                         source_run=reuse_ctx['source_eval_id'],
                         judge_model=judge_model,
                         reuse_aux=args.reuse_aux,
@@ -803,7 +815,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason=skip_reason,
                         )
@@ -817,7 +830,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='infer',
                         )
                     # Perform the Inference
@@ -828,6 +842,7 @@ def run_local_mode(args):
                             model_name=model_name,
                             dataset=dataset,
                             result_file=result_file,
+                            dataset_alias_name=dataset_alias_name,
                             verbose=args.verbose,
                             api_nproc=args.api_nproc,
                             use_vllm=args.use_vllm,
@@ -838,6 +853,8 @@ def run_local_mode(args):
                             work_dir=pred_root,
                             model_name=model_name,
                             dataset=dataset,
+                            result_file=result_file,
+                            dataset_alias_name=dataset_alias_name,
                             verbose=args.verbose,
                             api_nproc=args.api_nproc,
                             retry_failed=not args.keep_failed,
@@ -848,6 +865,8 @@ def run_local_mode(args):
                             work_dir=pred_root,
                             model_name=model_name,
                             dataset=dataset,
+                            result_file=result_file,
+                            dataset_alias_name=dataset_alias_name,
                             verbose=args.verbose,
                             api_nproc=args.api_nproc,
                             retry_failed=not args.keep_failed,
@@ -862,7 +881,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='eval',
                         )
                     # Prepare Submission Files for MMMU_TEST AND MMT-Bench_ALL
@@ -873,7 +893,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='official_submission_only_mmmu_test',
                         )
@@ -886,7 +907,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='official_submission_only_mmt_bench',
                         )
@@ -897,7 +919,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='mode_infer',
                         )
@@ -909,7 +932,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='evaluation_not_supported_for_dataset',
                         )
@@ -920,7 +944,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='external_submission_required',
                         )
@@ -931,7 +956,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='test_split_without_ground_truth',
                         )
@@ -945,7 +971,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='mmbench_evaluation_requires_official_server',
                         )
@@ -974,7 +1001,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             metrics_source=summary_eval_results,
                             dataset_obj=dataset,
@@ -983,7 +1011,8 @@ def run_local_mode(args):
                         upsert_dataset_status(
                             run_dir=pred_root,
                             model_name=model_name,
-                            dataset_name=dataset_name,
+                            dataset_name=dataset_alias_name,
+                            logical_dataset_name=dataset_name,
                             status='done',
                             skip_reason='evaluate_returned_none',
                         )
@@ -996,7 +1025,7 @@ def run_local_mode(args):
                     files = [
                         path for path in pred_root.iterdir()
                         if path.is_file() and (
-                            f'{model_name}_{dataset_name}' in path.name or path.name == 'status.json'
+                            f'{model_name}_{dataset_alias_name}' in path.name or path.name == 'status.json'
                         )
                     ]
                     # Exclude temporary intermediate files
@@ -1014,13 +1043,15 @@ def run_local_mode(args):
                         link_addr.symlink_to(rel_target)
 
             except Exception as e:
-                logger.exception(f'Model {model_name} x Dataset {dataset_name} combination failed: {e}, '
-                                 'skipping this combination.')
+                logger.exception(
+                    f'Model {model_name} x Dataset {dataset_alias_name} ({dataset_name}) combination failed: {e}, '
+                    'skipping this combination.')
                 if RANK == 0:
                     upsert_dataset_status(
                         run_dir=pred_root,
                         model_name=model_name,
-                        dataset_name=dataset_name,
+                        dataset_name=dataset_alias_name,
+                        logical_dataset_name=dataset_name,
                         status='done',
                         error_message=str(e),
                     )
@@ -1115,12 +1146,18 @@ def run_api_mode(args):
     # Prepare all datasets
     dataset_configs: List[DatasetConfig] = []
 
-    for ds_name in args.data:
-        logger.info(f'-------------------- {ds_name} --------------------')
+    for data_entry_name in args.data:
+        data_ctx = resolve_dataset_alias(data_entry_name, args.data_config)
+        ds_name = data_ctx.dataset_name
+        dataset_alias_name = data_ctx.dataset_alias_name
+        if dataset_alias_name == ds_name:
+            logger.info(f'-------------------- {ds_name} --------------------')
+        else:
+            logger.info(f'-------------------- {dataset_alias_name} ({ds_name}) --------------------')
 
         try:
-            dataset_kwargs = get_dataset_build_kwargs(ds_name, model_name, args.data_config)
-            dataset = build_dataset_from_cli(ds_name, args.data_config, dataset_kwargs)
+            dataset_kwargs = get_dataset_build_kwargs(ds_name, model_name, None)
+            dataset = build_dataset_from_cli(dataset_alias_name, args.data_config, dataset_kwargs)
 
             if dataset is None:
                 logger.error(f'Dataset {ds_name} is not valid, will be skipped.')
@@ -1128,7 +1165,7 @@ def run_api_mode(args):
 
             # Prepare the result file.
             result_file = get_pred_file_path(
-                pred_root, model_name, ds_name, use_env_format=True)
+                pred_root, model_name, dataset_alias_name, use_env_format=True)
 
             # Skip special datasets.
             if ds_name in ['MMMU_TEST']:
@@ -1138,8 +1175,7 @@ def run_api_mode(args):
                 logger.info(f'{ds_name} requires special handling, skipped in pipeline.')
                 continue
 
-            judge_dataset_name = get_judge_dataset_name(ds_name, args.data_config)
-            judge_kwargs = get_judge_kwargs(judge_dataset_name, dataset.TYPE, args)
+            judge_kwargs = get_judge_kwargs(ds_name, dataset.TYPE, args)
             judge_model = judge_kwargs.get('model', '')
             logger.info(f'Judge kwargs: {judge_kwargs}')
 
@@ -1147,7 +1183,7 @@ def run_api_mode(args):
                 pred_root_meta=str(work_dir),
                 eval_id=eval_id,
                 model_name=model_name,
-                dataset_name=ds_name,
+                dataset_name=dataset_alias_name,
                 dataset=dataset,
                 result_file=result_file,
                 reuse=args.reuse,
@@ -1159,7 +1195,8 @@ def run_api_mode(args):
             upsert_dataset_status(
                 run_dir=pred_root,
                 model_name=model_name,
-                dataset_name=ds_name,
+                dataset_name=dataset_alias_name,
+                logical_dataset_name=ds_name,
                 prediction_file=result_file,
                 source_run=reuse_ctx['source_eval_id'],
                 judge_model=judge_model,
@@ -1178,13 +1215,14 @@ def run_api_mode(args):
                     upsert_dataset_status(
                         run_dir=pred_root,
                         model_name=model_name,
-                        dataset_name=ds_name,
+                        dataset_name=dataset_alias_name,
+                        logical_dataset_name=ds_name,
                         status='done',
                         skip_reason=skip_reason,
                     )
                 except Exception as summary_err:
                     logger.warning(
-                        f'Failed to update status.json for {model_name} x {ds_name}: {summary_err}'
+                        f'Failed to update status.json for {model_name} x {dataset_alias_name}: {summary_err}'
                     )
                 continue
 
@@ -1197,6 +1235,7 @@ def run_api_mode(args):
                 dataset_type = 'image'
             dataset_config = DatasetConfig(
                 dataset_name=ds_name,
+                dataset_alias_name=dataset_alias_name,
                 dataset_obj=dataset,
                 dataset_type=dataset_type,
                 model_obj=model_builder(),
@@ -1209,7 +1248,7 @@ def run_api_mode(args):
             dataset_configs.append(dataset_config)
 
         except Exception as e:
-            logger.exception(f'Failed to prepare dataset {ds_name}: {e}')
+            logger.exception(f'Failed to prepare dataset {dataset_alias_name} ({ds_name}): {e}')
             continue
 
     # Create and run pipeline

--- a/run.py
+++ b/run.py
@@ -54,14 +54,13 @@ if LOCAL_WORLD_SIZE > 1 and len(GPU_LIST):
 from vlmeval.api import LMDeployAPI
 from vlmeval.config import supported_VLM
 from vlmeval.dataset import build_dataset
-from vlmeval.dataset.video_dataset_config import supported_video_datasets
 from vlmeval.inference import infer_data_job
 from vlmeval.inference_mt import infer_data_job_mt
 from vlmeval.inference_video import infer_data_job_video
 from vlmeval.smp import (MMBenchOfficialServer, build_eval_id, collect_run_benchmark_report,
                          get_eval_file_format, get_logger, get_pred_file_format,
                          get_pred_file_path, githash, is_prediction_complete, listinstr, load,
-                         load_env, prepare_reuse_files, proxy_set, resolve_dataset_alias,
+                         load_env, prepare_reuse_files, proxy_set, resolve_dataset_spec,
                          setup_logger, timestr, upsert_dataset_status, upsert_run_status)
 from vlmeval.utils.result_transfer import MMMU_result_transfer, MMTBench_result_transfer
 
@@ -162,18 +161,27 @@ def build_model_from_config(cfg, model_name, use_vllm=False):
     return model
 
 
-def build_dataset_from_config(cfg, dataset_name, *, strict=False, extra_kwargs=None):
+def _require_non_empty_str(config, key, display_name):
+    value = config.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f'`{key}` must be set to a non-empty string for dataset config {display_name}')
+    return value
+
+
+def build_dataset_from_config_dict(config, *, display_name=None, strict=True, extra_kwargs=None):
     import inspect
 
     import vlmeval.dataset
-    config = cp.deepcopy(cfg[dataset_name])
+    display_name = display_name or '<inline>'
+    config = cp.deepcopy(config)
     if config == {}:
-        if dataset_name not in supported_video_datasets:
-            raise ValueError(f'Empty dataset config {dataset_name} is not a supported video dataset shortcut')
-        return supported_video_datasets[dataset_name](**(extra_kwargs or {}))
-    if 'class' not in config:
-        raise ValueError(f'`class` must be set for dataset config {dataset_name}')
-    cls_name = config.pop('class')
+        raise ValueError(
+            f'Empty dataset config {display_name} is not supported. '
+            'Use direct --data shortcut or set a preset explicitly.'
+        )
+    cls_name = _require_non_empty_str(config, 'class', display_name)
+    _require_non_empty_str(config, 'dataset', display_name)
+    config.pop('class')
     if extra_kwargs:
         for k, v in extra_kwargs.items():
             config.setdefault(k, v)
@@ -185,14 +193,31 @@ def build_dataset_from_config(cfg, dataset_name, *, strict=False, extra_kwargs=N
             unknown = ', '.join(unknown_params)
             raise ValueError(f'Unsupported parameter(s) for dataset class {cls_name}: {unknown}')
         valid_params = {k: v for k, v in config.items() if k in sig.parameters}
-        if getattr(cls, 'MODALITY', None) == 'VIDEO':
-            if valid_params.get('fps', 0) > 0 and valid_params.get('nframe', 0) > 0:
-                raise ValueError('fps and nframe should not be set at the same time')
-            if valid_params.get('fps', 0) <= 0 and valid_params.get('nframe', 0) <= 0:
-                raise ValueError('fps and nframe should be set at least one valid value')
+        if hasattr(cls, 'validate_build_config'):
+            cls.validate_build_config(valid_params)
         return cls(**valid_params)
     else:
         raise ValueError(f'Class {cls_name} is not supported in `vlmeval.dataset`')
+
+
+def build_dataset_from_config(cfg, dataset_name, *, strict=True, extra_kwargs=None):
+    return build_dataset_from_config_dict(
+        cfg[dataset_name],
+        display_name=dataset_name,
+        strict=strict,
+        extra_kwargs=extra_kwargs,
+    )
+
+
+def build_dataset_from_spec(spec, extra_kwargs=None):
+    if spec.source in {'explicit_config', 'preset_config', 'predefined_shortcut'}:
+        return build_dataset_from_config_dict(
+            spec.build_config,
+            display_name=spec.dataset_alias_name,
+            strict=True,
+            extra_kwargs=extra_kwargs,
+        )
+    return build_dataset(spec.dataset_name, **(extra_kwargs or {}))
 
 
 def apply_supported_vlm_cli_overrides(args):
@@ -236,35 +261,16 @@ def load_data_config(data_config):
     return config
 
 
-def get_data_config_dataset_name(dataset_name, data_config):
-    data_config = data_config or {}
-    if dataset_name in data_config:
-        return data_config[dataset_name].get('dataset', dataset_name)
-    return dataset_name
-
-
-def get_judge_dataset_name(dataset_name, data_config):
-    return get_data_config_dataset_name(dataset_name, data_config)
-
-
-def get_dataset_build_kwargs(dataset_name, model_name, data_config):
+def get_dataset_build_kwargs(dataset_name, model_name):
     dataset_kwargs = {}
-    base_name = get_data_config_dataset_name(dataset_name, data_config)
-    if base_name in ['MMLongBench_DOC', 'DUDE', 'DUDE_MINI', 'SLIDEVQA', 'SLIDEVQA_MINI']:
+    if dataset_name in ['MMLongBench_DOC', 'DUDE', 'DUDE_MINI', 'SLIDEVQA', 'SLIDEVQA_MINI']:
         dataset_kwargs['model'] = model_name
     return dataset_kwargs
 
 
 def build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
-    data_config = data_config or {}
-    if dataset_name in data_config:
-        return build_dataset_from_config(
-            data_config,
-            dataset_name,
-            strict=True,
-            extra_kwargs=dataset_kwargs,
-        )
-    return build_dataset(dataset_name, **dataset_kwargs)
+    spec = resolve_dataset_spec(dataset_name, data_config)
+    return build_dataset_from_spec(spec, extra_kwargs=dataset_kwargs)
 
 
 def build_model_from_base_url(args):
@@ -501,14 +507,14 @@ You can launch the evaluation by setting either --data and --model or --config.
     - Other keys are specific to the model, please refer to the corresponding class.
     - Tip: The defined model in the `supported_VLM` of `vlmeval/config.py` can be used as a shortcut.
     For `data`, the key is an output alias. It is used for prediction files, status entries, reuse artifacts, \
-        and symlinks. Dataset logic uses the `dataset` field in the value, falling back to the key if it is omitted.
+        and symlinks. Dataset logic uses the `dataset` field in the value, or the referenced predefined `preset`.
         The value is a dictionary containing the following keys:
     - `class`: The class name of the dataset, which should be a class in `vlmeval.dataset`.
     - `dataset`: The name of the dataset, which should be a string that is accepted by the `dataset` argument of the \
         corresponding class.
     - Other keys are specific to the dataset, please refer to the corresponding class.
-    - Tip: The defined dataset in the `supported_video_datasets` of `vlmeval/dataset/video_dataset_config.py` \
-        can be used as a shortcut.
+    - Tip: Predefined video shortcuts can be used directly via `--data Video-MME_8frame`, or reused by an \
+        output alias with `{"preset": "Video-MME_8frame"}`. Empty dict shortcut configs are not supported.
 
     The keys in the `model` field and output aliases in the `data` field will be used for naming the prediction \
     files and evaluation results.
@@ -698,9 +704,10 @@ def run_local_mode(args):
 
         data_config_for_alias = cfg['data'] if use_config else args.data_config
         for _, data_entry_name in enumerate(args.data):
-            data_ctx = resolve_dataset_alias(data_entry_name, data_config_for_alias)
-            dataset_name = data_ctx.dataset_name
-            dataset_alias_name = data_ctx.dataset_alias_name
+            spec = resolve_dataset_spec(data_entry_name, data_config_for_alias)
+            dataset_name = spec.dataset_name
+            dataset_alias_name = spec.dataset_alias_name
+            dataset_class_name = spec.dataset_class_name
             if dataset_alias_name == dataset_name:
                 logger.info(f'----------- {dataset_name} -----------')
             else:
@@ -720,51 +727,36 @@ def run_local_mode(args):
                         run_dir=pred_root,
                         model_name=model_name,
                         dataset_name=dataset_alias_name,
-                        logical_dataset_name=dataset_name,
+                        resolved_dataset_name=dataset_name,
+                        dataset_alias_name=dataset_alias_name,
+                        dataset_class_name=dataset_class_name,
                         prediction_file=result_file,
                         status='pending',
                     )
 
-                if use_config:
-                    if WORLD_SIZE > 1:
-                        if RANK == 0:
-                            dataset = build_dataset_from_config(cfg['data'], dataset_alias_name)
-                        dist.barrier()
-                    dataset = build_dataset_from_config(cfg['data'], dataset_alias_name)
-                    if dataset is None:
-                        logger.error(f'Dataset {dataset_name} is not valid, will be skipped. ')
-                        if RANK == 0:
-                            upsert_dataset_status(
-                                run_dir=pred_root,
-                                model_name=model_name,
-                                dataset_name=dataset_alias_name,
-                                logical_dataset_name=dataset_name,
-                                status='done',
-                                skip_reason='invalid_dataset',
-                            )
-                        continue
-                else:
-                    dataset_kwargs = get_dataset_build_kwargs(dataset_name, model_name, None)
+                dataset_kwargs = get_dataset_build_kwargs(dataset_name, model_name)
 
-                    # If distributed, first build the dataset on the main process for doing preparation works
-                    if WORLD_SIZE > 1:
-                        if RANK == 0:
-                            dataset = build_dataset_from_cli(dataset_alias_name, args.data_config, dataset_kwargs)
-                        dist.barrier()
+                # If distributed, first build the dataset on the main process for doing preparation works
+                if WORLD_SIZE > 1:
+                    if RANK == 0:
+                        dataset = build_dataset_from_spec(spec, extra_kwargs=dataset_kwargs)
+                    dist.barrier()
 
-                    dataset = build_dataset_from_cli(dataset_alias_name, args.data_config, dataset_kwargs)
-                    if dataset is None:
-                        logger.error(f'Dataset {dataset_name} is not valid, will be skipped. ')
-                        if RANK == 0:
-                            upsert_dataset_status(
-                                run_dir=pred_root,
-                                model_name=model_name,
-                                dataset_name=dataset_alias_name,
-                                logical_dataset_name=dataset_name,
-                                status='done',
-                                skip_reason='invalid_dataset',
-                            )
-                        continue
+                dataset = build_dataset_from_spec(spec, extra_kwargs=dataset_kwargs)
+                if dataset is None:
+                    logger.error(f'Dataset {dataset_name} is not valid, will be skipped. ')
+                    if RANK == 0:
+                        upsert_dataset_status(
+                            run_dir=pred_root,
+                            model_name=model_name,
+                            dataset_name=dataset_alias_name,
+                            resolved_dataset_name=dataset_name,
+                            dataset_alias_name=dataset_alias_name,
+                            dataset_class_name=dataset_class_name,
+                            status='done',
+                            skip_reason='invalid_dataset',
+                        )
+                    continue
 
                 judge_kwargs = get_judge_kwargs(dataset_name, dataset.TYPE, args)
                 judge_model = judge_kwargs.get('model', '')
@@ -787,7 +779,7 @@ def run_local_mode(args):
                         run_dir=pred_root,
                         model_name=model_name,
                         dataset_name=dataset_alias_name,
-                        logical_dataset_name=dataset_name,
+                        resolved_dataset_name=dataset_name,
                         source_run=reuse_ctx['source_eval_id'],
                         judge_model=judge_model,
                         reuse_aux=args.reuse_aux,
@@ -816,7 +808,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason=skip_reason,
                         )
@@ -831,7 +823,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='infer',
                         )
                     # Perform the Inference
@@ -842,6 +834,7 @@ def run_local_mode(args):
                             model_name=model_name,
                             dataset=dataset,
                             result_file=result_file,
+                            dataset_name=dataset_name,
                             dataset_alias_name=dataset_alias_name,
                             verbose=args.verbose,
                             api_nproc=args.api_nproc,
@@ -854,6 +847,7 @@ def run_local_mode(args):
                             model_name=model_name,
                             dataset=dataset,
                             result_file=result_file,
+                            dataset_name=dataset_name,
                             dataset_alias_name=dataset_alias_name,
                             verbose=args.verbose,
                             api_nproc=args.api_nproc,
@@ -866,6 +860,7 @@ def run_local_mode(args):
                             model_name=model_name,
                             dataset=dataset,
                             result_file=result_file,
+                            dataset_name=dataset_name,
                             dataset_alias_name=dataset_alias_name,
                             verbose=args.verbose,
                             api_nproc=args.api_nproc,
@@ -882,7 +877,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='eval',
                         )
                     # Prepare Submission Files for MMMU_TEST AND MMT-Bench_ALL
@@ -894,7 +889,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='official_submission_only_mmmu_test',
                         )
@@ -908,7 +903,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='official_submission_only_mmt_bench',
                         )
@@ -920,7 +915,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='mode_infer',
                         )
@@ -933,7 +928,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='evaluation_not_supported_for_dataset',
                         )
@@ -945,7 +940,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='external_submission_required',
                         )
@@ -957,7 +952,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='test_split_without_ground_truth',
                         )
@@ -972,7 +967,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='mmbench_evaluation_requires_official_server',
                         )
@@ -1002,7 +997,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             metrics_source=summary_eval_results,
                             dataset_obj=dataset,
@@ -1012,7 +1007,7 @@ def run_local_mode(args):
                             run_dir=pred_root,
                             model_name=model_name,
                             dataset_name=dataset_alias_name,
-                            logical_dataset_name=dataset_name,
+                            resolved_dataset_name=dataset_name,
                             status='done',
                             skip_reason='evaluate_returned_none',
                         )
@@ -1051,7 +1046,7 @@ def run_local_mode(args):
                         run_dir=pred_root,
                         model_name=model_name,
                         dataset_name=dataset_alias_name,
-                        logical_dataset_name=dataset_name,
+                        resolved_dataset_name=dataset_name,
                         status='done',
                         error_message=str(e),
                     )
@@ -1147,17 +1142,18 @@ def run_api_mode(args):
     dataset_configs: List[DatasetConfig] = []
 
     for data_entry_name in args.data:
-        data_ctx = resolve_dataset_alias(data_entry_name, args.data_config)
-        ds_name = data_ctx.dataset_name
-        dataset_alias_name = data_ctx.dataset_alias_name
+        spec = resolve_dataset_spec(data_entry_name, args.data_config)
+        ds_name = spec.dataset_name
+        dataset_alias_name = spec.dataset_alias_name
+        dataset_class_name = spec.dataset_class_name
         if dataset_alias_name == ds_name:
             logger.info(f'-------------------- {ds_name} --------------------')
         else:
             logger.info(f'-------------------- {dataset_alias_name} ({ds_name}) --------------------')
 
         try:
-            dataset_kwargs = get_dataset_build_kwargs(ds_name, model_name, None)
-            dataset = build_dataset_from_cli(dataset_alias_name, args.data_config, dataset_kwargs)
+            dataset_kwargs = get_dataset_build_kwargs(ds_name, model_name)
+            dataset = build_dataset_from_spec(spec, extra_kwargs=dataset_kwargs)
 
             if dataset is None:
                 logger.error(f'Dataset {ds_name} is not valid, will be skipped.')
@@ -1196,7 +1192,9 @@ def run_api_mode(args):
                 run_dir=pred_root,
                 model_name=model_name,
                 dataset_name=dataset_alias_name,
-                logical_dataset_name=ds_name,
+                resolved_dataset_name=ds_name,
+                dataset_alias_name=dataset_alias_name,
+                dataset_class_name=dataset_class_name,
                 prediction_file=result_file,
                 source_run=reuse_ctx['source_eval_id'],
                 judge_model=judge_model,
@@ -1216,7 +1214,9 @@ def run_api_mode(args):
                         run_dir=pred_root,
                         model_name=model_name,
                         dataset_name=dataset_alias_name,
-                        logical_dataset_name=ds_name,
+                        resolved_dataset_name=ds_name,
+                        dataset_alias_name=dataset_alias_name,
+                        dataset_class_name=dataset_class_name,
                         status='done',
                         skip_reason=skip_reason,
                     )
@@ -1236,6 +1236,7 @@ def run_api_mode(args):
             dataset_config = DatasetConfig(
                 dataset_name=ds_name,
                 dataset_alias_name=dataset_alias_name,
+                dataset_class_name=dataset_class_name,
                 dataset_obj=dataset,
                 dataset_type=dataset_type,
                 model_obj=model_builder(),

--- a/run.py
+++ b/run.py
@@ -468,6 +468,7 @@ You can launch the evaluation by setting either --data and --model or --config.
         --data-config '{"Video-MME-custom": {"class": "VideoMME", "dataset": "Video-MME", "nframe": 16}}'
     The value of --data-config must be a JSON dict string so evaluation parameters are recorded in argv.
     The custom name is only used for output artifacts; dataset logic uses the `dataset` field.
+    Output aliases must use only letters, digits, ".", "_", and "-", and start with a letter or digit.
 
 --config:
     Launch the evaluation by specifying the path to the config json file. Sample Json Content:
@@ -497,7 +498,9 @@ You can launch the evaluation by setting either --data and --model or --config.
                 "class": "ImageMCQDataset",
                 "dataset": "MMBench_DEV_EN_V11"
             },
-            "MMBench_Video_8frame_nopack": {},
+            "MMBench_Video_8frame_nopack": {
+                "preset": "MMBench_Video_8frame_nopack"
+            },
             "Video-MME_16frame_subs": {
                 "class": "VideoMME",
                 "dataset": "Video-MME",
@@ -512,7 +515,8 @@ You can launch the evaluation by setting either --data and --model or --config.
     - `class`: The class name of the model, which should be a class in `vlmeval.vlm` or `vlmeval.api`.
     - Other keys are specific to the model, please refer to the corresponding class.
     - Tip: The defined model in the `supported_VLM` of `vlmeval/config.py` can be used as a shortcut.
-    For `data`, the key is an output alias. It is used for prediction files, status entries, reuse artifacts, \
+    For `data`, the key is an output alias. It must use only letters, digits, ".", "_", and "-", and start with \
+        a letter or digit. It is used for prediction files, status entries, reuse artifacts, \
         and symlinks. Dataset logic uses the `dataset` field in the value, or the referenced predefined `preset`.
         The value is a dictionary containing the following keys:
     - `class`: The class name of the dataset, which should be a class in `vlmeval.dataset`.

--- a/tests/fixtures/predefined_video_shortcuts_manifest.json
+++ b/tests/fixtures/predefined_video_shortcuts_manifest.json
@@ -1,0 +1,2206 @@
+{
+  "AV-SpeakerBench_16frame": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 16,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_16frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_1fps": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "fps": 1.0,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_1fps",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_8frame": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 8,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_8frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_audio_only_16frame": {
+    "build_config": {
+      "audio_only": true,
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 16,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_audio_only_16frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_audio_only_1fps": {
+    "build_config": {
+      "audio_only": true,
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "fps": 1.0,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_audio_only_1fps",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_audio_only_8frame": {
+    "build_config": {
+      "audio_only": true,
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 8,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_audio_only_8frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_audiovisual_16frame": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 16,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_audiovisual_16frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_audiovisual_1fps": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "fps": 1.0,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_audiovisual_1fps",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_audiovisual_8frame": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 8,
+      "use_audio": true
+    },
+    "dataset_alias_name": "AV-SpeakerBench_audiovisual_8frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_visual_16frame": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 16,
+      "use_audio": false
+    },
+    "dataset_alias_name": "AV-SpeakerBench_visual_16frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_visual_1fps": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "fps": 1.0,
+      "use_audio": false
+    },
+    "dataset_alias_name": "AV-SpeakerBench_visual_1fps",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "AV-SpeakerBench_visual_8frame": {
+    "build_config": {
+      "class": "AVSpeakerBench",
+      "dataset": "AV-SpeakerBench",
+      "nframe": 8,
+      "use_audio": false
+    },
+    "dataset_alias_name": "AV-SpeakerBench_visual_8frame",
+    "dataset_class_name": "AVSpeakerBench",
+    "dataset_name": "AV-SpeakerBench"
+  },
+  "CG-AV-Counting_32frame": {
+    "build_config": {
+      "class": "CGAVCounting",
+      "dataset": "CG-AV-Counting",
+      "nframe": 32,
+      "use_frame_time": false
+    },
+    "dataset_alias_name": "CG-AV-Counting_32frame",
+    "dataset_class_name": "CGAVCounting",
+    "dataset_name": "CG-AV-Counting"
+  },
+  "CG-AV-Counting_64frame": {
+    "build_config": {
+      "class": "CGAVCounting",
+      "dataset": "CG-AV-Counting",
+      "nframe": 64,
+      "use_frame_time": false
+    },
+    "dataset_alias_name": "CG-AV-Counting_64frame",
+    "dataset_class_name": "CGAVCounting",
+    "dataset_name": "CG-AV-Counting"
+  },
+  "CGBench_MCQ_Grounding_16frame_subs_subt_ft": {
+    "build_config": {
+      "class": "CGBench_MCQ_Grounding",
+      "dataset": "CG-Bench_MCQ_Grounding",
+      "nframe": 16,
+      "use_frame_time": true,
+      "use_subtitle": true,
+      "use_subtitle_time": true
+    },
+    "dataset_alias_name": "CGBench_MCQ_Grounding_16frame_subs_subt_ft",
+    "dataset_class_name": "CGBench_MCQ_Grounding",
+    "dataset_name": "CG-Bench_MCQ_Grounding"
+  },
+  "CGBench_MCQ_Grounding_32frame_subs": {
+    "build_config": {
+      "class": "CGBench_MCQ_Grounding",
+      "dataset": "CG-Bench_MCQ_Grounding",
+      "nframe": 32,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "CGBench_MCQ_Grounding_32frame_subs",
+    "dataset_class_name": "CGBench_MCQ_Grounding",
+    "dataset_name": "CG-Bench_MCQ_Grounding"
+  },
+  "CGBench_MCQ_Grounding_Mini_8frame_subs_subt": {
+    "build_config": {
+      "class": "CGBench_MCQ_Grounding_Mini",
+      "dataset": "CG-Bench_MCQ_Grounding_Mini",
+      "nframe": 8,
+      "use_subtitle": true,
+      "use_subtitle_time": true
+    },
+    "dataset_alias_name": "CGBench_MCQ_Grounding_Mini_8frame_subs_subt",
+    "dataset_class_name": "CGBench_MCQ_Grounding_Mini",
+    "dataset_name": "CG-Bench_MCQ_Grounding_Mini"
+  },
+  "CGBench_OpenEnded_16frame_subs_subt_ft": {
+    "build_config": {
+      "class": "CGBench_OpenEnded",
+      "dataset": "CG-Bench_OpenEnded",
+      "nframe": 16,
+      "use_frame_time": true,
+      "use_subtitle": true,
+      "use_subtitle_time": true
+    },
+    "dataset_alias_name": "CGBench_OpenEnded_16frame_subs_subt_ft",
+    "dataset_class_name": "CGBench_OpenEnded",
+    "dataset_name": "CG-Bench_OpenEnded"
+  },
+  "CGBench_OpenEnded_8frame": {
+    "build_config": {
+      "class": "CGBench_OpenEnded",
+      "dataset": "CG-Bench_OpenEnded",
+      "nframe": 8
+    },
+    "dataset_alias_name": "CGBench_OpenEnded_8frame",
+    "dataset_class_name": "CGBench_OpenEnded",
+    "dataset_name": "CG-Bench_OpenEnded"
+  },
+  "CGBench_OpenEnded_Mini_8frame_subs_subt_ft": {
+    "build_config": {
+      "class": "CGBench_OpenEnded_Mini",
+      "dataset": "CG-Bench_OpenEnded_Mini",
+      "nframe": 8,
+      "use_frame_time": true,
+      "use_subtitle": true,
+      "use_subtitle_time": true
+    },
+    "dataset_alias_name": "CGBench_OpenEnded_Mini_8frame_subs_subt_ft",
+    "dataset_class_name": "CGBench_OpenEnded_Mini",
+    "dataset_name": "CG-Bench_OpenEnded_Mini"
+  },
+  "DREAM-1K_0.5fps": {
+    "build_config": {
+      "class": "DREAM",
+      "dataset": "DREAM-1K",
+      "fps": 0.5
+    },
+    "dataset_alias_name": "DREAM-1K_0.5fps",
+    "dataset_class_name": "DREAM",
+    "dataset_name": "DREAM-1K"
+  },
+  "DREAM-1K_1fps": {
+    "build_config": {
+      "class": "DREAM",
+      "dataset": "DREAM-1K",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "DREAM-1K_1fps",
+    "dataset_class_name": "DREAM",
+    "dataset_name": "DREAM-1K"
+  },
+  "DREAM-1K_2fps": {
+    "build_config": {
+      "class": "DREAM",
+      "dataset": "DREAM-1K",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "DREAM-1K_2fps",
+    "dataset_class_name": "DREAM",
+    "dataset_name": "DREAM-1K"
+  },
+  "DREAM-1K_64frame": {
+    "build_config": {
+      "class": "DREAM",
+      "dataset": "DREAM-1K",
+      "nframe": 64
+    },
+    "dataset_alias_name": "DREAM-1K_64frame",
+    "dataset_class_name": "DREAM",
+    "dataset_name": "DREAM-1K"
+  },
+  "DREAM-1K_8frame": {
+    "build_config": {
+      "class": "DREAM",
+      "dataset": "DREAM-1K",
+      "nframe": 8
+    },
+    "dataset_alias_name": "DREAM-1K_8frame",
+    "dataset_class_name": "DREAM",
+    "dataset_name": "DREAM-1K"
+  },
+  "DSRBench_1fps": {
+    "build_config": {
+      "class": "DSRBench",
+      "dataset": "DSRBench",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "DSRBench_1fps",
+    "dataset_class_name": "DSRBench",
+    "dataset_name": "DSRBench"
+  },
+  "DSRBench_30frame": {
+    "build_config": {
+      "class": "DSRBench",
+      "dataset": "DSRBench",
+      "nframe": 30
+    },
+    "dataset_alias_name": "DSRBench_30frame",
+    "dataset_class_name": "DSRBench",
+    "dataset_name": "DSRBench"
+  },
+  "DSRBench_32frame": {
+    "build_config": {
+      "class": "DSRBench",
+      "dataset": "DSRBench",
+      "nframe": 32
+    },
+    "dataset_alias_name": "DSRBench_32frame",
+    "dataset_class_name": "DSRBench",
+    "dataset_name": "DSRBench"
+  },
+  "DSRBench_64frame": {
+    "build_config": {
+      "class": "DSRBench",
+      "dataset": "DSRBench",
+      "nframe": 64
+    },
+    "dataset_alias_name": "DSRBench_64frame",
+    "dataset_class_name": "DSRBench",
+    "dataset_name": "DSRBench"
+  },
+  "EgoExoBench_64frame": {
+    "build_config": {
+      "class": "EgoExoBench_MCQ",
+      "dataset": "EgoExoBench_MCQ",
+      "nframe": 64,
+      "skip_EgoExo4D": false
+    },
+    "dataset_alias_name": "EgoExoBench_64frame",
+    "dataset_class_name": "EgoExoBench_MCQ",
+    "dataset_name": "EgoExoBench_MCQ"
+  },
+  "EgoExoBench_64frame_skip_EgoExo4D": {
+    "build_config": {
+      "class": "EgoExoBench_MCQ",
+      "dataset": "EgoExoBench_MCQ",
+      "nframe": 64,
+      "skip_EgoExo4D": true
+    },
+    "dataset_alias_name": "EgoExoBench_64frame_skip_EgoExo4D",
+    "dataset_class_name": "EgoExoBench_MCQ",
+    "dataset_name": "EgoExoBench_MCQ"
+  },
+  "LongVideoBench_0.5fps": {
+    "build_config": {
+      "class": "LongVideoBench",
+      "dataset": "LongVideoBench",
+      "fps": 0.5
+    },
+    "dataset_alias_name": "LongVideoBench_0.5fps",
+    "dataset_class_name": "LongVideoBench",
+    "dataset_name": "LongVideoBench"
+  },
+  "LongVideoBench_0.5fps_subs": {
+    "build_config": {
+      "class": "LongVideoBench",
+      "dataset": "LongVideoBench",
+      "fps": 0.5,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "LongVideoBench_0.5fps_subs",
+    "dataset_class_name": "LongVideoBench",
+    "dataset_name": "LongVideoBench"
+  },
+  "LongVideoBench_1fps": {
+    "build_config": {
+      "class": "LongVideoBench",
+      "dataset": "LongVideoBench",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "LongVideoBench_1fps",
+    "dataset_class_name": "LongVideoBench",
+    "dataset_name": "LongVideoBench"
+  },
+  "LongVideoBench_64frame": {
+    "build_config": {
+      "class": "LongVideoBench",
+      "dataset": "LongVideoBench",
+      "nframe": 64
+    },
+    "dataset_alias_name": "LongVideoBench_64frame",
+    "dataset_class_name": "LongVideoBench",
+    "dataset_name": "LongVideoBench"
+  },
+  "LongVideoBench_8frame": {
+    "build_config": {
+      "class": "LongVideoBench",
+      "dataset": "LongVideoBench",
+      "nframe": 8
+    },
+    "dataset_alias_name": "LongVideoBench_8frame",
+    "dataset_class_name": "LongVideoBench",
+    "dataset_name": "LongVideoBench"
+  },
+  "LongVideoBench_8frame_subs": {
+    "build_config": {
+      "class": "LongVideoBench",
+      "dataset": "LongVideoBench",
+      "nframe": 8,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "LongVideoBench_8frame_subs",
+    "dataset_class_name": "LongVideoBench",
+    "dataset_name": "LongVideoBench"
+  },
+  "MEGABench_core_16frame": {
+    "build_config": {
+      "class": "MEGABench",
+      "dataset": "MEGABench",
+      "nframe": 16,
+      "subset_name": "core"
+    },
+    "dataset_alias_name": "MEGABench_core_16frame",
+    "dataset_class_name": "MEGABench",
+    "dataset_name": "MEGABench"
+  },
+  "MEGABench_core_64frame": {
+    "build_config": {
+      "class": "MEGABench",
+      "dataset": "MEGABench",
+      "nframe": 64,
+      "subset_name": "core"
+    },
+    "dataset_alias_name": "MEGABench_core_64frame",
+    "dataset_class_name": "MEGABench",
+    "dataset_name": "MEGABench"
+  },
+  "MEGABench_open_16frame": {
+    "build_config": {
+      "class": "MEGABench",
+      "dataset": "MEGABench",
+      "nframe": 16,
+      "subset_name": "open"
+    },
+    "dataset_alias_name": "MEGABench_open_16frame",
+    "dataset_class_name": "MEGABench",
+    "dataset_name": "MEGABench"
+  },
+  "MEGABench_open_64frame": {
+    "build_config": {
+      "class": "MEGABench",
+      "dataset": "MEGABench",
+      "nframe": 64,
+      "subset_name": "open"
+    },
+    "dataset_alias_name": "MEGABench_open_64frame",
+    "dataset_class_name": "MEGABench",
+    "dataset_name": "MEGABench"
+  },
+  "MLVU_1fps": {
+    "build_config": {
+      "class": "MLVU",
+      "dataset": "MLVU",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "MLVU_1fps",
+    "dataset_class_name": "MLVU",
+    "dataset_name": "MLVU"
+  },
+  "MLVU_64frame": {
+    "build_config": {
+      "class": "MLVU",
+      "dataset": "MLVU",
+      "nframe": 64
+    },
+    "dataset_alias_name": "MLVU_64frame",
+    "dataset_class_name": "MLVU",
+    "dataset_name": "MLVU"
+  },
+  "MLVU_8frame": {
+    "build_config": {
+      "class": "MLVU",
+      "dataset": "MLVU",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MLVU_8frame",
+    "dataset_class_name": "MLVU",
+    "dataset_name": "MLVU"
+  },
+  "MMBench_Video_16frame_nopack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "nframe": 16,
+      "pack": false
+    },
+    "dataset_alias_name": "MMBench_Video_16frame_nopack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMBench_Video_1fps_nopack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "fps": 1.0,
+      "pack": false
+    },
+    "dataset_alias_name": "MMBench_Video_1fps_nopack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMBench_Video_1fps_pack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "fps": 1.0,
+      "pack": true
+    },
+    "dataset_alias_name": "MMBench_Video_1fps_pack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMBench_Video_64frame_nopack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "nframe": 64,
+      "pack": false
+    },
+    "dataset_alias_name": "MMBench_Video_64frame_nopack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMBench_Video_64frame_pack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "nframe": 64,
+      "pack": true
+    },
+    "dataset_alias_name": "MMBench_Video_64frame_pack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMBench_Video_8frame_nopack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "nframe": 8,
+      "pack": false
+    },
+    "dataset_alias_name": "MMBench_Video_8frame_nopack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMBench_Video_8frame_pack": {
+    "build_config": {
+      "class": "MMBenchVideo",
+      "dataset": "MMBench-Video",
+      "nframe": 8,
+      "pack": true
+    },
+    "dataset_alias_name": "MMBench_Video_8frame_pack",
+    "dataset_class_name": "MMBenchVideo",
+    "dataset_name": "MMBench-Video"
+  },
+  "MMSIVideoBench_1fps": {
+    "build_config": {
+      "class": "MMSIVideoBench",
+      "dataset": "MMSIVideoBench",
+      "fps": 1
+    },
+    "dataset_alias_name": "MMSIVideoBench_1fps",
+    "dataset_class_name": "MMSIVideoBench",
+    "dataset_name": "MMSIVideoBench"
+  },
+  "MMSIVideoBench_300frame": {
+    "build_config": {
+      "class": "MMSIVideoBench",
+      "dataset": "MMSIVideoBench",
+      "nframe": 300
+    },
+    "dataset_alias_name": "MMSIVideoBench_300frame",
+    "dataset_class_name": "MMSIVideoBench",
+    "dataset_name": "MMSIVideoBench"
+  },
+  "MMSIVideoBench_32frame": {
+    "build_config": {
+      "class": "MMSIVideoBench",
+      "dataset": "MMSIVideoBench",
+      "nframe": 32
+    },
+    "dataset_alias_name": "MMSIVideoBench_32frame",
+    "dataset_class_name": "MMSIVideoBench",
+    "dataset_name": "MMSIVideoBench"
+  },
+  "MMSIVideoBench_50frame": {
+    "build_config": {
+      "class": "MMSIVideoBench",
+      "dataset": "MMSIVideoBench",
+      "nframe": 50
+    },
+    "dataset_alias_name": "MMSIVideoBench_50frame",
+    "dataset_class_name": "MMSIVideoBench",
+    "dataset_name": "MMSIVideoBench"
+  },
+  "MMSIVideoBench_64frame": {
+    "build_config": {
+      "class": "MMSIVideoBench",
+      "dataset": "MMSIVideoBench",
+      "nframe": 64
+    },
+    "dataset_alias_name": "MMSIVideoBench_64frame",
+    "dataset_class_name": "MMSIVideoBench",
+    "dataset_name": "MMSIVideoBench"
+  },
+  "MVBench_64frame": {
+    "build_config": {
+      "class": "MVBench",
+      "dataset": "MVBench",
+      "nframe": 64
+    },
+    "dataset_alias_name": "MVBench_64frame",
+    "dataset_class_name": "MVBench",
+    "dataset_name": "MVBench"
+  },
+  "MVBench_8frame": {
+    "build_config": {
+      "class": "MVBench",
+      "dataset": "MVBench",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MVBench_8frame",
+    "dataset_class_name": "MVBench",
+    "dataset_name": "MVBench"
+  },
+  "MVBench_MP4_1fps": {
+    "build_config": {
+      "class": "MVBench_MP4",
+      "dataset": "MVBench_MP4",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "MVBench_MP4_1fps",
+    "dataset_class_name": "MVBench_MP4",
+    "dataset_name": "MVBench_MP4"
+  },
+  "MVBench_MP4_8frame": {
+    "build_config": {
+      "class": "MVBench_MP4",
+      "dataset": "MVBench_MP4",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MVBench_MP4_8frame",
+    "dataset_class_name": "MVBench_MP4",
+    "dataset_name": "MVBench_MP4"
+  },
+  "MVTamperBenchEnd_8frame": {
+    "build_config": {
+      "class": "MVTamperBench",
+      "dataset": "MVTamperBenchEnd",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MVTamperBenchEnd_8frame",
+    "dataset_class_name": "MVTamperBench",
+    "dataset_name": "MVTamperBenchEnd"
+  },
+  "MVTamperBenchStart_8frame": {
+    "build_config": {
+      "class": "MVTamperBench",
+      "dataset": "MVTamperBenchStart",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MVTamperBenchStart_8frame",
+    "dataset_class_name": "MVTamperBench",
+    "dataset_name": "MVTamperBenchStart"
+  },
+  "MVTamperBench_8frame": {
+    "build_config": {
+      "class": "MVTamperBench",
+      "dataset": "MVTamperBench",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MVTamperBench_8frame",
+    "dataset_class_name": "MVTamperBench",
+    "dataset_name": "MVTamperBench"
+  },
+  "MVU-Eval_16frame": {
+    "build_config": {
+      "class": "MVUEval",
+      "dataset": "MVU-Eval",
+      "nframe": 16
+    },
+    "dataset_alias_name": "MVU-Eval_16frame",
+    "dataset_class_name": "MVUEval",
+    "dataset_name": "MVU-Eval"
+  },
+  "MVU-Eval_8frame": {
+    "build_config": {
+      "class": "MVUEval",
+      "dataset": "MVU-Eval",
+      "nframe": 8
+    },
+    "dataset_alias_name": "MVU-Eval_8frame",
+    "dataset_class_name": "MVUEval",
+    "dataset_name": "MVU-Eval"
+  },
+  "OMTGBench_1fps": {
+    "build_config": {
+      "class": "OMTGBench",
+      "dataset": "OMTGBench",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "OMTGBench_1fps",
+    "dataset_class_name": "OMTGBench",
+    "dataset_name": "OMTGBench"
+  },
+  "OMTGBench_2fps": {
+    "build_config": {
+      "class": "OMTGBench",
+      "dataset": "OMTGBench",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "OMTGBench_2fps",
+    "dataset_class_name": "OMTGBench",
+    "dataset_name": "OMTGBench"
+  },
+  "QBench_Video_16frame": {
+    "build_config": {
+      "class": "QBench_Video",
+      "dataset": "QBench_Video",
+      "nframe": 16
+    },
+    "dataset_alias_name": "QBench_Video_16frame",
+    "dataset_class_name": "QBench_Video",
+    "dataset_name": "QBench_Video"
+  },
+  "QBench_Video_8frame": {
+    "build_config": {
+      "class": "QBench_Video",
+      "dataset": "QBench_Video",
+      "nframe": 8
+    },
+    "dataset_alias_name": "QBench_Video_8frame",
+    "dataset_class_name": "QBench_Video",
+    "dataset_name": "QBench_Video"
+  },
+  "STI-Bench_1fps": {
+    "build_config": {
+      "class": "STIBench",
+      "dataset": "STI-Bench",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "STI-Bench_1fps",
+    "dataset_class_name": "STIBench",
+    "dataset_name": "STI-Bench"
+  },
+  "STI-Bench_30frame": {
+    "build_config": {
+      "class": "STIBench",
+      "dataset": "STI-Bench",
+      "nframe": 30
+    },
+    "dataset_alias_name": "STI-Bench_30frame",
+    "dataset_class_name": "STIBench",
+    "dataset_name": "STI-Bench"
+  },
+  "STI-Bench_32frame": {
+    "build_config": {
+      "class": "STIBench",
+      "dataset": "STI-Bench",
+      "nframe": 32
+    },
+    "dataset_alias_name": "STI-Bench_32frame",
+    "dataset_class_name": "STIBench",
+    "dataset_name": "STI-Bench"
+  },
+  "STI-Bench_64frame": {
+    "build_config": {
+      "class": "STIBench",
+      "dataset": "STI-Bench",
+      "nframe": 64
+    },
+    "dataset_alias_name": "STI-Bench_64frame",
+    "dataset_class_name": "STIBench",
+    "dataset_name": "STI-Bench"
+  },
+  "SiteBenchVideo_1fps": {
+    "build_config": {
+      "class": "SiteBenchVideo",
+      "dataset": "SiteBenchVideo",
+      "fps": 1
+    },
+    "dataset_alias_name": "SiteBenchVideo_1fps",
+    "dataset_class_name": "SiteBenchVideo",
+    "dataset_name": "SiteBenchVideo"
+  },
+  "SiteBenchVideo_32frame": {
+    "build_config": {
+      "class": "SiteBenchVideo",
+      "dataset": "SiteBenchVideo",
+      "nframe": 32
+    },
+    "dataset_alias_name": "SiteBenchVideo_32frame",
+    "dataset_class_name": "SiteBenchVideo",
+    "dataset_name": "SiteBenchVideo"
+  },
+  "SiteBenchVideo_64frame": {
+    "build_config": {
+      "class": "SiteBenchVideo",
+      "dataset": "SiteBenchVideo",
+      "nframe": 64
+    },
+    "dataset_alias_name": "SiteBenchVideo_64frame",
+    "dataset_class_name": "SiteBenchVideo",
+    "dataset_name": "SiteBenchVideo"
+  },
+  "TempCompass_0.5fps": {
+    "build_config": {
+      "class": "TempCompass",
+      "dataset": "TempCompass",
+      "fps": 0.5
+    },
+    "dataset_alias_name": "TempCompass_0.5fps",
+    "dataset_class_name": "TempCompass",
+    "dataset_name": "TempCompass"
+  },
+  "TempCompass_1fps": {
+    "build_config": {
+      "class": "TempCompass",
+      "dataset": "TempCompass",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "TempCompass_1fps",
+    "dataset_class_name": "TempCompass",
+    "dataset_name": "TempCompass"
+  },
+  "TempCompass_64frame": {
+    "build_config": {
+      "class": "TempCompass",
+      "dataset": "TempCompass",
+      "nframe": 64
+    },
+    "dataset_alias_name": "TempCompass_64frame",
+    "dataset_class_name": "TempCompass",
+    "dataset_name": "TempCompass"
+  },
+  "TempCompass_8frame": {
+    "build_config": {
+      "class": "TempCompass",
+      "dataset": "TempCompass",
+      "nframe": 8
+    },
+    "dataset_alias_name": "TempCompass_8frame",
+    "dataset_class_name": "TempCompass",
+    "dataset_name": "TempCompass"
+  },
+  "V2PBench_128frame_nopack": {
+    "build_config": {
+      "class": "V2PBench",
+      "dataset": "V2P-Bench",
+      "nframe": 128,
+      "pack": false
+    },
+    "dataset_alias_name": "V2PBench_128frame_nopack",
+    "dataset_class_name": "V2PBench",
+    "dataset_name": "V2P-Bench"
+  },
+  "V2PBench_16frame_nopack": {
+    "build_config": {
+      "class": "V2PBench",
+      "dataset": "V2P-Bench",
+      "nframe": 16,
+      "pack": false
+    },
+    "dataset_alias_name": "V2PBench_16frame_nopack",
+    "dataset_class_name": "V2PBench",
+    "dataset_name": "V2P-Bench"
+  },
+  "V2PBench_1fps_nopack": {
+    "build_config": {
+      "class": "V2PBench",
+      "dataset": "V2P-Bench",
+      "fps": 1.0,
+      "pack": false
+    },
+    "dataset_alias_name": "V2PBench_1fps_nopack",
+    "dataset_class_name": "V2PBench",
+    "dataset_name": "V2P-Bench"
+  },
+  "V2PBench_2frame_nopack": {
+    "build_config": {
+      "class": "V2PBench",
+      "dataset": "V2P-Bench",
+      "nframe": 2,
+      "pack": false
+    },
+    "dataset_alias_name": "V2PBench_2frame_nopack",
+    "dataset_class_name": "V2PBench",
+    "dataset_name": "V2P-Bench"
+  },
+  "V2PBench_64frame_nopack": {
+    "build_config": {
+      "class": "V2PBench",
+      "dataset": "V2P-Bench",
+      "nframe": 64,
+      "pack": false
+    },
+    "dataset_alias_name": "V2PBench_64frame_nopack",
+    "dataset_class_name": "V2PBench",
+    "dataset_name": "V2P-Bench"
+  },
+  "V2PBench_8frame_nopack": {
+    "build_config": {
+      "class": "V2PBench",
+      "dataset": "V2P-Bench",
+      "nframe": 8,
+      "pack": false
+    },
+    "dataset_alias_name": "V2PBench_8frame_nopack",
+    "dataset_class_name": "V2PBench",
+    "dataset_name": "V2P-Bench"
+  },
+  "VCRBench_16frame_nopack": {
+    "build_config": {
+      "class": "VCRBench",
+      "dataset": "VCR-Bench",
+      "nframe": 16,
+      "pack": false
+    },
+    "dataset_alias_name": "VCRBench_16frame_nopack",
+    "dataset_class_name": "VCRBench",
+    "dataset_name": "VCR-Bench"
+  },
+  "VCRBench_1fps_nopack": {
+    "build_config": {
+      "class": "VCRBench",
+      "dataset": "VCR-Bench",
+      "fps": 1.0,
+      "pack": false
+    },
+    "dataset_alias_name": "VCRBench_1fps_nopack",
+    "dataset_class_name": "VCRBench",
+    "dataset_name": "VCR-Bench"
+  },
+  "VCRBench_32frame_nopack": {
+    "build_config": {
+      "class": "VCRBench",
+      "dataset": "VCR-Bench",
+      "nframe": 32,
+      "pack": false
+    },
+    "dataset_alias_name": "VCRBench_32frame_nopack",
+    "dataset_class_name": "VCRBench",
+    "dataset_name": "VCR-Bench"
+  },
+  "VCRBench_64frame_nopack": {
+    "build_config": {
+      "class": "VCRBench",
+      "dataset": "VCR-Bench",
+      "nframe": 64,
+      "pack": false
+    },
+    "dataset_alias_name": "VCRBench_64frame_nopack",
+    "dataset_class_name": "VCRBench",
+    "dataset_name": "VCR-Bench"
+  },
+  "VCRBench_8frame_nopack": {
+    "build_config": {
+      "class": "VCRBench",
+      "dataset": "VCR-Bench",
+      "nframe": 8,
+      "pack": false
+    },
+    "dataset_alias_name": "VCRBench_8frame_nopack",
+    "dataset_class_name": "VCRBench",
+    "dataset_name": "VCR-Bench"
+  },
+  "VDC_1fps": {
+    "build_config": {
+      "class": "VDC",
+      "dataset": "VDC",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VDC_1fps",
+    "dataset_class_name": "VDC",
+    "dataset_name": "VDC"
+  },
+  "VDC_8frame": {
+    "build_config": {
+      "class": "VDC",
+      "dataset": "VDC",
+      "nframe": 8
+    },
+    "dataset_alias_name": "VDC_8frame",
+    "dataset_class_name": "VDC",
+    "dataset_name": "VDC"
+  },
+  "VSI-Bench-Debiased_128frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench-Debiased",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VSI-Bench-Debiased_128frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench-Debiased"
+  },
+  "VSI-Bench-Debiased_16frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench-Debiased",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VSI-Bench-Debiased_16frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench-Debiased"
+  },
+  "VSI-Bench-Debiased_1fps": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench-Debiased",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VSI-Bench-Debiased_1fps",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench-Debiased"
+  },
+  "VSI-Bench-Debiased_2fps": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench-Debiased",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VSI-Bench-Debiased_2fps",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench-Debiased"
+  },
+  "VSI-Bench-Debiased_32frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench-Debiased",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VSI-Bench-Debiased_32frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench-Debiased"
+  },
+  "VSI-Bench-Debiased_64frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench-Debiased",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VSI-Bench-Debiased_64frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench-Debiased"
+  },
+  "VSI-Bench_128frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VSI-Bench_128frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench"
+  },
+  "VSI-Bench_16frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VSI-Bench_16frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench"
+  },
+  "VSI-Bench_1fps": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VSI-Bench_1fps",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench"
+  },
+  "VSI-Bench_2fps": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VSI-Bench_2fps",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench"
+  },
+  "VSI-Bench_32frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VSI-Bench_32frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench"
+  },
+  "VSI-Bench_64frame": {
+    "build_config": {
+      "class": "VsiBench",
+      "dataset": "VSI-Bench",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VSI-Bench_64frame",
+    "dataset_class_name": "VsiBench",
+    "dataset_name": "VSI-Bench"
+  },
+  "Video-MME-v2_1fps": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "fps": 1.0,
+      "nframe": 0
+    },
+    "dataset_alias_name": "Video-MME-v2_1fps",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_1fps_resize": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "fps": 1.0,
+      "nframe": 0,
+      "resize_target_area": 200704
+    },
+    "dataset_alias_name": "Video-MME-v2_1fps_resize",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_1fps_subs": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "fps": 1.0,
+      "nframe": 0,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_1fps_subs",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_1fps_subs_interleave": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "fps": 1.0,
+      "nframe": 0,
+      "subtitle_interleave": true,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_1fps_subs_interleave",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_reasoning": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "reasoning": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_reasoning",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_reasoning_subs": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "reasoning": true,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_reasoning_subs",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_reasoning_subs_interleave": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "reasoning": true,
+      "subtitle_interleave": true,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_reasoning_subs_interleave",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_resize": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "resize_target_area": 200704
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_resize",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_resize_reasoning": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "reasoning": true,
+      "resize_target_area": 200704
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_resize_reasoning",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_resize_subs": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "resize_target_area": 200704,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_resize_subs",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_resize_subs_interleave": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "resize_target_area": 200704,
+      "subtitle_interleave": true,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_resize_subs_interleave",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_subs": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_subs",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME-v2_64frame_subs_interleave": {
+    "build_config": {
+      "class": "VideoMMEv2",
+      "dataset": "Video-MME-v2",
+      "nframe": 64,
+      "subtitle_interleave": true,
+      "with_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME-v2_64frame_subs_interleave",
+    "dataset_class_name": "VideoMMEv2",
+    "dataset_name": "Video-MME-v2"
+  },
+  "Video-MME_0.5fps": {
+    "build_config": {
+      "class": "VideoMME",
+      "dataset": "Video-MME",
+      "fps": 0.5
+    },
+    "dataset_alias_name": "Video-MME_0.5fps",
+    "dataset_class_name": "VideoMME",
+    "dataset_name": "Video-MME"
+  },
+  "Video-MME_0.5fps_subs": {
+    "build_config": {
+      "class": "VideoMME",
+      "dataset": "Video-MME",
+      "fps": 0.5,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME_0.5fps_subs",
+    "dataset_class_name": "VideoMME",
+    "dataset_name": "Video-MME"
+  },
+  "Video-MME_1fps": {
+    "build_config": {
+      "class": "VideoMME",
+      "dataset": "Video-MME",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "Video-MME_1fps",
+    "dataset_class_name": "VideoMME",
+    "dataset_name": "Video-MME"
+  },
+  "Video-MME_64frame": {
+    "build_config": {
+      "class": "VideoMME",
+      "dataset": "Video-MME",
+      "nframe": 64
+    },
+    "dataset_alias_name": "Video-MME_64frame",
+    "dataset_class_name": "VideoMME",
+    "dataset_name": "Video-MME"
+  },
+  "Video-MME_8frame": {
+    "build_config": {
+      "class": "VideoMME",
+      "dataset": "Video-MME",
+      "nframe": 8
+    },
+    "dataset_alias_name": "Video-MME_8frame",
+    "dataset_class_name": "VideoMME",
+    "dataset_name": "Video-MME"
+  },
+  "Video-MME_8frame_subs": {
+    "build_config": {
+      "class": "VideoMME",
+      "dataset": "Video-MME",
+      "nframe": 8,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "Video-MME_8frame_subs",
+    "dataset_class_name": "VideoMME",
+    "dataset_name": "Video-MME"
+  },
+  "VideoMMMU_0.5fps": {
+    "build_config": {
+      "class": "VideoMMMU",
+      "dataset": "VideoMMMU",
+      "fps": 0.5
+    },
+    "dataset_alias_name": "VideoMMMU_0.5fps",
+    "dataset_class_name": "VideoMMMU",
+    "dataset_name": "VideoMMMU"
+  },
+  "VideoMMMU_1fps": {
+    "build_config": {
+      "class": "VideoMMMU",
+      "dataset": "VideoMMMU",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VideoMMMU_1fps",
+    "dataset_class_name": "VideoMMMU",
+    "dataset_name": "VideoMMMU"
+  },
+  "VideoMMMU_64frame": {
+    "build_config": {
+      "class": "VideoMMMU",
+      "dataset": "VideoMMMU",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VideoMMMU_64frame",
+    "dataset_class_name": "VideoMMMU",
+    "dataset_name": "VideoMMMU"
+  },
+  "VideoMMMU_8frame": {
+    "build_config": {
+      "class": "VideoMMMU",
+      "dataset": "VideoMMMU",
+      "nframe": 8
+    },
+    "dataset_alias_name": "VideoMMMU_8frame",
+    "dataset_class_name": "VideoMMMU",
+    "dataset_name": "VideoMMMU"
+  },
+  "Video_Holmes_32frame": {
+    "build_config": {
+      "class": "Video_Holmes",
+      "dataset": "Video_Holmes",
+      "nframe": 32
+    },
+    "dataset_alias_name": "Video_Holmes_32frame",
+    "dataset_class_name": "Video_Holmes",
+    "dataset_name": "Video_Holmes"
+  },
+  "Video_Holmes_64frame": {
+    "build_config": {
+      "class": "Video_Holmes",
+      "dataset": "Video_Holmes",
+      "nframe": 64
+    },
+    "dataset_alias_name": "Video_Holmes_64frame",
+    "dataset_class_name": "Video_Holmes",
+    "dataset_name": "Video_Holmes"
+  },
+  "Video_MMLU_CAP_16frame": {
+    "build_config": {
+      "class": "Video_MMLU_CAP",
+      "dataset": "Video_MMLU_CAP",
+      "nframe": 16
+    },
+    "dataset_alias_name": "Video_MMLU_CAP_16frame",
+    "dataset_class_name": "Video_MMLU_CAP",
+    "dataset_name": "Video_MMLU_CAP"
+  },
+  "Video_MMLU_CAP_64frame": {
+    "build_config": {
+      "class": "Video_MMLU_CAP",
+      "dataset": "Video_MMLU_CAP",
+      "nframe": 64
+    },
+    "dataset_alias_name": "Video_MMLU_CAP_64frame",
+    "dataset_class_name": "Video_MMLU_CAP",
+    "dataset_name": "Video_MMLU_CAP"
+  },
+  "Video_MMLU_QA_16frame": {
+    "build_config": {
+      "class": "Video_MMLU_QA",
+      "dataset": "Video_MMLU_QA",
+      "nframe": 16
+    },
+    "dataset_alias_name": "Video_MMLU_QA_16frame",
+    "dataset_class_name": "Video_MMLU_QA",
+    "dataset_name": "Video_MMLU_QA"
+  },
+  "Video_MMLU_QA_64frame": {
+    "build_config": {
+      "class": "Video_MMLU_QA",
+      "dataset": "Video_MMLU_QA",
+      "nframe": 64
+    },
+    "dataset_alias_name": "Video_MMLU_QA_64frame",
+    "dataset_class_name": "Video_MMLU_QA",
+    "dataset_name": "Video_MMLU_QA"
+  },
+  "Video_TT_16frame": {
+    "build_config": {
+      "class": "VideoTT",
+      "dataset": "Video-TT",
+      "nframe": 16
+    },
+    "dataset_alias_name": "Video_TT_16frame",
+    "dataset_class_name": "VideoTT",
+    "dataset_name": "Video-TT"
+  },
+  "Video_TT_32frame": {
+    "build_config": {
+      "class": "VideoTT",
+      "dataset": "Video-TT",
+      "nframe": 32
+    },
+    "dataset_alias_name": "Video_TT_32frame",
+    "dataset_class_name": "VideoTT",
+    "dataset_name": "Video-TT"
+  },
+  "Video_TT_64frame": {
+    "build_config": {
+      "class": "VideoTT",
+      "dataset": "Video-TT",
+      "nframe": 64
+    },
+    "dataset_alias_name": "Video_TT_64frame",
+    "dataset_class_name": "VideoTT",
+    "dataset_name": "Video-TT"
+  },
+  "VsiSuperCount_10mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_10mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperCount_10mins_128frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_10mins"
+  },
+  "VsiSuperCount_10mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_10mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperCount_10mins_16frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_10mins"
+  },
+  "VsiSuperCount_10mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_10mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperCount_10mins_1fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_10mins"
+  },
+  "VsiSuperCount_10mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_10mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperCount_10mins_2fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_10mins"
+  },
+  "VsiSuperCount_10mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_10mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperCount_10mins_32frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_10mins"
+  },
+  "VsiSuperCount_10mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_10mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperCount_10mins_64frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_10mins"
+  },
+  "VsiSuperCount_120mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_120mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperCount_120mins_128frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_120mins"
+  },
+  "VsiSuperCount_120mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_120mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperCount_120mins_16frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_120mins"
+  },
+  "VsiSuperCount_120mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_120mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperCount_120mins_1fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_120mins"
+  },
+  "VsiSuperCount_120mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_120mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperCount_120mins_2fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_120mins"
+  },
+  "VsiSuperCount_120mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_120mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperCount_120mins_32frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_120mins"
+  },
+  "VsiSuperCount_120mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_120mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperCount_120mins_64frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_120mins"
+  },
+  "VsiSuperCount_30mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_30mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperCount_30mins_128frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_30mins"
+  },
+  "VsiSuperCount_30mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_30mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperCount_30mins_16frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_30mins"
+  },
+  "VsiSuperCount_30mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_30mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperCount_30mins_1fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_30mins"
+  },
+  "VsiSuperCount_30mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_30mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperCount_30mins_2fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_30mins"
+  },
+  "VsiSuperCount_30mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_30mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperCount_30mins_32frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_30mins"
+  },
+  "VsiSuperCount_30mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_30mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperCount_30mins_64frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_30mins"
+  },
+  "VsiSuperCount_60mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_60mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperCount_60mins_128frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_60mins"
+  },
+  "VsiSuperCount_60mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_60mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperCount_60mins_16frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_60mins"
+  },
+  "VsiSuperCount_60mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_60mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperCount_60mins_1fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_60mins"
+  },
+  "VsiSuperCount_60mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_60mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperCount_60mins_2fps",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_60mins"
+  },
+  "VsiSuperCount_60mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_60mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperCount_60mins_32frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_60mins"
+  },
+  "VsiSuperCount_60mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperCount",
+      "dataset": "VsiSuperCount_60mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperCount_60mins_64frame",
+    "dataset_class_name": "VsiSuperCount",
+    "dataset_name": "VsiSuperCount_60mins"
+  },
+  "VsiSuperRecall_10mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_10mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperRecall_10mins_128frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_10mins"
+  },
+  "VsiSuperRecall_10mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_10mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperRecall_10mins_16frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_10mins"
+  },
+  "VsiSuperRecall_10mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_10mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_10mins_1fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_10mins"
+  },
+  "VsiSuperRecall_10mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_10mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_10mins_2fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_10mins"
+  },
+  "VsiSuperRecall_10mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_10mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperRecall_10mins_32frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_10mins"
+  },
+  "VsiSuperRecall_10mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_10mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperRecall_10mins_64frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_10mins"
+  },
+  "VsiSuperRecall_120mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_120mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperRecall_120mins_128frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_120mins"
+  },
+  "VsiSuperRecall_120mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_120mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperRecall_120mins_16frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_120mins"
+  },
+  "VsiSuperRecall_120mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_120mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_120mins_1fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_120mins"
+  },
+  "VsiSuperRecall_120mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_120mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_120mins_2fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_120mins"
+  },
+  "VsiSuperRecall_120mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_120mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperRecall_120mins_32frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_120mins"
+  },
+  "VsiSuperRecall_120mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_120mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperRecall_120mins_64frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_120mins"
+  },
+  "VsiSuperRecall_240mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_240mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperRecall_240mins_128frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_240mins"
+  },
+  "VsiSuperRecall_240mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_240mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperRecall_240mins_16frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_240mins"
+  },
+  "VsiSuperRecall_240mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_240mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_240mins_1fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_240mins"
+  },
+  "VsiSuperRecall_240mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_240mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_240mins_2fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_240mins"
+  },
+  "VsiSuperRecall_240mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_240mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperRecall_240mins_32frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_240mins"
+  },
+  "VsiSuperRecall_240mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_240mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperRecall_240mins_64frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_240mins"
+  },
+  "VsiSuperRecall_30mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_30mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperRecall_30mins_128frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_30mins"
+  },
+  "VsiSuperRecall_30mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_30mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperRecall_30mins_16frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_30mins"
+  },
+  "VsiSuperRecall_30mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_30mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_30mins_1fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_30mins"
+  },
+  "VsiSuperRecall_30mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_30mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_30mins_2fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_30mins"
+  },
+  "VsiSuperRecall_30mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_30mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperRecall_30mins_32frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_30mins"
+  },
+  "VsiSuperRecall_30mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_30mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperRecall_30mins_64frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_30mins"
+  },
+  "VsiSuperRecall_60mins_128frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_60mins",
+      "nframe": 128
+    },
+    "dataset_alias_name": "VsiSuperRecall_60mins_128frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_60mins"
+  },
+  "VsiSuperRecall_60mins_16frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_60mins",
+      "nframe": 16
+    },
+    "dataset_alias_name": "VsiSuperRecall_60mins_16frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_60mins"
+  },
+  "VsiSuperRecall_60mins_1fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_60mins",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_60mins_1fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_60mins"
+  },
+  "VsiSuperRecall_60mins_2fps": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_60mins",
+      "fps": 2.0
+    },
+    "dataset_alias_name": "VsiSuperRecall_60mins_2fps",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_60mins"
+  },
+  "VsiSuperRecall_60mins_32frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_60mins",
+      "nframe": 32
+    },
+    "dataset_alias_name": "VsiSuperRecall_60mins_32frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_60mins"
+  },
+  "VsiSuperRecall_60mins_64frame": {
+    "build_config": {
+      "class": "VsiSuperRecall",
+      "dataset": "VsiSuperRecall_60mins",
+      "nframe": 64
+    },
+    "dataset_alias_name": "VsiSuperRecall_60mins_64frame",
+    "dataset_class_name": "VsiSuperRecall",
+    "dataset_name": "VsiSuperRecall_60mins"
+  },
+  "WorldSense_0.5fps": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "fps": 0.5
+    },
+    "dataset_alias_name": "WorldSense_0.5fps",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_0.5fps_audio": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "fps": 0.5,
+      "use_audio": true
+    },
+    "dataset_alias_name": "WorldSense_0.5fps_audio",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_0.5fps_subs": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "fps": 0.5,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "WorldSense_0.5fps_subs",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_1fps": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "fps": 1.0
+    },
+    "dataset_alias_name": "WorldSense_1fps",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_1fps_audio": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "fps": 1.0,
+      "use_audio": true
+    },
+    "dataset_alias_name": "WorldSense_1fps_audio",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_1fps_subs": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "fps": 1.0,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "WorldSense_1fps_subs",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_32frame": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "nframe": 32
+    },
+    "dataset_alias_name": "WorldSense_32frame",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_32frame_audio": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "nframe": 32,
+      "use_audio": true
+    },
+    "dataset_alias_name": "WorldSense_32frame_audio",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_32frame_subs": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "nframe": 32,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "WorldSense_32frame_subs",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_8frame": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "nframe": 8
+    },
+    "dataset_alias_name": "WorldSense_8frame",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_8frame_audio": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "nframe": 8,
+      "use_audio": true
+    },
+    "dataset_alias_name": "WorldSense_8frame_audio",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "WorldSense_8frame_subs": {
+    "build_config": {
+      "class": "WorldSense",
+      "dataset": "WorldSense",
+      "nframe": 8,
+      "use_subtitle": true
+    },
+    "dataset_alias_name": "WorldSense_8frame_subs",
+    "dataset_class_name": "WorldSense",
+    "dataset_name": "WorldSense"
+  },
+  "moviechat1k_breakpoint_8frame": {
+    "build_config": {
+      "class": "MovieChat1k",
+      "dataset": "MovieChat1k",
+      "nframe": 8,
+      "subset": "breakpoint"
+    },
+    "dataset_alias_name": "moviechat1k_breakpoint_8frame",
+    "dataset_class_name": "MovieChat1k",
+    "dataset_name": "MovieChat1k"
+  },
+  "moviechat1k_global_14frame": {
+    "build_config": {
+      "class": "MovieChat1k",
+      "dataset": "MovieChat1k",
+      "nframe": 14,
+      "subset": "global"
+    },
+    "dataset_alias_name": "moviechat1k_global_14frame",
+    "dataset_class_name": "MovieChat1k",
+    "dataset_name": "MovieChat1k"
+  },
+  "moviechat1k_global_8frame_limit0.01": {
+    "build_config": {
+      "class": "MovieChat1k",
+      "dataset": "MovieChat1k",
+      "limit": 0.01,
+      "nframe": 8,
+      "subset": "global"
+    },
+    "dataset_alias_name": "moviechat1k_global_8frame_limit0.01",
+    "dataset_class_name": "MovieChat1k",
+    "dataset_name": "MovieChat1k"
+  },
+  "revsi_16_frame": {
+    "build_config": {
+      "class": "ReVSI",
+      "dataset": "ReVSI",
+      "nframe": 16
+    },
+    "dataset_alias_name": "revsi_16_frame",
+    "dataset_class_name": "ReVSI",
+    "dataset_name": "ReVSI"
+  },
+  "revsi_32_frame": {
+    "build_config": {
+      "class": "ReVSI",
+      "dataset": "ReVSI",
+      "nframe": 32
+    },
+    "dataset_alias_name": "revsi_32_frame",
+    "dataset_class_name": "ReVSI",
+    "dataset_name": "ReVSI"
+  },
+  "revsi_64_frame": {
+    "build_config": {
+      "class": "ReVSI",
+      "dataset": "ReVSI",
+      "nframe": 64
+    },
+    "dataset_alias_name": "revsi_64_frame",
+    "dataset_class_name": "ReVSI",
+    "dataset_name": "ReVSI"
+  },
+  "revsi_all_frame": {
+    "build_config": {
+      "class": "ReVSI",
+      "dataset": "ReVSI",
+      "nframe": null
+    },
+    "dataset_alias_name": "revsi_all_frame",
+    "dataset_class_name": "ReVSI",
+    "dataset_name": "ReVSI"
+  }
+}

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -8,8 +8,9 @@ from unittest import mock
 import pandas as pd
 
 from vlmeval.inference import infer_data_job
-from vlmeval.smp import status_report
-from vlmeval.smp.dataset_alias import resolve_dataset_alias
+from vlmeval.smp import dump, get_composite_child_eval_file, load, status_report
+from vlmeval.smp.dataset_alias import (DatasetSpec, get_predefined_dataset_spec,
+                                       resolve_dataset_alias, resolve_dataset_spec)
 
 os.environ.setdefault('LMUData', '/tmp/vlmevalkit-test-lmudata')
 os.makedirs(os.environ['LMUData'], exist_ok=True)
@@ -55,6 +56,19 @@ class FakeEntryDataset(FakeDataset):
         return {'acc': 1.0}
 
 
+class RecordingChildEvaluator:
+
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+        self.frames = []
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        self.calls.append(eval_file)
+        self.frames.append(load(eval_file))
+        return self.result
+
+
 class FakeModel:
     is_api = False
 
@@ -84,8 +98,85 @@ class TestDatasetAlias(unittest.TestCase):
 
         self.assertEqual(ctx.dataset_alias_name, 'AnyAlias')
         self.assertEqual(ctx.dataset_name, 'MMBench_DEV_EN_V11')
+        self.assertEqual(ctx.dataset_class_name, 'ImageMCQDataset')
 
-    def test_status_keeps_alias_key_and_logical_dataset_name_for_reporter(self):
+    def test_resolve_predefined_shortcut(self):
+        spec = resolve_dataset_spec('MMBench_Video_8frame_nopack')
+
+        self.assertEqual(spec.dataset_alias_name, 'MMBench_Video_8frame_nopack')
+        self.assertEqual(spec.dataset_name, 'MMBench-Video')
+        self.assertEqual(spec.dataset_class_name, 'MMBenchVideo')
+        self.assertEqual(spec.build_config['class'], 'MMBenchVideo')
+        self.assertEqual(spec.build_config['dataset'], 'MMBench-Video')
+        self.assertEqual(spec.build_config['nframe'], 8)
+        self.assertFalse(spec.build_config['pack'])
+
+    def test_resolve_preset_alias(self):
+        spec = resolve_dataset_spec(
+            'AliasVideo',
+            {'AliasVideo': {'preset': 'MMBench_Video_8frame_nopack', 'nframe': 16}},
+        )
+
+        self.assertEqual(spec.dataset_alias_name, 'AliasVideo')
+        self.assertEqual(spec.dataset_name, 'MMBench-Video')
+        self.assertEqual(spec.dataset_class_name, 'MMBenchVideo')
+        self.assertEqual(spec.build_config['nframe'], 16)
+        self.assertFalse(spec.build_config['pack'])
+
+    def test_empty_dict_config_is_not_predefined_shortcut(self):
+        with self.assertRaisesRegex(ValueError, 'Empty dataset config'):
+            resolve_dataset_spec(
+                'MMBench_Video_8frame_nopack',
+                {'MMBench_Video_8frame_nopack': {}},
+            )
+
+    def test_explicit_config_requires_non_empty_class_and_dataset(self):
+        bad_configs = [
+            {'dataset': 'Video-MME'},
+            {'class': 'VideoMME'},
+            {'class': '', 'dataset': 'Video-MME'},
+            {'class': '   ', 'dataset': 'Video-MME'},
+            {'class': 'VideoMME', 'dataset': ''},
+            {'class': 'VideoMME', 'dataset': '   '},
+            {'class': None, 'dataset': 'Video-MME'},
+            {'class': 'VideoMME', 'dataset': None},
+        ]
+        for cfg in bad_configs:
+            with self.subTest(cfg=cfg):
+                with self.assertRaises(ValueError):
+                    resolve_dataset_spec('AliasVideo', {'AliasVideo': cfg})
+
+    def test_get_predefined_dataset_spec_returns_deepcopy(self):
+        import vlmeval.dataset.video_dataset_config as video_config
+
+        video_config.PREDEFINED_DATASET_SPECS['NestedSpecForTest'] = DatasetSpec(
+            dataset_alias_name='NestedSpecForTest',
+            dataset_name='NestedDS',
+            dataset_class_name='NestedClass',
+            build_config={
+                'class': 'NestedClass',
+                'dataset': 'NestedDS',
+                'nested': {'values': [1]},
+            },
+            source='predefined_shortcut',
+        )
+        try:
+            first = get_predefined_dataset_spec('NestedSpecForTest')
+            second = get_predefined_dataset_spec('NestedSpecForTest')
+            first.build_config['nested']['values'].append(2)
+
+            self.assertEqual(second.build_config['nested']['values'], [1])
+            registry_values = video_config.PREDEFINED_DATASET_SPECS[
+                'NestedSpecForTest'
+            ].build_config['nested']['values']
+            self.assertEqual(
+                registry_values,
+                [1],
+            )
+        finally:
+            video_config.PREDEFINED_DATASET_SPECS.pop('NestedSpecForTest', None)
+
+    def test_status_keeps_alias_key_and_dataset_class_name_for_reporter(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             run_dir = Path(tmpdir)
             pred_file = run_dir / 'MockModel_AnyAlias.tsv'
@@ -95,27 +186,122 @@ class TestDatasetAlias(unittest.TestCase):
                 run_dir=run_dir,
                 model_name='MockModel',
                 dataset_name='AnyAlias',
-                logical_dataset_name='LogicalDS',
+                resolved_dataset_name='LogicalDS',
+                dataset_alias_name='AnyAlias',
+                dataset_class_name='DummyReporter',
                 prediction_file=pred_file,
                 status='done',
             )
 
             status = status_report.load_run_status(run_dir)
             self.assertIn('AnyAlias', status['datasets'])
-            self.assertEqual(status['datasets']['AnyAlias']['logical_dataset_name'], 'LogicalDS')
+            self.assertEqual(status['datasets']['AnyAlias']['dataset_name'], 'LogicalDS')
+            self.assertEqual(status['datasets']['AnyAlias']['dataset_alias_name'], 'AnyAlias')
+            self.assertEqual(status['datasets']['AnyAlias']['dataset_class_name'], 'DummyReporter')
+            self.assertNotIn('logical_dataset_name', status['datasets']['AnyAlias'])
 
-            resolved_names = []
+            resolved_args = []
 
-            def fake_resolve(name, dataset_obj=None):
-                resolved_names.append(name)
+            def fake_resolve(
+                name,
+                dataset_class_name=None,
+                dataset_obj=None,
+                dataset_alias_name=None,
+            ):
+                resolved_args.append((name, dataset_class_name, dataset_alias_name))
                 return DummyReporter
 
             with mock.patch.object(
                     status_report, '_resolve_dataset_reporter', side_effect=fake_resolve):
                 rows = status_report.collect_run_benchmark_report(run_dir)
 
-            self.assertEqual(resolved_names, ['LogicalDS'])
+            self.assertEqual(resolved_args, [('LogicalDS', 'DummyReporter', 'AnyAlias')])
             self.assertEqual(rows[0]['benchmark'], 'AnyAlias')
+
+    def test_status_report_resolves_reporter_from_dataset_class_name(self):
+        reporter = status_report._resolve_dataset_reporter(
+            'CG-AV-Counting',
+            dataset_class_name='CGAVCounting',
+            dataset_alias_name='AnyAlias',
+        )
+
+        self.assertEqual(reporter.__name__, 'CGAVCounting')
+
+    def test_predefined_video_manifest_matches_registry(self):
+        import json
+
+        import vlmeval.dataset.video_dataset_config as video_config
+
+        manifest_path = (
+            Path(__file__).parent / 'fixtures' / 'predefined_video_shortcuts_manifest.json'
+        )
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+        registry = video_config.PREDEFINED_DATASET_SPECS
+
+        self.assertEqual(set(registry), set(manifest))
+        for key, expected in manifest.items():
+            with self.subTest(key=key):
+                spec = registry[key]
+                self.assertEqual(spec.dataset_alias_name, expected['dataset_alias_name'])
+                self.assertEqual(spec.dataset_name, expected['dataset_name'])
+                self.assertEqual(spec.dataset_class_name, expected['dataset_class_name'])
+                self.assertEqual(spec.build_config, expected['build_config'])
+                self.assertEqual(spec.dataset_alias_name, key)
+                self.assertEqual(spec.dataset_name, spec.build_config['dataset'])
+                self.assertEqual(spec.dataset_class_name, spec.build_config['class'])
+                self.assertTrue(spec.build_config['class'].strip())
+                self.assertTrue(spec.build_config['dataset'].strip())
+
+    def test_video_build_config_validation_uses_class_defaults_and_rejects_none(self):
+        from vlmeval.dataset import MMBenchVideo, VideoMMEv2
+
+        with self.assertRaisesRegex(ValueError, 'fps and nframe'):
+            VideoMMEv2.validate_build_config({'dataset': 'Video-MME-v2', 'fps': 1.0})
+
+        VideoMMEv2.validate_build_config({
+            'dataset': 'Video-MME-v2',
+            'nframe': 0,
+            'fps': 1.0,
+        })
+
+        with self.assertRaisesRegex(ValueError, 'fps should not be None'):
+            MMBenchVideo.validate_build_config({
+                'dataset': 'MMBench-Video',
+                'nframe': 8,
+                'fps': None,
+            })
+        with self.assertRaisesRegex(ValueError, 'nframe should not be None'):
+            MMBenchVideo.validate_build_config({
+                'dataset': 'MMBench-Video',
+                'nframe': None,
+                'fps': 1.0,
+            })
+
+    def test_videommev2_1fps_presets_clear_default_nframe(self):
+        from vlmeval.dataset import VideoMMEv2
+
+        shortcut_names = [
+            'Video-MME-v2_1fps',
+            'Video-MME-v2_1fps_subs',
+            'Video-MME-v2_1fps_subs_interleave',
+            'Video-MME-v2_1fps_resize',
+        ]
+        for name in shortcut_names:
+            with self.subTest(name=name):
+                spec = resolve_dataset_spec(name)
+                self.assertEqual(spec.build_config['nframe'], 0)
+                self.assertEqual(spec.build_config['fps'], 1.0)
+                VideoMMEv2.validate_build_config(spec.build_config)
+
+    def test_supported_video_datasets_symbol_removed(self):
+        import vlmeval.dataset.video_dataset_config as video_config
+
+        self.assertFalse(hasattr(video_config, 'supported_video_datasets'))
+
+    def test_build_dataset_does_not_parse_predefined_shortcut(self):
+        from vlmeval.dataset import build_dataset
+
+        self.assertIsNone(build_dataset('MMBench_Video_8frame_nopack'))
 
     def test_infer_data_job_writes_alias_result_but_uses_logical_dataset_for_model(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -137,6 +323,154 @@ class TestDatasetAlias(unittest.TestCase):
             self.assertFalse(logical_result_file.exists())
             self.assertEqual(model.custom_prompt_datasets, ['LogicalDS'])
             self.assertEqual(model.generate_datasets, ['LogicalDS'])
+
+    def test_composite_child_eval_file_handles_direct_and_alias_names(self):
+        direct = get_composite_child_eval_file('/tmp/MockModel_SIUO.tsv', 'SIUO', 'SIUO_GEN')
+        alias = get_composite_child_eval_file('/tmp/MockModel_OutputAlias.tsv', 'SIUO', 'SIUO_GEN')
+        alias_with_parent = get_composite_child_eval_file(
+            '/tmp/MockModel_CustomSIUOAlias.tsv',
+            'SIUO',
+            'SIUO_GEN',
+        )
+
+        self.assertEqual(direct, '/tmp/MockModel_SIUO_GEN.tsv')
+        self.assertEqual(alias, '/tmp/MockModel_OutputAlias_SIUO_GEN.tsv')
+        self.assertEqual(alias_with_parent, '/tmp/MockModel_CustomSIUOAlias_SIUO_GEN.tsv')
+
+    def test_siuo_composite_evaluate_uses_alias_safe_child_files(self):
+        from vlmeval.dataset.siuo import SIUODataset
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            eval_file = tmpdir / 'MockModel_OutputAlias.tsv'
+            dump(
+                pd.DataFrame([
+                    {
+                        'index': 0,
+                        'original_index': 11,
+                        'SUB_DATASET': 'SIUO_GEN',
+                        'prediction': 'gen',
+                    },
+                    {
+                        'index': 1,
+                        'original_index': 22,
+                        'SUB_DATASET': 'SIUO_MCQ',
+                        'prediction': 'mcq',
+                    },
+                ]),
+                str(eval_file),
+            )
+
+            dataset = SIUODataset.__new__(SIUODataset)
+            dataset.dataset_name = 'SIUO'
+            dataset.dataset_map = {
+                'SIUO_GEN': RecordingChildEvaluator({'overall_avg_combined': 40}),
+                'SIUO_MCQ': RecordingChildEvaluator({'Overall': 80}),
+            }
+
+            score = dataset.evaluate(str(eval_file))
+            gen_file = tmpdir / 'MockModel_OutputAlias_SIUO_GEN.tsv'
+            mcq_file = tmpdir / 'MockModel_OutputAlias_SIUO_MCQ.tsv'
+
+            self.assertTrue(eval_file.exists())
+            self.assertTrue(gen_file.exists())
+            self.assertTrue(mcq_file.exists())
+            self.assertEqual(dataset.dataset_map['SIUO_GEN'].calls, [str(gen_file)])
+            self.assertEqual(dataset.dataset_map['SIUO_MCQ'].calls, [str(mcq_file)])
+            self.assertEqual(list(dataset.dataset_map['SIUO_GEN'].frames[0]['index']), [11])
+            self.assertEqual(list(dataset.dataset_map['SIUO_MCQ'].frames[0]['index']), [22])
+            self.assertNotIn('SUB_DATASET', dataset.dataset_map['SIUO_GEN'].frames[0])
+            self.assertNotIn('original_index', dataset.dataset_map['SIUO_MCQ'].frames[0])
+            self.assertEqual(float(score['SIUO'].iloc[0]), 60.0)
+
+    def test_concat_dataset_evaluate_uses_alias_safe_child_files(self):
+        from vlmeval.dataset import ConcatDataset
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            eval_file = tmpdir / 'MockModel_ImageAlias.tsv'
+            dump(
+                pd.DataFrame([
+                    {
+                        'index': 0,
+                        'original_index': 101,
+                        'SUB_DATASET': 'ChildImageA',
+                        'prediction': 'a',
+                    },
+                    {
+                        'index': 1,
+                        'original_index': 202,
+                        'SUB_DATASET': 'ChildImageB',
+                        'prediction': 'b',
+                    },
+                ]),
+                str(eval_file),
+            )
+
+            dataset = ConcatDataset.__new__(ConcatDataset)
+            dataset.dataset_name = 'ImageParent'
+            dataset.datasets = ['ChildImageA', 'ChildImageB']
+            dataset.dataset_map = {
+                'ChildImageA': RecordingChildEvaluator({'acc': 1}),
+                'ChildImageB': RecordingChildEvaluator({'acc': 2}),
+            }
+
+            result = dataset.evaluate(str(eval_file))
+            child_a_file = tmpdir / 'MockModel_ImageAlias_ChildImageA.tsv'
+            child_b_file = tmpdir / 'MockModel_ImageAlias_ChildImageB.tsv'
+
+            self.assertEqual(result, {'ChildImageA:acc': 1, 'ChildImageB:acc': 2})
+            self.assertEqual(dataset.dataset_map['ChildImageA'].calls, [str(child_a_file)])
+            self.assertEqual(dataset.dataset_map['ChildImageB'].calls, [str(child_b_file)])
+            self.assertEqual(list(dataset.dataset_map['ChildImageA'].frames[0]['index']), [101])
+            self.assertEqual(list(dataset.dataset_map['ChildImageB'].frames[0]['index']), [202])
+            self.assertNotIn('SUB_DATASET', dataset.dataset_map['ChildImageA'].frames[0])
+            self.assertNotIn('original_index', dataset.dataset_map['ChildImageB'].frames[0])
+
+    def test_concat_video_dataset_evaluate_uses_alias_safe_child_files(self):
+        from vlmeval.dataset.video_concat_dataset import ConcatVideoDataset
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            eval_file = tmpdir / 'MockModel_VideoAlias.tsv'
+            dump(
+                pd.DataFrame([
+                    {
+                        'index': 0,
+                        'original_index': 7,
+                        'SUB_DATASET': 'ChildVideoA',
+                        'prediction': 'a',
+                    },
+                    {
+                        'index': 1,
+                        'original_index': 8,
+                        'SUB_DATASET': 'ChildVideoB',
+                        'prediction': 'b',
+                    },
+                ]),
+                str(eval_file),
+            )
+
+            dataset = ConcatVideoDataset.__new__(ConcatVideoDataset)
+            dataset.dataset_name = 'VideoParent'
+            dataset.datasets = ['ChildVideoA', 'ChildVideoB']
+            dataset.dataset_map = {
+                'ChildVideoA': RecordingChildEvaluator({'ChildVideoA': {'success': 1, 'overall': 2}}),
+                'ChildVideoB': RecordingChildEvaluator({'ChildVideoB': {'success': 3, 'overall': 4}}),
+            }
+
+            result = dataset.evaluate(str(eval_file))
+            child_a_file = tmpdir / 'MockModel_VideoAlias_ChildVideoA.tsv'
+            child_b_file = tmpdir / 'MockModel_VideoAlias_ChildVideoB.tsv'
+
+            self.assertEqual(dataset.dataset_map['ChildVideoA'].calls, [str(child_a_file)])
+            self.assertEqual(dataset.dataset_map['ChildVideoB'].calls, [str(child_b_file)])
+            self.assertEqual(list(dataset.dataset_map['ChildVideoA'].frames[0]['index']), [7])
+            self.assertEqual(list(dataset.dataset_map['ChildVideoB'].frames[0]['index']), [8])
+            self.assertNotIn('SUB_DATASET', dataset.dataset_map['ChildVideoA'].frames[0])
+            self.assertNotIn('original_index', dataset.dataset_map['ChildVideoB'].frames[0])
+            self.assertEqual(float(result.loc['ChildVideoA', 'acc']), 50.0)
+            self.assertEqual(float(result.loc['ChildVideoB', 'acc']), 75.0)
 
     def test_run_local_mode_non_config_data_allows_missing_data_config(self):
         import run as runner
@@ -169,8 +503,8 @@ class TestDatasetAlias(unittest.TestCase):
             pred_file = Path(tmpdir) / 'MockModel' / 'TENTRY' / 'MockModel_PlainAlias.tsv'
             build_calls = []
 
-            def fake_build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
-                build_calls.append((dataset_name, data_config, dataset_kwargs))
+            def fake_build_dataset_from_spec(spec, extra_kwargs=None):
+                build_calls.append((spec.dataset_alias_name, spec.dataset_name, extra_kwargs))
                 return FakeEntryDataset()
 
             judge_kwargs = {'model': 'mock-judge'}
@@ -185,8 +519,8 @@ class TestDatasetAlias(unittest.TestCase):
                     mock.patch.object(runner, 'upsert_run_status'), \
                     mock.patch.object(runner, 'upsert_dataset_status'), \
                     mock.patch.object(runner, 'get_pred_file_path', return_value=str(pred_file)), \
-                    mock.patch.object(runner, 'build_dataset_from_cli',
-                                      side_effect=fake_build_dataset_from_cli), \
+                    mock.patch.object(runner, 'build_dataset_from_spec',
+                                      side_effect=fake_build_dataset_from_spec), \
                     mock.patch.object(runner, 'get_judge_kwargs', return_value=judge_kwargs), \
                     mock.patch.object(runner, 'prepare_reuse_files', return_value=reuse_ctx), \
                     mock.patch.object(runner, 'is_prediction_complete', return_value=False), \
@@ -194,7 +528,7 @@ class TestDatasetAlias(unittest.TestCase):
                     mock.patch.object(runner, 'log_run_benchmark_report'):
                 runner.run_local_mode(args)
 
-            self.assertEqual(build_calls, [('PlainAlias', {}, {})])
+            self.assertEqual(build_calls, [('PlainAlias', 'PlainAlias', {})])
 
     def test_run_api_mode_non_config_data_allows_missing_data_config(self):
         import run as runner
@@ -239,8 +573,8 @@ class TestDatasetAlias(unittest.TestCase):
 
             build_calls = []
 
-            def fake_build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
-                build_calls.append((dataset_name, data_config, dataset_kwargs))
+            def fake_build_dataset_from_spec(spec, extra_kwargs=None):
+                build_calls.append((spec.dataset_alias_name, spec.dataset_name, extra_kwargs))
                 return FakeEntryDataset()
 
             def fake_pred_file(work_dir, model_name, dataset_name, use_env_format=True):
@@ -257,18 +591,19 @@ class TestDatasetAlias(unittest.TestCase):
                     mock.patch.object(runner, 'upsert_run_status'), \
                     mock.patch.object(runner, 'upsert_dataset_status'), \
                     mock.patch.object(runner, 'get_pred_file_path', side_effect=fake_pred_file), \
-                    mock.patch.object(runner, 'build_dataset_from_cli',
-                                      side_effect=fake_build_dataset_from_cli), \
+                    mock.patch.object(runner, 'build_dataset_from_spec',
+                                      side_effect=fake_build_dataset_from_spec), \
                     mock.patch.object(runner, 'get_judge_kwargs', return_value=judge_kwargs), \
                     mock.patch.object(runner, 'prepare_reuse_files', return_value=reuse_ctx), \
                     mock.patch.object(runner, 'log_run_benchmark_report'), \
                     mock.patch.object(inference_api, 'APIEvalPipeline', FakePipeline):
                 runner.run_api_mode(args)
 
-            self.assertEqual(build_calls, [('PlainAlias', {}, {})])
+            self.assertEqual(build_calls, [('PlainAlias', 'PlainAlias', {})])
             self.assertEqual(len(captured_configs), 1)
             self.assertEqual(captured_configs[0].dataset_name, 'PlainAlias')
             self.assertEqual(captured_configs[0].dataset_alias_name, 'PlainAlias')
+            self.assertIsNone(captured_configs[0].dataset_class_name)
 
 
 if __name__ == '__main__':

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -123,6 +123,15 @@ class TestDatasetAlias(unittest.TestCase):
         self.assertEqual(spec.build_config['nframe'], 16)
         self.assertFalse(spec.build_config['pack'])
 
+    def test_resolve_direct_dataset_spec_does_not_build_dataset_class_name(self):
+        spec = resolve_dataset_spec('MMBench_DEV_EN_V11')
+
+        self.assertEqual(spec.dataset_alias_name, 'MMBench_DEV_EN_V11')
+        self.assertEqual(spec.dataset_name, 'MMBench_DEV_EN_V11')
+        self.assertIsNone(spec.dataset_class_name)
+        self.assertEqual(spec.build_config, {'dataset': 'MMBench_DEV_EN_V11'})
+        self.assertEqual(spec.source, 'direct_dataset')
+
     def test_empty_dict_config_is_not_predefined_shortcut(self):
         with self.assertRaisesRegex(ValueError, 'Empty dataset config'):
             resolve_dataset_spec(
@@ -634,10 +643,16 @@ class TestDatasetAlias(unittest.TestCase):
 
             pred_file = Path(tmpdir) / 'MockModel' / 'TENTRY' / 'MockModel_PlainAlias.tsv'
             build_calls = []
+            status_calls = []
 
             def fake_build_dataset_from_spec(spec, extra_kwargs=None):
-                build_calls.append((spec.dataset_alias_name, spec.dataset_name, extra_kwargs))
+                build_calls.append(
+                    (spec.dataset_alias_name, spec.dataset_name, spec.dataset_class_name, extra_kwargs)
+                )
                 return FakeEntryDataset()
+
+            def fake_upsert_dataset_status(**kwargs):
+                status_calls.append(kwargs)
 
             judge_kwargs = {'model': 'mock-judge'}
             reuse_ctx = {'source_eval_id': None, 'prediction_complete': False}
@@ -649,7 +664,8 @@ class TestDatasetAlias(unittest.TestCase):
                     mock.patch.object(runner, 'setup_logger'), \
                     mock.patch.object(runner, 'apply_supported_vlm_cli_overrides'), \
                     mock.patch.object(runner, 'upsert_run_status'), \
-                    mock.patch.object(runner, 'upsert_dataset_status'), \
+                    mock.patch.object(runner, 'upsert_dataset_status',
+                                      side_effect=fake_upsert_dataset_status), \
                     mock.patch.object(runner, 'get_pred_file_path', return_value=str(pred_file)), \
                     mock.patch.object(runner, 'build_dataset_from_spec',
                                       side_effect=fake_build_dataset_from_spec), \
@@ -660,7 +676,11 @@ class TestDatasetAlias(unittest.TestCase):
                     mock.patch.object(runner, 'log_run_benchmark_report'):
                 runner.run_local_mode(args)
 
-            self.assertEqual(build_calls, [('PlainAlias', 'PlainAlias', {})])
+            self.assertEqual(build_calls, [('PlainAlias', 'PlainAlias', None, {})])
+            self.assertTrue(any(
+                call.get('dataset_class_name') == 'FakeEntryDataset'
+                for call in status_calls
+            ))
 
     def test_run_api_mode_non_config_data_allows_missing_data_config(self):
         import run as runner
@@ -706,7 +726,9 @@ class TestDatasetAlias(unittest.TestCase):
             build_calls = []
 
             def fake_build_dataset_from_spec(spec, extra_kwargs=None):
-                build_calls.append((spec.dataset_alias_name, spec.dataset_name, extra_kwargs))
+                build_calls.append(
+                    (spec.dataset_alias_name, spec.dataset_name, spec.dataset_class_name, extra_kwargs)
+                )
                 return FakeEntryDataset()
 
             def fake_pred_file(work_dir, model_name, dataset_name, use_env_format=True):
@@ -731,11 +753,11 @@ class TestDatasetAlias(unittest.TestCase):
                     mock.patch.object(inference_api, 'APIEvalPipeline', FakePipeline):
                 runner.run_api_mode(args)
 
-            self.assertEqual(build_calls, [('PlainAlias', 'PlainAlias', {})])
+            self.assertEqual(build_calls, [('PlainAlias', 'PlainAlias', None, {})])
             self.assertEqual(len(captured_configs), 1)
             self.assertEqual(captured_configs[0].dataset_name, 'PlainAlias')
             self.assertEqual(captured_configs[0].dataset_alias_name, 'PlainAlias')
-            self.assertIsNone(captured_configs[0].dataset_class_name)
+            self.assertEqual(captured_configs[0].dataset_class_name, 'FakeEntryDataset')
 
 
 if __name__ == '__main__':

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -258,6 +258,12 @@ class TestDatasetAlias(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'fps and nframe'):
             VideoMMEv2.validate_build_config({'dataset': 'Video-MME-v2', 'fps': 1.0})
 
+        MMBenchVideo.validate_build_config({
+            'dataset': 'MMBench-Video',
+            'nframe': 8,
+            'fps': 0,
+        })
+
         VideoMMEv2.validate_build_config({
             'dataset': 'Video-MME-v2',
             'nframe': 0,
@@ -292,6 +298,21 @@ class TestDatasetAlias(unittest.TestCase):
                 self.assertEqual(spec.build_config['nframe'], 0)
                 self.assertEqual(spec.build_config['fps'], 1.0)
                 VideoMMEv2.validate_build_config(spec.build_config)
+
+    def test_video_sampling_branches_treat_fps_zero_as_unset(self):
+        repo_root = Path(__file__).parents[1]
+        dataset_dir = repo_root / 'vlmeval' / 'dataset'
+        offenders = []
+        for path in dataset_dir.rglob('*.py'):
+            text = path.read_text(encoding='utf-8')
+            if 'self.nframe > 0 and self.fps < 0' in text:
+                offenders.append(str(path.relative_to(repo_root)))
+
+        mvbench_text = (dataset_dir / 'mvbench.py').read_text(encoding='utf-8')
+        if 'if self.fps < 0:' in mvbench_text:
+            offenders.append('vlmeval/dataset/mvbench.py')
+
+        self.assertEqual(offenders, [])
 
     def test_supported_video_datasets_symbol_removed(self):
         import vlmeval.dataset.video_dataset_config as video_config

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -457,18 +457,17 @@ class TestDatasetAlias(unittest.TestCase):
             self.assertEqual(model.custom_prompt_datasets, ['LogicalDS'])
             self.assertEqual(model.generate_datasets, ['LogicalDS'])
 
-    def test_composite_child_eval_file_handles_direct_and_alias_names(self):
-        direct = get_composite_child_eval_file('/tmp/MockModel_SIUO.tsv', 'SIUO', 'SIUO_GEN')
-        alias = get_composite_child_eval_file('/tmp/MockModel_OutputAlias.tsv', 'SIUO', 'SIUO_GEN')
+    def test_composite_child_eval_file_uses_sub_marker_without_parent_replace(self):
+        direct = get_composite_child_eval_file('/tmp/MockModel_SIUO.tsv', 'SIUO_GEN')
+        alias = get_composite_child_eval_file('/tmp/MockModel_OutputAlias.tsv', 'SIUO_GEN')
         alias_with_parent = get_composite_child_eval_file(
             '/tmp/MockModel_CustomSIUOAlias.tsv',
-            'SIUO',
             'SIUO_GEN',
         )
 
-        self.assertEqual(direct, '/tmp/MockModel_SIUO_GEN.tsv')
-        self.assertEqual(alias, '/tmp/MockModel_OutputAlias_SIUO_GEN.tsv')
-        self.assertEqual(alias_with_parent, '/tmp/MockModel_CustomSIUOAlias_SIUO_GEN.tsv')
+        self.assertEqual(direct, '/tmp/_MockModel_SIUO_SUB_SIUO_GEN.tsv')
+        self.assertEqual(alias, '/tmp/_MockModel_OutputAlias_SUB_SIUO_GEN.tsv')
+        self.assertEqual(alias_with_parent, '/tmp/_MockModel_CustomSIUOAlias_SUB_SIUO_GEN.tsv')
 
     def test_siuo_composite_evaluate_uses_alias_safe_child_files(self):
         from vlmeval.dataset.siuo import SIUODataset
@@ -502,8 +501,8 @@ class TestDatasetAlias(unittest.TestCase):
             }
 
             score = dataset.evaluate(str(eval_file))
-            gen_file = tmpdir / 'MockModel_OutputAlias_SIUO_GEN.tsv'
-            mcq_file = tmpdir / 'MockModel_OutputAlias_SIUO_MCQ.tsv'
+            gen_file = tmpdir / '_MockModel_OutputAlias_SUB_SIUO_GEN.tsv'
+            mcq_file = tmpdir / '_MockModel_OutputAlias_SUB_SIUO_MCQ.tsv'
 
             self.assertTrue(eval_file.exists())
             self.assertTrue(gen_file.exists())
@@ -549,8 +548,8 @@ class TestDatasetAlias(unittest.TestCase):
             }
 
             result = dataset.evaluate(str(eval_file))
-            child_a_file = tmpdir / 'MockModel_ImageAlias_ChildImageA.tsv'
-            child_b_file = tmpdir / 'MockModel_ImageAlias_ChildImageB.tsv'
+            child_a_file = tmpdir / '_MockModel_ImageAlias_SUB_ChildImageA.tsv'
+            child_b_file = tmpdir / '_MockModel_ImageAlias_SUB_ChildImageB.tsv'
 
             self.assertEqual(result, {'ChildImageA:acc': 1, 'ChildImageB:acc': 2})
             self.assertEqual(dataset.dataset_map['ChildImageA'].calls, [str(child_a_file)])
@@ -593,8 +592,8 @@ class TestDatasetAlias(unittest.TestCase):
             }
 
             result = dataset.evaluate(str(eval_file))
-            child_a_file = tmpdir / 'MockModel_VideoAlias_ChildVideoA.tsv'
-            child_b_file = tmpdir / 'MockModel_VideoAlias_ChildVideoB.tsv'
+            child_a_file = tmpdir / '_MockModel_VideoAlias_SUB_ChildVideoA.tsv'
+            child_b_file = tmpdir / '_MockModel_VideoAlias_SUB_ChildVideoB.tsv'
 
             self.assertEqual(dataset.dataset_map['ChildVideoA'].calls, [str(child_a_file)])
             self.assertEqual(dataset.dataset_map['ChildVideoB'].calls, [str(child_b_file)])

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -345,6 +345,38 @@ class TestDatasetAlias(unittest.TestCase):
                 display_name='SiteBenchImageAlias',
             )
 
+    def test_model_dependent_doc_datasets_accept_model_extra_kwarg(self):
+        import run as runner
+        from vlmeval.dataset import DUDE, MMLongBenchDoc, SlideVQA
+
+        fake_data = pd.DataFrame([{
+            'index': 0,
+            'question': 'question',
+            'image_path': ['page_0.jpg'],
+        }])
+
+        cases = [
+            (DUDE, 'DUDE'),
+            (SlideVQA, 'SLIDEVQA'),
+            (MMLongBenchDoc, 'MMLongBench_DOC'),
+        ]
+        for dataset_cls, dataset_name in cases:
+            with self.subTest(dataset_name=dataset_name):
+                with mock.patch.object(dataset_cls, 'load_data', return_value=fake_data.copy()):
+                    dataset = runner.build_dataset_from_config_dict(
+                        {
+                            'class': dataset_cls.__name__,
+                            'dataset': dataset_name,
+                        },
+                        display_name=f'{dataset_name}Alias',
+                        extra_kwargs={'model': 'GPT4o'},
+                    )
+
+                self.assertIsInstance(dataset, dataset_cls)
+                self.assertEqual(dataset.dataset_name, dataset_name)
+                self.assertEqual(dataset.concat_num, 1)
+                self.assertEqual(dataset.column_num, 1)
+
     def test_videommev2_1fps_presets_clear_default_nframe(self):
         from vlmeval.dataset import VideoMMEv2
 

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -10,8 +10,7 @@ import pandas as pd
 from vlmeval.inference import infer_data_job
 from vlmeval.smp import dump, get_composite_child_eval_file, load, status_report
 from vlmeval.smp.dataset_alias import (DatasetSpec, get_predefined_dataset_spec,
-                                       resolve_dataset_alias, resolve_dataset_alias_name,
-                                       resolve_dataset_spec)
+                                       resolve_dataset_alias_name, resolve_dataset_spec)
 
 os.environ.setdefault('LMUData', '/tmp/vlmevalkit-test-lmudata')
 os.makedirs(os.environ['LMUData'], exist_ok=True)
@@ -91,15 +90,15 @@ class FakeModel:
 
 class TestDatasetAlias(unittest.TestCase):
 
-    def test_resolve_dataset_alias_uses_config_dataset_as_logical_name(self):
-        ctx = resolve_dataset_alias(
+    def test_resolve_dataset_spec_uses_config_dataset_as_logical_name(self):
+        spec = resolve_dataset_spec(
             'AnyAlias',
             {'AnyAlias': {'class': 'ImageMCQDataset', 'dataset': 'MMBench_DEV_EN_V11'}},
         )
 
-        self.assertEqual(ctx.dataset_alias_name, 'AnyAlias')
-        self.assertEqual(ctx.dataset_name, 'MMBench_DEV_EN_V11')
-        self.assertEqual(ctx.dataset_class_name, 'ImageMCQDataset')
+        self.assertEqual(spec.dataset_alias_name, 'AnyAlias')
+        self.assertEqual(spec.dataset_name, 'MMBench_DEV_EN_V11')
+        self.assertEqual(spec.dataset_class_name, 'ImageMCQDataset')
 
     def test_resolve_predefined_shortcut(self):
         spec = resolve_dataset_spec('MMBench_Video_8frame_nopack')

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -303,16 +303,75 @@ class TestDatasetAlias(unittest.TestCase):
         repo_root = Path(__file__).parents[1]
         dataset_dir = repo_root / 'vlmeval' / 'dataset'
         offenders = []
+        legacy_patterns = [
+            'self.nframe > 0 and self.fps < 0',
+            'num_frames > 0 and fps < 0',
+        ]
         for path in dataset_dir.rglob('*.py'):
+            if path.relative_to(repo_root).as_posix() == 'vlmeval/dataset/utils/cgbench.py':
+                continue
             text = path.read_text(encoding='utf-8')
-            if 'self.nframe > 0 and self.fps < 0' in text:
-                offenders.append(str(path.relative_to(repo_root)))
+            for pattern in legacy_patterns:
+                if pattern in text:
+                    offenders.append(f'{path.relative_to(repo_root)}: {pattern}')
 
         mvbench_text = (dataset_dir / 'mvbench.py').read_text(encoding='utf-8')
         if 'if self.fps < 0:' in mvbench_text:
             offenders.append('vlmeval/dataset/mvbench.py')
 
         self.assertEqual(offenders, [])
+
+    def test_cgbench_local_fps_zero_sampling_uses_nframe_branch(self):
+        import numpy as np
+        from PIL import Image
+
+        from vlmeval.dataset.cgbench import CGBench_MCQ_Grounding_Mini
+
+        class FakeFrame:
+
+            def asnumpy(self):
+                return np.zeros((2, 2, 3), dtype=np.uint8)
+
+        class FakeVideoReader:
+
+            def __init__(self, path):
+                self.path = path
+
+            def __len__(self):
+                return 9
+
+            def __getitem__(self, idx):
+                return FakeFrame()
+
+            def get_avg_fps(self):
+                return 30
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            dataset = CGBench_MCQ_Grounding_Mini.__new__(CGBench_MCQ_Grounding_Mini)
+            dataset.data_root = str(tmpdir)
+            dataset.frame_root = str(tmpdir / 'frames')
+            dataset.frame_tmpl = 'frame-{}-of-{}.jpg'
+            dataset.frame_tmpl_fps = 'frame-{}-of-{}-{}fps.jpg'
+            dataset.nframe = 2
+
+            frame_dir = tmpdir / 'frames' / 'sample'
+            frame_dir.mkdir(parents=True)
+            for idx in range(1, 3):
+                Image.new('RGB', (2, 2)).save(frame_dir / f'frame-{idx}-of-2.jpg')
+
+            fake_decord = types.SimpleNamespace(VideoReader=FakeVideoReader)
+            with mock.patch.dict('sys.modules', {'decord': fake_decord}):
+                paths, indices, vid_fps = dataset.save_video_frames(
+                    'video.mp4',
+                    uid='sample',
+                    num_frames=2,
+                    fps=0,
+                )
+
+        self.assertEqual(indices, [3, 6])
+        self.assertEqual(vid_fps, 30)
+        self.assertEqual(len(paths), 2)
 
     def test_supported_video_datasets_symbol_removed(self):
         import vlmeval.dataset.video_dataset_config as video_config

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -253,7 +253,7 @@ class TestDatasetAlias(unittest.TestCase):
                 self.assertTrue(spec.build_config['dataset'].strip())
 
     def test_video_build_config_validation_uses_class_defaults_and_rejects_none(self):
-        from vlmeval.dataset import MMBenchVideo, VideoMMEv2
+        from vlmeval.dataset import DREAM, MMBenchVideo, MVUEval, VideoMMEv2
 
         with self.assertRaisesRegex(ValueError, 'fps and nframe'):
             VideoMMEv2.validate_build_config({'dataset': 'Video-MME-v2', 'fps': 1.0})
@@ -270,6 +270,23 @@ class TestDatasetAlias(unittest.TestCase):
             'fps': 1.0,
         })
 
+        for dataset_cls, dataset_name in [
+            (DREAM, 'DREAM-1K'),
+            (MVUEval, 'MVU-Eval'),
+        ]:
+            with self.subTest(dataset_name=dataset_name):
+                dataset_cls.validate_build_config({'dataset': dataset_name})
+                dataset_cls.validate_build_config({
+                    'dataset': dataset_name,
+                    'nframe': 0,
+                    'fps': -1,
+                })
+                with self.assertRaisesRegex(ValueError, 'fps and nframe'):
+                    dataset_cls.validate_build_config({
+                        'dataset': dataset_name,
+                        'fps': 0,
+                    })
+
         with self.assertRaisesRegex(ValueError, 'fps should not be None'):
             MMBenchVideo.validate_build_config({
                 'dataset': 'MMBench-Video',
@@ -282,6 +299,42 @@ class TestDatasetAlias(unittest.TestCase):
                 'nframe': None,
                 'fps': 1.0,
             })
+
+    def test_sitebench_image_strict_config_uses_explicit_init_signature(self):
+        import run as runner
+        from vlmeval.dataset import SiteBenchImage
+
+        fake_data = pd.DataFrame([{
+            'index': 0,
+            'question': 'question',
+            'options': '["A", "B"]',
+            'image_path': '/tmp/sitebench.jpg',
+        }])
+
+        with mock.patch.object(SiteBenchImage, 'load_data', return_value=fake_data):
+            dataset = runner.build_dataset_from_config_dict(
+                {
+                    'class': 'SiteBenchImage',
+                    'dataset': 'SiteBenchImage',
+                    'skip_noimg': False,
+                },
+                display_name='SiteBenchImageAlias',
+            )
+
+        self.assertIsInstance(dataset, SiteBenchImage)
+        self.assertEqual(dataset.dataset_name, 'SiteBenchImage')
+        self.assertFalse(dataset.skip_noimg)
+        self.assertEqual(dataset.repo_id, 'franky-veteran/SITE-Bench')
+
+        with self.assertRaisesRegex(ValueError, 'Unsupported parameter'):
+            runner.build_dataset_from_config_dict(
+                {
+                    'class': 'SiteBenchImage',
+                    'dataset': 'SiteBenchImage',
+                    'unknown': 1,
+                },
+                display_name='SiteBenchImageAlias',
+            )
 
     def test_videommev2_1fps_presets_clear_default_nframe(self):
         from vlmeval.dataset import VideoMMEv2

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -10,7 +10,8 @@ import pandas as pd
 from vlmeval.inference import infer_data_job
 from vlmeval.smp import dump, get_composite_child_eval_file, load, status_report
 from vlmeval.smp.dataset_alias import (DatasetSpec, get_predefined_dataset_spec,
-                                       resolve_dataset_alias, resolve_dataset_spec)
+                                       resolve_dataset_alias, resolve_dataset_alias_name,
+                                       resolve_dataset_spec)
 
 os.environ.setdefault('LMUData', '/tmp/vlmevalkit-test-lmudata')
 os.makedirs(os.environ['LMUData'], exist_ok=True)
@@ -131,6 +132,35 @@ class TestDatasetAlias(unittest.TestCase):
         self.assertIsNone(spec.dataset_class_name)
         self.assertEqual(spec.build_config, {'dataset': 'MMBench_DEV_EN_V11'})
         self.assertEqual(spec.source, 'direct_dataset')
+
+    def test_dataset_alias_name_must_be_safe_filename_component(self):
+        bad_names = [
+            '',
+            '   ',
+            '.HiddenAlias',
+            '../MMBench',
+            'MMBench/Video',
+            r'MMBench\Video',
+            'MMBench Video',
+            'MMBench:Video',
+        ]
+        for name in bad_names:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    resolve_dataset_spec(name)
+
+    def test_resolve_dataset_alias_name_validates_filename_component(self):
+        self.assertEqual(
+            resolve_dataset_alias_name('MMBench_DEV_EN_V11'),
+            'MMBench_DEV_EN_V11',
+        )
+        self.assertEqual(
+            resolve_dataset_alias_name('Video-MME', 'Video-MME_0.5fps'),
+            'Video-MME_0.5fps',
+        )
+
+        with self.assertRaisesRegex(ValueError, 'safe filename component'):
+            resolve_dataset_alias_name('Video-MME', '../Video-MME')
 
     def test_empty_dict_config_is_not_predefined_shortcut(self):
         with self.assertRaisesRegex(ValueError, 'Empty dataset config'):

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -115,14 +115,31 @@ class TestDatasetAlias(unittest.TestCase):
     def test_resolve_preset_alias(self):
         spec = resolve_dataset_spec(
             'AliasVideo',
-            {'AliasVideo': {'preset': 'MMBench_Video_8frame_nopack', 'nframe': 16}},
+            {
+                'AliasVideo': {
+                    'preset': 'MMBench_Video_8frame_nopack',
+                    'nframe': 16,
+                    'future_dataset_arg': 'kept-for-strict-build',
+                }
+            },
         )
 
         self.assertEqual(spec.dataset_alias_name, 'AliasVideo')
         self.assertEqual(spec.dataset_name, 'MMBench-Video')
         self.assertEqual(spec.dataset_class_name, 'MMBenchVideo')
         self.assertEqual(spec.build_config['nframe'], 16)
+        self.assertEqual(spec.build_config['future_dataset_arg'], 'kept-for-strict-build')
         self.assertFalse(spec.build_config['pack'])
+
+    def test_preset_alias_rejects_identity_overrides(self):
+        bad_configs = [
+            {'preset': 'MMBench_Video_8frame_nopack', 'class': 'VideoMME'},
+            {'preset': 'MMBench_Video_8frame_nopack', 'dataset': 'Video-MME'},
+        ]
+        for cfg in bad_configs:
+            with self.subTest(cfg=cfg):
+                with self.assertRaises(ValueError):
+                    resolve_dataset_spec('AliasVideo', {'AliasVideo': cfg})
 
     def test_resolve_direct_dataset_spec_does_not_build_dataset_class_name(self):
         spec = resolve_dataset_spec('MMBench_DEV_EN_V11')

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -1,0 +1,275 @@
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pandas as pd
+
+from vlmeval.inference import infer_data_job
+from vlmeval.smp import status_report
+from vlmeval.smp.dataset_alias import resolve_dataset_alias
+
+os.environ.setdefault('LMUData', '/tmp/vlmevalkit-test-lmudata')
+os.makedirs(os.environ['LMUData'], exist_ok=True)
+
+
+class DummyReporter:
+
+    @staticmethod
+    def report_infer_err(pred_path):
+        return {'failed': 0, 'total': 1 if pred_path else 0}
+
+    @staticmethod
+    def report_judge_err(pred_path, total_samples=None, judge_model=None, error_message=None):
+        return {'failed': 0, 'total': total_samples or 0}
+
+    @staticmethod
+    def report_primary_metric(metrics):
+        return {}
+
+
+class FakeDataset:
+    dataset_name = 'LogicalDS'
+    MODALITY = 'IMAGE'
+    TYPE = 'VQA'
+
+    def __init__(self):
+        self.data = pd.DataFrame([{'index': 0, 'question': 'question'}])
+
+    def __len__(self):
+        return len(self.data)
+
+    def build_prompt(self, line):
+        return [{'type': 'text', 'value': line['question']}]
+
+    def dump_image(self, line):
+        return []
+
+
+class FakeEntryDataset(FakeDataset):
+    dataset_name = 'PlainAlias'
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        return {'acc': 1.0}
+
+
+class FakeModel:
+    is_api = False
+
+    def __init__(self):
+        self.custom_prompt_datasets = []
+        self.generate_datasets = []
+
+    def set_dump_image(self, dump_image):
+        self.dump_image = dump_image
+
+    def use_custom_prompt(self, dataset):
+        self.custom_prompt_datasets.append(dataset)
+        return False
+
+    def generate(self, message, dataset=None):
+        self.generate_datasets.append(dataset)
+        return 'ok'
+
+
+class TestDatasetAlias(unittest.TestCase):
+
+    def test_resolve_dataset_alias_uses_config_dataset_as_logical_name(self):
+        ctx = resolve_dataset_alias(
+            'AnyAlias',
+            {'AnyAlias': {'class': 'ImageMCQDataset', 'dataset': 'MMBench_DEV_EN_V11'}},
+        )
+
+        self.assertEqual(ctx.dataset_alias_name, 'AnyAlias')
+        self.assertEqual(ctx.dataset_name, 'MMBench_DEV_EN_V11')
+
+    def test_status_keeps_alias_key_and_logical_dataset_name_for_reporter(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = Path(tmpdir)
+            pred_file = run_dir / 'MockModel_AnyAlias.tsv'
+            pred_file.write_text('index\tprediction\n0\tok\n', encoding='utf-8')
+
+            status_report.upsert_dataset_status(
+                run_dir=run_dir,
+                model_name='MockModel',
+                dataset_name='AnyAlias',
+                logical_dataset_name='LogicalDS',
+                prediction_file=pred_file,
+                status='done',
+            )
+
+            status = status_report.load_run_status(run_dir)
+            self.assertIn('AnyAlias', status['datasets'])
+            self.assertEqual(status['datasets']['AnyAlias']['logical_dataset_name'], 'LogicalDS')
+
+            resolved_names = []
+
+            def fake_resolve(name, dataset_obj=None):
+                resolved_names.append(name)
+                return DummyReporter
+
+            with mock.patch.object(
+                    status_report, '_resolve_dataset_reporter', side_effect=fake_resolve):
+                rows = status_report.collect_run_benchmark_report(run_dir)
+
+            self.assertEqual(resolved_names, ['LogicalDS'])
+            self.assertEqual(rows[0]['benchmark'], 'AnyAlias')
+
+    def test_infer_data_job_writes_alias_result_but_uses_logical_dataset_for_model(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            result_file = tmpdir / 'MockModel_AnyAlias.tsv'
+            logical_result_file = tmpdir / 'MockModel_LogicalDS.tsv'
+            model = FakeModel()
+
+            infer_data_job(
+                model=model,
+                work_dir=str(tmpdir),
+                model_name='MockModel',
+                dataset=FakeDataset(),
+                result_file=str(result_file),
+                dataset_alias_name='AnyAlias',
+            )
+
+            self.assertTrue(result_file.exists())
+            self.assertFalse(logical_result_file.exists())
+            self.assertEqual(model.custom_prompt_datasets, ['LogicalDS'])
+            self.assertEqual(model.generate_datasets, ['LogicalDS'])
+
+    def test_run_local_mode_non_config_data_allows_missing_data_config(self):
+        import run as runner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = types.SimpleNamespace(
+                config=None,
+                data=['PlainAlias'],
+                model=['MockModel'],
+                data_config={},
+                work_dir=tmpdir,
+                mode='infer',
+                reuse=False,
+                reuse_aux='all',
+                base_url=None,
+                api_nproc=1,
+                retry=1,
+                verbose=False,
+                keep_failed=False,
+                use_vllm=False,
+                judge_api_nproc=None,
+                judge_retry=None,
+                judge_timeout=600,
+                judge_args=None,
+                judge_base_url=None,
+                judge_key=None,
+                judge=None,
+            )
+
+            pred_file = Path(tmpdir) / 'MockModel' / 'TENTRY' / 'MockModel_PlainAlias.tsv'
+            build_calls = []
+
+            def fake_build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
+                build_calls.append((dataset_name, data_config, dataset_kwargs))
+                return FakeEntryDataset()
+
+            judge_kwargs = {'model': 'mock-judge'}
+            reuse_ctx = {'source_eval_id': None, 'prediction_complete': False}
+
+            with mock.patch.object(runner, 'RANK', 0), \
+                    mock.patch.object(runner, 'WORLD_SIZE', 1), \
+                    mock.patch.object(runner, 'build_eval_id', return_value='TENTRY'), \
+                    mock.patch.object(runner, 'githash', return_value='deadbeef'), \
+                    mock.patch.object(runner, 'setup_logger'), \
+                    mock.patch.object(runner, 'apply_supported_vlm_cli_overrides'), \
+                    mock.patch.object(runner, 'upsert_run_status'), \
+                    mock.patch.object(runner, 'upsert_dataset_status'), \
+                    mock.patch.object(runner, 'get_pred_file_path', return_value=str(pred_file)), \
+                    mock.patch.object(runner, 'build_dataset_from_cli',
+                                      side_effect=fake_build_dataset_from_cli), \
+                    mock.patch.object(runner, 'get_judge_kwargs', return_value=judge_kwargs), \
+                    mock.patch.object(runner, 'prepare_reuse_files', return_value=reuse_ctx), \
+                    mock.patch.object(runner, 'is_prediction_complete', return_value=False), \
+                    mock.patch.object(runner, 'infer_data_job', return_value='MockModel'), \
+                    mock.patch.object(runner, 'log_run_benchmark_report'):
+                runner.run_local_mode(args)
+
+            self.assertEqual(build_calls, [('PlainAlias', {}, {})])
+
+    def test_run_api_mode_non_config_data_allows_missing_data_config(self):
+        import run as runner
+        import vlmeval.inference_api as inference_api
+
+        captured_configs = []
+
+        class FakePipeline:
+
+            def __init__(self, dataset_configs, **kwargs):
+                captured_configs.extend(dataset_configs)
+                self.kwargs = kwargs
+
+            async def run(self):
+                return None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = types.SimpleNamespace(
+                data=['PlainAlias'],
+                model='MockModel',
+                data_config={},
+                work_dir=tmpdir,
+                mode='infer',
+                reuse=False,
+                reuse_aux='all',
+                base_url=None,
+                api_nproc=1,
+                monitor_interval=30,
+                debug=False,
+                retry=1,
+                verbose=False,
+                keep_failed=False,
+                custom_prompt=None,
+                judge_api_nproc=None,
+                judge_retry=None,
+                judge_timeout=600,
+                judge_args=None,
+                judge_base_url=None,
+                judge_key=None,
+                judge=None,
+            )
+
+            build_calls = []
+
+            def fake_build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
+                build_calls.append((dataset_name, data_config, dataset_kwargs))
+                return FakeEntryDataset()
+
+            def fake_pred_file(work_dir, model_name, dataset_name, use_env_format=True):
+                return str(Path(work_dir) / f'{model_name}_{dataset_name}.tsv')
+
+            judge_kwargs = {'model': 'mock-judge'}
+            reuse_ctx = {'source_eval_id': None, 'prediction_complete': False}
+
+            with mock.patch.object(runner, 'build_eval_id', return_value='TENTRY'), \
+                    mock.patch.object(runner, 'githash', return_value='deadbeef'), \
+                    mock.patch.object(runner, 'setup_logger'), \
+                    mock.patch.object(runner, 'apply_supported_vlm_cli_overrides'), \
+                    mock.patch.object(runner, 'supported_VLM', {'MockModel': lambda: object()}), \
+                    mock.patch.object(runner, 'upsert_run_status'), \
+                    mock.patch.object(runner, 'upsert_dataset_status'), \
+                    mock.patch.object(runner, 'get_pred_file_path', side_effect=fake_pred_file), \
+                    mock.patch.object(runner, 'build_dataset_from_cli',
+                                      side_effect=fake_build_dataset_from_cli), \
+                    mock.patch.object(runner, 'get_judge_kwargs', return_value=judge_kwargs), \
+                    mock.patch.object(runner, 'prepare_reuse_files', return_value=reuse_ctx), \
+                    mock.patch.object(runner, 'log_run_benchmark_report'), \
+                    mock.patch.object(inference_api, 'APIEvalPipeline', FakePipeline):
+                runner.run_api_mode(args)
+
+            self.assertEqual(build_calls, [('PlainAlias', {}, {})])
+            self.assertEqual(len(captured_configs), 1)
+            self.assertEqual(captured_configs[0].dataset_name, 'PlainAlias')
+            self.assertEqual(captured_configs[0].dataset_alias_name, 'PlainAlias')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -359,7 +359,7 @@ class TestDatasetAlias(unittest.TestCase):
                     'nframe': 0,
                     'fps': -1,
                 })
-                with self.assertRaisesRegex(ValueError, 'fps and nframe'):
+                with self.assertWarnsRegex(UserWarning, 'disable frame split'):
                     dataset_cls.validate_build_config({
                         'dataset': dataset_name,
                         'fps': 0,

--- a/tests/test_dataset_alias.py
+++ b/tests/test_dataset_alias.py
@@ -111,6 +111,29 @@ class TestDatasetAlias(unittest.TestCase):
         self.assertEqual(spec.build_config['nframe'], 8)
         self.assertFalse(spec.build_config['pack'])
 
+    def test_get_judge_kwargs_matches_mmb_video_logical_and_legacy_names(self):
+        import run as runner
+
+        args = types.SimpleNamespace(
+            judge_api_nproc=None,
+            api_nproc=1,
+            judge_retry=None,
+            retry=1,
+            verbose=False,
+            judge_timeout=600,
+            judge_args=None,
+            judge_base_url=None,
+            judge_key=None,
+            judge=None,
+            use_verifier=False,
+            use_vllm=False,
+        )
+
+        for dataset_name in ['MMBench-Video', 'MMBench_Video']:
+            with self.subTest(dataset_name=dataset_name):
+                judge_kwargs = runner.get_judge_kwargs(dataset_name, 'Video-VQA', args)
+                self.assertEqual(judge_kwargs['model'], 'gpt-4-turbo')
+
     def test_resolve_preset_alias(self):
         spec = resolve_dataset_spec(
             'AliasVideo',

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -91,6 +91,38 @@ class FakeCrashEvalDataset:
         os._exit(1)
 
 
+class FakeAliasDataset:
+    dataset_name = 'LogicalEval'
+    data = [{'index': 0}]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+    def build_prompt(self, item):
+        return {'dataset_prompt': item['index']}
+
+    def dump_image(self, item):
+        return []
+
+
+class FakeAliasModel:
+
+    def __init__(self):
+        self.use_custom_prompt_datasets = []
+        self.build_prompt_datasets = []
+
+    def use_custom_prompt(self, dataset):
+        self.use_custom_prompt_datasets.append(dataset)
+        return True
+
+    def build_prompt(self, item, dataset=None):
+        self.build_prompt_datasets.append(dataset)
+        return {'model_prompt': item['index'], 'dataset': dataset}
+
+
 class TestInferenceApiProcessHelpers(unittest.TestCase):
 
     def test_async_wait_process_observes_abrupt_exit(self):
@@ -230,6 +262,42 @@ class TestInferenceApiProcessHelpers(unittest.TestCase):
                 self.assertEqual(pipeline.eval_processes, {})
             finally:
                 logging.disable(logging.NOTSET)
+                pipeline._shutdown_executors()
+
+    def test_dataset_config_separates_logical_name_from_output_alias(self):
+        inference_api = _load_inference_api()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model = FakeAliasModel()
+            cfg = inference_api.DatasetConfig(
+                dataset_name='LogicalEval',
+                dataset_alias_name='AliasEval',
+                dataset_obj=FakeAliasDataset(),
+                model_name='mock',
+                model_obj=model,
+                work_dir=tmpdir,
+                result_file=str(Path(tmpdir) / 'mock_AliasEval.tsv'),
+                judge_kwargs={},
+            )
+            pipeline = inference_api.APIEvalPipeline([cfg], concurrency=1, run_eval=False)
+
+            try:
+                self.assertIn('AliasEval', pipeline.states)
+                self.assertNotIn('LogicalEval', pipeline.states)
+                self.assertEqual(
+                    pipeline._get_checkpoint_file('AliasEval').name,
+                    'mock_AliasEval_checkpoint.pkl',
+                )
+
+                tasks_generated = asyncio.run(pipeline._produce_image_tasks(cfg, {}))
+                self.assertEqual(tasks_generated, 1)
+                task = pipeline.queue.get_nowait()
+
+                self.assertEqual(task.dataset_name, 'LogicalEval')
+                self.assertEqual(task.dataset_alias_name, 'AliasEval')
+                self.assertEqual(model.use_custom_prompt_datasets, ['LogicalEval'])
+                self.assertEqual(model.build_prompt_datasets, ['LogicalEval'])
+            finally:
                 pipeline._shutdown_executors()
 
 

--- a/vlmeval/dataset/CGAVCounting/cg_av_counting.py
+++ b/vlmeval/dataset/CGAVCounting/cg_av_counting.py
@@ -318,7 +318,7 @@ class CGAVCounting(VideoBaseDataset):
         vid_fps = vid.get_avg_fps()
         n_frames = len(vid)
 
-        if num_frames > 0 and fps < 0:
+        if num_frames > 0 and fps <= 0:
             step_size = len(vid) / (num_frames + 1)
             indices = [int(i * step_size) for i in range(1, num_frames + 1)]
 

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -246,7 +246,7 @@ class ConcatDataset(ImageBaseDataset):
         data_all = load(eval_file)
         child_eval_files = {}
         for dname in self.datasets:
-            tgt = get_composite_child_eval_file(eval_file, self.dataset_name, dname)
+            tgt = get_composite_child_eval_file(eval_file, dname)
             child_eval_files[dname] = tgt
             data_sub = data_all[data_all['SUB_DATASET'] == dname].copy()
             data_sub.pop('index')

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -5,7 +5,8 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from vlmeval.smp import LMUDataRoot, dump, get_intermediate_file_path, load, localize_df, toliststr
+from vlmeval.smp import (LMUDataRoot, dump, get_composite_child_eval_file,
+                         get_intermediate_file_path, load, localize_df, toliststr)
 from .asclepius import Asclepius
 from .av_speakerbench import AVSpeakerBench
 from .babyvision import BabyVision
@@ -169,8 +170,6 @@ from .worldsense import WorldSense
 from .worldvqa import WorldVQA
 from .xstest import XSTestDataset
 
-from .video_dataset_config import supported_video_datasets  # isort: skip
-
 
 class ConcatDataset(ImageBaseDataset):
     # This dataset takes multiple dataset names as input and aggregate them into a single dataset.
@@ -245,9 +244,11 @@ class ConcatDataset(ImageBaseDataset):
     def evaluate(self, eval_file, **judge_kwargs):
         # First, split the eval_file by dataset
         data_all = load(eval_file)
+        child_eval_files = {}
         for dname in self.datasets:
-            tgt = eval_file.replace(self.dataset_name, dname)
-            data_sub = data_all[data_all['SUB_DATASET'] == dname]
+            tgt = get_composite_child_eval_file(eval_file, self.dataset_name, dname)
+            child_eval_files[dname] = tgt
+            data_sub = data_all[data_all['SUB_DATASET'] == dname].copy()
             data_sub.pop('index')
             data_sub['index'] = data_sub.pop('original_index')
             data_sub.pop('SUB_DATASET')
@@ -257,7 +258,7 @@ class ConcatDataset(ImageBaseDataset):
         dict_all = {}
         # One of the vars will be used to aggregate results
         for dname in self.datasets:
-            tgt = eval_file.replace(self.dataset_name, dname)
+            tgt = child_eval_files[dname]
             res = self.dataset_map[dname].evaluate(tgt, **judge_kwargs)
             if isinstance(res, pd.DataFrame):
                 res['DATASET'] = [dname] * len(res)
@@ -395,9 +396,7 @@ def DATASET_MODALITY(dataset, *, default: str = 'IMAGE') -> str:
 
 def build_dataset(dataset_name, **kwargs):
     for cls in DATASET_CLASSES:
-        if dataset_name in supported_video_datasets:
-            return supported_video_datasets[dataset_name](**kwargs)
-        elif dataset_name in cls.supported_datasets():
+        if dataset_name in cls.supported_datasets():
             return cls(dataset=dataset_name, **kwargs)
 
     warnings.warn(f'Dataset {dataset_name} is not officially supported. ')

--- a/vlmeval/dataset/av_speakerbench.py
+++ b/vlmeval/dataset/av_speakerbench.py
@@ -174,7 +174,7 @@ Focus on the audio and respond with only the letter (A, B, C, or D).
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video_id)

--- a/vlmeval/dataset/cgbench.py
+++ b/vlmeval/dataset/cgbench.py
@@ -374,7 +374,7 @@ class CGBench_MCQ_Grounding_Mini(VideoBaseDataset):
         if clue_intervals is not None:
             merged_intervals = merge_intervals(clue_intervals)
 
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 indices = sample_frames_clue_average(merged_intervals, num_frames, vid_fps)
                 frame_paths = self.clue_frame_paths(uid, len(indices))
 
@@ -396,7 +396,7 @@ class CGBench_MCQ_Grounding_Mini(VideoBaseDataset):
                 frame_paths = self.clue_frame_paths_fps(uid, len(indices), fps)
 
         else:
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 step_size = len(vid) / (num_frames + 1)
                 indices = [int(i * step_size) for i in range(1, num_frames + 1)]
 
@@ -702,7 +702,7 @@ class CGBench_OpenEnded_Mini(VideoBaseDataset):
         if clue_intervals is not None:
             merged_intervals = merge_intervals(clue_intervals)
 
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 indices = sample_frames_clue_average(merged_intervals, num_frames, vid_fps)
                 frame_paths = self.clue_frame_paths(uid, len(indices))
 
@@ -724,7 +724,7 @@ class CGBench_OpenEnded_Mini(VideoBaseDataset):
                 frame_paths = self.clue_frame_paths_fps(uid, len(indices), fps)
 
         else:
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 step_size = len(vid) / (num_frames + 1)
                 indices = [int(i * step_size) for i in range(1, num_frames + 1)]
                 frame_paths = self.frame_paths(uid)
@@ -1256,7 +1256,7 @@ class CGBench_MCQ_Grounding(VideoBaseDataset):
         if clue_intervals is not None:
             merged_intervals = merge_intervals(clue_intervals)
 
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 indices = sample_frames_clue_average(merged_intervals, num_frames, vid_fps)
                 frame_paths = self.clue_frame_paths(uid, len(indices))
 
@@ -1278,7 +1278,7 @@ class CGBench_MCQ_Grounding(VideoBaseDataset):
                 frame_paths = self.clue_frame_paths_fps(uid, len(indices), fps)
 
         else:
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 step_size = len(vid) / (num_frames + 1)
                 indices = [int(i * step_size) for i in range(1, num_frames + 1)]
 
@@ -1583,7 +1583,7 @@ class CGBench_OpenEnded(VideoBaseDataset):
         if clue_intervals is not None:
             merged_intervals = merge_intervals(clue_intervals)
 
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 indices = sample_frames_clue_average(merged_intervals, num_frames, vid_fps)
                 frame_paths = self.clue_frame_paths(uid, len(indices))
 
@@ -1605,7 +1605,7 @@ class CGBench_OpenEnded(VideoBaseDataset):
                 frame_paths = self.clue_frame_paths_fps(uid, len(indices), fps)
 
         else:
-            if num_frames > 0 and fps < 0:
+            if num_frames > 0 and fps <= 0:
                 step_size = len(vid) / (num_frames + 1)
                 indices = [int(i * step_size) for i in range(1, num_frames + 1)]
                 frame_paths = self.frame_paths(uid)

--- a/vlmeval/dataset/dream.py
+++ b/vlmeval/dataset/dream.py
@@ -56,10 +56,20 @@ class DREAM(VideoBaseDataset):
 
     TYPE = 'DREAM-1K'
     MD5 = 'e8f0a486429bb6c27806bc0669e0d8b2'
+    DEFAULT_NFRAME = 8
+
+    @classmethod
+    def validate_build_config(cls, config: dict) -> None:
+        config = dict(config)
+        nframe = config.get('nframe', 0)
+        fps = config.get('fps', -1)
+        if nframe == 0 and fps == -1:
+            config['nframe'] = cls.DEFAULT_NFRAME
+        super().validate_build_config(config)
 
     def __init__(self, dataset='DREAM-1K', pack=False, nframe=0, fps=-1):
         if nframe == 0 and fps == -1:
-            nframe = 8
+            nframe = self.DEFAULT_NFRAME
         super().__init__(dataset=dataset, pack=pack, nframe=nframe, fps=fps)
 
     def prepare_dataset(self, dataset):

--- a/vlmeval/dataset/dsrbench.py
+++ b/vlmeval/dataset/dsrbench.py
@@ -138,7 +138,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
 
         indices = []
 
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             indices = np.linspace(0, video_nframes - 1, self.nframe, dtype=int).tolist()
             frame_paths = self.frame_paths(video_path)
 

--- a/vlmeval/dataset/dude.py
+++ b/vlmeval/dataset/dude.py
@@ -74,9 +74,9 @@ class DUDE(ImageBaseDataset):
         'InternVL-Chat-V1-5': (5, 2),
     }
 
-    def __init__(self, dataset, **kwargs):
+    def __init__(self, dataset, model=None):
         self.model_list = list(self.SUPPORTED_MODELS.keys())
-        model_name = kwargs['model']
+        model_name = model
         if not listinstr(self.model_list, model_name):
             raise AssertionError("{} doesn't support the evaluation on DUDE.".format(model_name))
         super(DUDE, self).__init__(dataset)

--- a/vlmeval/dataset/longvideobench.py
+++ b/vlmeval/dataset/longvideobench.py
@@ -218,7 +218,7 @@ class LongVideoBench(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video_path[:-4])

--- a/vlmeval/dataset/mlvu.py
+++ b/vlmeval/dataset/mlvu.py
@@ -164,7 +164,7 @@ class MLVU_MCQ(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)
@@ -367,7 +367,7 @@ class MLVU_OpenEnded(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)

--- a/vlmeval/dataset/mmlongbenchdoc.py
+++ b/vlmeval/dataset/mmlongbenchdoc.py
@@ -456,9 +456,9 @@ class MMLongBenchDoc(ImageBaseDataset):
         'XComposer2d5': (1, -1),
     }
 
-    def __init__(self, dataset, **kwargs):
+    def __init__(self, dataset, model=None):
         self.model_list = list(self.SUPPORTED_MODELS.keys())
-        model_name = kwargs['model']
+        model_name = model
         if not listinstr(self.model_list, model_name):
             raise AssertionError("{} doesn't support the evaluation on MMLongBench_DOC.".format(model_name))
         super(MMLongBenchDoc, self).__init__(dataset)

--- a/vlmeval/dataset/mmsibench.py
+++ b/vlmeval/dataset/mmsibench.py
@@ -309,7 +309,7 @@ class MMSIVideoBench(VideoBaseDataset):
         # Sample in the global index space [0, total_frames - 1]
         indices_global = []
 
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             n = min(self.nframe, total_frames)
             if n == total_frames:
                 indices_global = list(range(total_frames))

--- a/vlmeval/dataset/mvbench.py
+++ b/vlmeval/dataset/mvbench.py
@@ -553,7 +553,7 @@ Based on your observations, select the best option that accurately addresses the
         max_frame = len(vr) - 1
 
         images_group = list()
-        if self.fps < 0:
+        if self.fps <= 0:
             frame_indices = self.get_index_by_frame(max_frame)
         else:
             frame_indices = self.get_index_by_fps(vr, self.fps)

--- a/vlmeval/dataset/mvu_eval.py
+++ b/vlmeval/dataset/mvu_eval.py
@@ -66,10 +66,20 @@ def check_model_output(output_text, true_answer):
 class MVUEval(VideoBaseDataset):
 
     TYPE = 'MVU-Eval'
+    DEFAULT_NFRAME = 16
+
+    @classmethod
+    def validate_build_config(cls, config: dict) -> None:
+        config = dict(config)
+        nframe = config.get('nframe', 0)
+        fps = config.get('fps', -1)
+        if nframe == 0 and fps == -1:
+            config['nframe'] = cls.DEFAULT_NFRAME
+        super().validate_build_config(config)
 
     def __init__(self, dataset='MVU-Eval', pack=False, nframe=0, fps=-1):
         if nframe == 0 and fps == -1:
-            nframe = 16
+            nframe = self.DEFAULT_NFRAME
         super().__init__(dataset=dataset, pack=pack, nframe=nframe, fps=fps)
 
     # ===================== 1) Data Download & Preprocessing =====================

--- a/vlmeval/dataset/qbench_video.py
+++ b/vlmeval/dataset/qbench_video.py
@@ -106,7 +106,7 @@ Please do not add any other answers beyond this.
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)
@@ -266,7 +266,7 @@ Please analyze these frames and provide a detailed and accurate answer from the 
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)

--- a/vlmeval/dataset/revsi.py
+++ b/vlmeval/dataset/revsi.py
@@ -153,7 +153,7 @@ class ReVSI(VideoBaseDataset):
         frame_key = os.path.join(self.frame_subset, os.path.splitext(video)[0])
         vid = decord.VideoReader(vid_path)
         video_fps = vid.get_avg_fps()
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(frame_key)

--- a/vlmeval/dataset/revsi.py
+++ b/vlmeval/dataset/revsi.py
@@ -95,6 +95,13 @@ class ReVSI(VideoBaseDataset):
 
     TYPE = 'Video-VQA'
 
+    @classmethod
+    def validate_build_config(cls, config: dict) -> None:
+        nframe = config.get('nframe', None)
+        if nframe in [None, "all", "all_frame"]:
+            return
+        super().validate_build_config(config)
+
     def __init__(self, dataset='ReVSI', pack=False, nframe=None, **kwargs):
         if nframe in [None, "all", "all_frame"]:
             self.frame_subset = "all_frame"

--- a/vlmeval/dataset/sitebench.py
+++ b/vlmeval/dataset/sitebench.py
@@ -204,6 +204,9 @@ class SiteBenchImage(SiteBenchBase, ImageMCQDataset):
         'SiteBenchImage': '59a2ada248b743c1d7b2f89dd5afcdc3'
     }
 
+    def __init__(self, dataset='SiteBenchImage', skip_noimg=True):
+        super().__init__(dataset=dataset, skip_noimg=skip_noimg)
+
     def prepare_tsv(self, url, file_md5=None):
         data = super().prepare_tsv(url, file_md5)
 

--- a/vlmeval/dataset/sitebench.py
+++ b/vlmeval/dataset/sitebench.py
@@ -370,7 +370,7 @@ class SiteBenchVideo(SiteBenchBase, VideoBaseDataset):
             'n_frames': video_nframes,
         }
 
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             indices = np.linspace(0, video_nframes - 1, self.nframe, dtype=int).tolist()
             # Use os.path.relpath for robust relative path extraction
             frame_paths = self.frame_paths(rel_video_path)

--- a/vlmeval/dataset/siuo.py
+++ b/vlmeval/dataset/siuo.py
@@ -79,7 +79,7 @@ class SIUODataset(ImageBaseDataset):
         # Split unified prediction file into two subset prediction files.
         child_eval_files = {}
         for dname in self.SUB_DATASETS:
-            tgt = get_composite_child_eval_file(eval_file, self.dataset_name, dname)
+            tgt = get_composite_child_eval_file(eval_file, dname)
             child_eval_files[dname] = tgt
             sub = data_all[data_all['SUB_DATASET'] == dname].copy()
             sub.pop('index')

--- a/vlmeval/dataset/siuo.py
+++ b/vlmeval/dataset/siuo.py
@@ -3,7 +3,7 @@ import copy as cp
 import pandas as pd
 
 from ..smp import d2df, dump, load
-from ..smp.file import get_intermediate_file_path
+from ..smp.file import get_composite_child_eval_file, get_intermediate_file_path
 from .image_base import ImageBaseDataset
 from .siuo_gen import SIUOGenDataset
 from .siuo_mcq import SIUOMCQDataset
@@ -77,8 +77,10 @@ class SIUODataset(ImageBaseDataset):
         data_all = load(eval_file)
 
         # Split unified prediction file into two subset prediction files.
+        child_eval_files = {}
         for dname in self.SUB_DATASETS:
-            tgt = eval_file.replace(self.dataset_name, dname)
+            tgt = get_composite_child_eval_file(eval_file, self.dataset_name, dname)
+            child_eval_files[dname] = tgt
             sub = data_all[data_all['SUB_DATASET'] == dname].copy()
             sub.pop('index')
             sub['index'] = sub.pop('original_index')
@@ -86,8 +88,8 @@ class SIUODataset(ImageBaseDataset):
             dump(sub, tgt)
 
         # Evaluate subsets with their native logic.
-        gen_file = eval_file.replace(self.dataset_name, 'SIUO_GEN')
-        mcq_file = eval_file.replace(self.dataset_name, 'SIUO_MCQ')
+        gen_file = child_eval_files['SIUO_GEN']
+        mcq_file = child_eval_files['SIUO_MCQ']
 
         gen_score_obj = self.dataset_map['SIUO_GEN'].evaluate(gen_file, **judge_kwargs)
         mcq_score_obj = self.dataset_map['SIUO_MCQ'].evaluate(mcq_file, **judge_kwargs)

--- a/vlmeval/dataset/slidevqa.py
+++ b/vlmeval/dataset/slidevqa.py
@@ -88,9 +88,9 @@ class SlideVQA(ImageBaseDataset):
         'InternVL-Chat-V1-5': (5, 2),
     }
 
-    def __init__(self, dataset, **kwargs):
+    def __init__(self, dataset, model=None):
         self.model_list = list(self.SUPPORTED_MODELS.keys())
-        model_name = kwargs['model']
+        model_name = model
         if not listinstr(self.model_list, model_name):
             raise AssertionError("{} doesn't support the evaluation on SlideVQA.".format(model_name))
         super(SlideVQA, self).__init__(dataset)

--- a/vlmeval/dataset/stibench.py
+++ b/vlmeval/dataset/stibench.py
@@ -136,7 +136,7 @@ class STIBench(VideoBaseDataset):
         indices = []
         sample_fps = None
 
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             indices = np.linspace(0, video_nframes - 1, self.nframe, dtype=int).tolist()
             frame_paths = self.frame_paths(video_path)
 

--- a/vlmeval/dataset/tempcompass.py
+++ b/vlmeval/dataset/tempcompass.py
@@ -160,7 +160,7 @@ class TempCompass_MCQ(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(line['video'])
@@ -358,7 +358,7 @@ class TempCompass_Captioning(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(line['video'])
@@ -553,7 +553,7 @@ class TempCompass_YorN(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(line['video'])

--- a/vlmeval/dataset/video_base.py
+++ b/vlmeval/dataset/video_base.py
@@ -48,7 +48,7 @@ class VideoBaseDataset(metaclass=ABCMeta):
         if fps > 0 and nframe > 0:
             raise ValueError('fps and nframe should not be set at the same time')
         if fps <= 0 and nframe <= 0:
-            raise ValueError('fps and nframe should be set at least one valid value')
+            warnings.warn('fps and nframe is not set, disable frame split (Use video file directly.)', stacklevel=2)
 
     def __init__(self,
                  dataset='MMBench-Video',

--- a/vlmeval/dataset/video_base.py
+++ b/vlmeval/dataset/video_base.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import os.path as osp
 import warnings
@@ -27,6 +28,27 @@ class VideoBaseDataset(metaclass=ABCMeta):
 
     INFER_FAIL_MARKERS = (INFER_FAIL_MSG, )
     JUDGE_FAIL_MARKERS = (INFER_FAIL_MSG, )
+
+    @classmethod
+    def validate_build_config(cls, config: dict) -> None:
+        sig = inspect.signature(cls.__init__)
+
+        def get_sampling_value(name, fallback):
+            if name in config:
+                value = config[name]
+            else:
+                param = sig.parameters.get(name)
+                value = param.default if param is not None and param.default is not inspect._empty else fallback
+            if value is None:
+                raise ValueError(f'{name} should not be None')
+            return value
+
+        fps = get_sampling_value('fps', -1)
+        nframe = get_sampling_value('nframe', 0)
+        if fps > 0 and nframe > 0:
+            raise ValueError('fps and nframe should not be set at the same time')
+        if fps <= 0 and nframe <= 0:
+            raise ValueError('fps and nframe should be set at least one valid value')
 
     def __init__(self,
                  dataset='MMBench-Video',

--- a/vlmeval/dataset/video_concat_dataset.py
+++ b/vlmeval/dataset/video_concat_dataset.py
@@ -3,7 +3,8 @@ import copy as cp
 import numpy as np
 import pandas as pd
 
-from vlmeval.smp import dump, get_intermediate_file_path, load, toliststr
+from vlmeval.smp import (dump, get_composite_child_eval_file, get_intermediate_file_path, load,
+                         toliststr)
 from .video_base import VideoBaseDataset
 
 
@@ -69,9 +70,11 @@ class ConcatVideoDataset(VideoBaseDataset):
     def evaluate(self, eval_file, **judge_kwargs):
         # First, split the eval_file by dataset
         data_all = load(eval_file)
+        child_eval_files = {}
         for dname in self.datasets:
-            tgt = eval_file.replace(self.dataset_name, dname)
-            data_sub = data_all[data_all['SUB_DATASET'] == dname]
+            tgt = get_composite_child_eval_file(eval_file, self.dataset_name, dname)
+            child_eval_files[dname] = tgt
+            data_sub = data_all[data_all['SUB_DATASET'] == dname].copy()
             data_sub.pop('index')
             data_sub['index'] = data_sub.pop('original_index')
             data_sub.pop('SUB_DATASET')
@@ -79,7 +82,7 @@ class ConcatVideoDataset(VideoBaseDataset):
         # Then, evaluate each dataset separately
         results_all = {}
         for dname in self.datasets:
-            tgt = eval_file.replace(self.dataset_name, dname)
+            tgt = child_eval_files[dname]
             res = self.dataset_map[dname].evaluate(tgt, **judge_kwargs)
             results_all.update(res)
 

--- a/vlmeval/dataset/video_concat_dataset.py
+++ b/vlmeval/dataset/video_concat_dataset.py
@@ -72,7 +72,7 @@ class ConcatVideoDataset(VideoBaseDataset):
         data_all = load(eval_file)
         child_eval_files = {}
         for dname in self.datasets:
-            tgt = get_composite_child_eval_file(eval_file, self.dataset_name, dname)
+            tgt = get_composite_child_eval_file(eval_file, dname)
             child_eval_files[dname] = tgt
             data_sub = data_all[data_all['SUB_DATASET'] == dname].copy()
             data_sub.pop('index')

--- a/vlmeval/dataset/video_dataset_config.py
+++ b/vlmeval/dataset/video_dataset_config.py
@@ -1,132 +1,147 @@
-from functools import partial
-
 from vlmeval.dataset import *
+from vlmeval.smp.dataset_alias import DatasetSpec
+
+
+def _video_spec(cls, **kwargs):
+    dataset = kwargs.get('dataset')
+    if not isinstance(dataset, str) or not dataset.strip():
+        raise ValueError(
+            f'Predefined video dataset for {cls.__name__} must set a non-empty dataset'
+        )
+    return DatasetSpec(
+        dataset_alias_name='',
+        dataset_name=dataset,
+        dataset_class_name=cls.__name__,
+        build_config={'class': cls.__name__, **kwargs},
+        source='predefined_shortcut',
+    )
+
 
 vcrbench_dataset = {
-    'VCRBench_8frame_nopack': partial(VCRBench, dataset='VCR-Bench', nframe=8, pack=False),
-    'VCRBench_16frame_nopack': partial(VCRBench, dataset='VCR-Bench', nframe=16, pack=False),
-    'VCRBench_32frame_nopack': partial(VCRBench, dataset='VCR-Bench', nframe=32, pack=False),
-    'VCRBench_64frame_nopack': partial(VCRBench, dataset='VCR-Bench', nframe=64, pack=False),
-    'VCRBench_1fps_nopack': partial(VCRBench, dataset='VCR-Bench', fps=1.0, pack=False)
+    'VCRBench_8frame_nopack': _video_spec(VCRBench, dataset='VCR-Bench', nframe=8, pack=False),
+    'VCRBench_16frame_nopack': _video_spec(VCRBench, dataset='VCR-Bench', nframe=16, pack=False),
+    'VCRBench_32frame_nopack': _video_spec(VCRBench, dataset='VCR-Bench', nframe=32, pack=False),
+    'VCRBench_64frame_nopack': _video_spec(VCRBench, dataset='VCR-Bench', nframe=64, pack=False),
+    'VCRBench_1fps_nopack': _video_spec(VCRBench, dataset='VCR-Bench', fps=1.0, pack=False)
 }
 
 v2pbench_dataset = {
-    'V2PBench_2frame_nopack': partial(V2PBench, dataset='V2P-Bench', nframe=2, pack=False),
-    'V2PBench_8frame_nopack': partial(V2PBench, dataset='V2P-Bench', nframe=8, pack=False),
-    'V2PBench_16frame_nopack': partial(V2PBench, dataset='V2P-Bench', nframe=16, pack=False),
-    'V2PBench_64frame_nopack': partial(V2PBench, dataset='V2P-Bench', nframe=64, pack=False),
-    'V2PBench_128frame_nopack': partial(V2PBench, dataset='V2P-Bench', nframe=128, pack=False),
-    'V2PBench_1fps_nopack': partial(V2PBench, dataset='V2P-Bench', fps=1.0, pack=False)
+    'V2PBench_2frame_nopack': _video_spec(V2PBench, dataset='V2P-Bench', nframe=2, pack=False),
+    'V2PBench_8frame_nopack': _video_spec(V2PBench, dataset='V2P-Bench', nframe=8, pack=False),
+    'V2PBench_16frame_nopack': _video_spec(V2PBench, dataset='V2P-Bench', nframe=16, pack=False),
+    'V2PBench_64frame_nopack': _video_spec(V2PBench, dataset='V2P-Bench', nframe=64, pack=False),
+    'V2PBench_128frame_nopack': _video_spec(V2PBench, dataset='V2P-Bench', nframe=128, pack=False),
+    'V2PBench_1fps_nopack': _video_spec(V2PBench, dataset='V2P-Bench', fps=1.0, pack=False)
 }
 
 mmbench_video_dataset = {
-    'MMBench_Video_8frame_nopack': partial(MMBenchVideo, dataset='MMBench-Video', nframe=8, pack=False),
-    'MMBench_Video_8frame_pack': partial(MMBenchVideo, dataset='MMBench-Video', nframe=8, pack=True),
-    'MMBench_Video_16frame_nopack': partial(MMBenchVideo, dataset='MMBench-Video', nframe=16, pack=False),
-    'MMBench_Video_64frame_nopack': partial(MMBenchVideo, dataset='MMBench-Video', nframe=64, pack=False),
-    'MMBench_Video_64frame_pack': partial(MMBenchVideo, dataset='MMBench-Video', nframe=64, pack=True),
-    'MMBench_Video_1fps_nopack': partial(MMBenchVideo, dataset='MMBench-Video', fps=1.0, pack=False),
-    'MMBench_Video_1fps_pack': partial(MMBenchVideo, dataset='MMBench-Video', fps=1.0, pack=True)
+    'MMBench_Video_8frame_nopack': _video_spec(MMBenchVideo, dataset='MMBench-Video', nframe=8, pack=False),
+    'MMBench_Video_8frame_pack': _video_spec(MMBenchVideo, dataset='MMBench-Video', nframe=8, pack=True),
+    'MMBench_Video_16frame_nopack': _video_spec(MMBenchVideo, dataset='MMBench-Video', nframe=16, pack=False),
+    'MMBench_Video_64frame_nopack': _video_spec(MMBenchVideo, dataset='MMBench-Video', nframe=64, pack=False),
+    'MMBench_Video_64frame_pack': _video_spec(MMBenchVideo, dataset='MMBench-Video', nframe=64, pack=True),
+    'MMBench_Video_1fps_nopack': _video_spec(MMBenchVideo, dataset='MMBench-Video', fps=1.0, pack=False),
+    'MMBench_Video_1fps_pack': _video_spec(MMBenchVideo, dataset='MMBench-Video', fps=1.0, pack=True)
 }
 
 mvbench_dataset = {
-    'MVBench_8frame': partial(MVBench, dataset='MVBench', nframe=8),
-    'MVBench_64frame': partial(MVBench, dataset='MVBench', nframe=64),
+    'MVBench_8frame': _video_spec(MVBench, dataset='MVBench', nframe=8),
+    'MVBench_64frame': _video_spec(MVBench, dataset='MVBench', nframe=64),
     # MVBench not support fps, but MVBench_MP4 does
-    'MVBench_MP4_8frame': partial(MVBench_MP4, dataset='MVBench_MP4', nframe=8),
-    'MVBench_MP4_1fps': partial(MVBench_MP4, dataset='MVBench_MP4', fps=1.0),
+    'MVBench_MP4_8frame': _video_spec(MVBench_MP4, dataset='MVBench_MP4', nframe=8),
+    'MVBench_MP4_1fps': _video_spec(MVBench_MP4, dataset='MVBench_MP4', fps=1.0),
 }
 
 tamperbench_dataset = {
-    'MVTamperBench_8frame': partial(MVTamperBench, dataset='MVTamperBench', nframe=8),
-    'MVTamperBenchStart_8frame': partial(MVTamperBench, dataset='MVTamperBenchStart', nframe=8),
-    'MVTamperBenchEnd_8frame': partial(MVTamperBench, dataset='MVTamperBenchEnd', nframe=8),
+    'MVTamperBench_8frame': _video_spec(MVTamperBench, dataset='MVTamperBench', nframe=8),
+    'MVTamperBenchStart_8frame': _video_spec(MVTamperBench, dataset='MVTamperBenchStart', nframe=8),
+    'MVTamperBenchEnd_8frame': _video_spec(MVTamperBench, dataset='MVTamperBenchEnd', nframe=8),
 }
 
 videomme_dataset = {
-    'Video-MME_8frame': partial(VideoMME, dataset='Video-MME', nframe=8),
-    'Video-MME_64frame': partial(VideoMME, dataset='Video-MME', nframe=64),
-    'Video-MME_8frame_subs': partial(VideoMME, dataset='Video-MME', nframe=8, use_subtitle=True),
-    'Video-MME_1fps': partial(VideoMME, dataset='Video-MME', fps=1.0),
-    'Video-MME_0.5fps': partial(VideoMME, dataset='Video-MME', fps=0.5),
-    'Video-MME_0.5fps_subs': partial(VideoMME, dataset='Video-MME', fps=0.5, use_subtitle=True),
+    'Video-MME_8frame': _video_spec(VideoMME, dataset='Video-MME', nframe=8),
+    'Video-MME_64frame': _video_spec(VideoMME, dataset='Video-MME', nframe=64),
+    'Video-MME_8frame_subs': _video_spec(VideoMME, dataset='Video-MME', nframe=8, use_subtitle=True),
+    'Video-MME_1fps': _video_spec(VideoMME, dataset='Video-MME', fps=1.0),
+    'Video-MME_0.5fps': _video_spec(VideoMME, dataset='Video-MME', fps=0.5),
+    'Video-MME_0.5fps_subs': _video_spec(VideoMME, dataset='Video-MME', fps=0.5, use_subtitle=True),
 }
 
 videommev2_dataset = {
     # ── No subtitle ──
-    'Video-MME-v2_64frame': partial(VideoMMEv2, dataset='Video-MME-v2', nframe=64),
-    'Video-MME-v2_1fps': partial(VideoMMEv2, dataset='Video-MME-v2', fps=1.0),
+    'Video-MME-v2_64frame': _video_spec(VideoMMEv2, dataset='Video-MME-v2', nframe=64),
+    'Video-MME-v2_1fps': _video_spec(VideoMMEv2, dataset='Video-MME-v2', nframe=0, fps=1.0),
     # ── Subtitle (non-interleave, concatenated as text block) ──
-    'Video-MME-v2_64frame_subs': partial(
+    'Video-MME-v2_64frame_subs': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64, with_subtitle=True),
-    'Video-MME-v2_1fps_subs': partial(
-        VideoMMEv2, dataset='Video-MME-v2', fps=1.0, with_subtitle=True),
+    'Video-MME-v2_1fps_subs': _video_spec(
+        VideoMMEv2, dataset='Video-MME-v2', nframe=0, fps=1.0, with_subtitle=True),
     # ── Subtitle (interleave, timestamp-aligned between frames) ──
-    'Video-MME-v2_64frame_subs_interleave': partial(
+    'Video-MME-v2_64frame_subs_interleave': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         with_subtitle=True, subtitle_interleave=True),
-    'Video-MME-v2_1fps_subs_interleave': partial(
-        VideoMMEv2, dataset='Video-MME-v2', fps=1.0,
+    'Video-MME-v2_1fps_subs_interleave': _video_spec(
+        VideoMMEv2, dataset='Video-MME-v2', nframe=0, fps=1.0,
         with_subtitle=True, subtitle_interleave=True),
     # ── Reasoning (no subtitle) ──
-    'Video-MME-v2_64frame_reasoning': partial(
+    'Video-MME-v2_64frame_reasoning': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64, reasoning=True),
     # ── Reasoning + subtitle (non-interleave) ──
-    'Video-MME-v2_64frame_reasoning_subs': partial(
+    'Video-MME-v2_64frame_reasoning_subs': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         reasoning=True, with_subtitle=True),
     # ── Reasoning + subtitle (interleave) ──
-    'Video-MME-v2_64frame_reasoning_subs_interleave': partial(
+    'Video-MME-v2_64frame_reasoning_subs_interleave': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         reasoning=True, with_subtitle=True, subtitle_interleave=True),
     # ── Resize (no subtitle) ──
-    'Video-MME-v2_64frame_resize': partial(
+    'Video-MME-v2_64frame_resize': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         resize_target_area=448 * 448),
-    'Video-MME-v2_1fps_resize': partial(
-        VideoMMEv2, dataset='Video-MME-v2', fps=1.0,
+    'Video-MME-v2_1fps_resize': _video_spec(
+        VideoMMEv2, dataset='Video-MME-v2', nframe=0, fps=1.0,
         resize_target_area=448 * 448),
     # ── Resize + subtitle ──
-    'Video-MME-v2_64frame_resize_subs': partial(
+    'Video-MME-v2_64frame_resize_subs': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         resize_target_area=448 * 448, with_subtitle=True),
     # ── Resize + subtitle interleave ──
-    'Video-MME-v2_64frame_resize_subs_interleave': partial(
+    'Video-MME-v2_64frame_resize_subs_interleave': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         resize_target_area=448 * 448, with_subtitle=True, subtitle_interleave=True),
     # ── Resize + reasoning ──
-    'Video-MME-v2_64frame_resize_reasoning': partial(
+    'Video-MME-v2_64frame_resize_reasoning': _video_spec(
         VideoMMEv2, dataset='Video-MME-v2', nframe=64,
         resize_target_area=448 * 448, reasoning=True),
 }
 
 videommmu_dataset = {
-    'VideoMMMU_8frame': partial(VideoMMMU, dataset='VideoMMMU', nframe=8),
-    'VideoMMMU_64frame': partial(VideoMMMU, dataset='VideoMMMU', nframe=64),
-    'VideoMMMU_1fps': partial(VideoMMMU, dataset='VideoMMMU', fps=1.0),
-    'VideoMMMU_0.5fps': partial(VideoMMMU, dataset='VideoMMMU', fps=0.5),
+    'VideoMMMU_8frame': _video_spec(VideoMMMU, dataset='VideoMMMU', nframe=8),
+    'VideoMMMU_64frame': _video_spec(VideoMMMU, dataset='VideoMMMU', nframe=64),
+    'VideoMMMU_1fps': _video_spec(VideoMMMU, dataset='VideoMMMU', fps=1.0),
+    'VideoMMMU_0.5fps': _video_spec(VideoMMMU, dataset='VideoMMMU', fps=0.5),
 }
 
 longvideobench_dataset = {
-    'LongVideoBench_8frame': partial(LongVideoBench, dataset='LongVideoBench', nframe=8),
-    'LongVideoBench_8frame_subs': partial(LongVideoBench, dataset='LongVideoBench', nframe=8, use_subtitle=True),
-    'LongVideoBench_64frame': partial(LongVideoBench, dataset='LongVideoBench', nframe=64),
-    'LongVideoBench_1fps': partial(LongVideoBench, dataset='LongVideoBench', fps=1.0),
-    'LongVideoBench_0.5fps': partial(LongVideoBench, dataset='LongVideoBench', fps=0.5),
-    'LongVideoBench_0.5fps_subs': partial(LongVideoBench, dataset='LongVideoBench', fps=0.5, use_subtitle=True)
+    'LongVideoBench_8frame': _video_spec(LongVideoBench, dataset='LongVideoBench', nframe=8),
+    'LongVideoBench_8frame_subs': _video_spec(LongVideoBench, dataset='LongVideoBench', nframe=8, use_subtitle=True),
+    'LongVideoBench_64frame': _video_spec(LongVideoBench, dataset='LongVideoBench', nframe=64),
+    'LongVideoBench_1fps': _video_spec(LongVideoBench, dataset='LongVideoBench', fps=1.0),
+    'LongVideoBench_0.5fps': _video_spec(LongVideoBench, dataset='LongVideoBench', fps=0.5),
+    'LongVideoBench_0.5fps_subs': _video_spec(LongVideoBench, dataset='LongVideoBench', fps=0.5, use_subtitle=True)
 }
 
 mlvu_dataset = {
-    'MLVU_8frame': partial(MLVU, dataset='MLVU', nframe=8),
-    'MLVU_64frame': partial(MLVU, dataset='MLVU', nframe=64),
-    'MLVU_1fps': partial(MLVU, dataset='MLVU', fps=1.0)
+    'MLVU_8frame': _video_spec(MLVU, dataset='MLVU', nframe=8),
+    'MLVU_64frame': _video_spec(MLVU, dataset='MLVU', nframe=64),
+    'MLVU_1fps': _video_spec(MLVU, dataset='MLVU', fps=1.0)
 }
 
 tempcompass_dataset = {
-    'TempCompass_8frame': partial(TempCompass, dataset='TempCompass', nframe=8),
-    'TempCompass_64frame': partial(TempCompass, dataset='TempCompass', nframe=64),
-    'TempCompass_1fps': partial(TempCompass, dataset='TempCompass', fps=1.0),
-    'TempCompass_0.5fps': partial(TempCompass, dataset='TempCompass', fps=0.5)
+    'TempCompass_8frame': _video_spec(TempCompass, dataset='TempCompass', nframe=8),
+    'TempCompass_64frame': _video_spec(TempCompass, dataset='TempCompass', nframe=64),
+    'TempCompass_1fps': _video_spec(TempCompass, dataset='TempCompass', fps=1.0),
+    'TempCompass_0.5fps': _video_spec(TempCompass, dataset='TempCompass', fps=0.5)
 }
 
 # In order to reproduce the experimental results in CGbench paper,
@@ -137,14 +152,14 @@ tempcompass_dataset = {
 # in the CGBench_MCQ_Grounding_Mini and CGBench_MCQ_Grounding datasets;
 # the metric open-ended is implemented in the CGBench_OpenEnded_Mini and CGBench_OpenEnded datasets.
 cgbench_dataset = {
-    'CGBench_MCQ_Grounding_Mini_8frame_subs_subt': partial(
+    'CGBench_MCQ_Grounding_Mini_8frame_subs_subt': _video_spec(
         CGBench_MCQ_Grounding_Mini,
         dataset='CG-Bench_MCQ_Grounding_Mini',
         nframe=8,
         use_subtitle=True,
         use_subtitle_time=True
     ),
-    'CGBench_OpenEnded_Mini_8frame_subs_subt_ft': partial(
+    'CGBench_OpenEnded_Mini_8frame_subs_subt_ft': _video_spec(
         CGBench_OpenEnded_Mini,
         dataset='CG-Bench_OpenEnded_Mini',
         nframe=8,
@@ -152,18 +167,18 @@ cgbench_dataset = {
         use_subtitle_time=True,
         use_frame_time=True
     ),
-    'CGBench_MCQ_Grounding_32frame_subs': partial(
+    'CGBench_MCQ_Grounding_32frame_subs': _video_spec(
         CGBench_MCQ_Grounding,
         dataset='CG-Bench_MCQ_Grounding',
         nframe=32,
         use_subtitle=True
     ),
-    'CGBench_OpenEnded_8frame': partial(
+    'CGBench_OpenEnded_8frame': _video_spec(
         CGBench_OpenEnded,
         dataset='CG-Bench_OpenEnded',
         nframe=8
     ),
-    'CGBench_MCQ_Grounding_16frame_subs_subt_ft': partial(
+    'CGBench_MCQ_Grounding_16frame_subs_subt_ft': _video_spec(
         CGBench_MCQ_Grounding,
         dataset='CG-Bench_MCQ_Grounding',
         nframe=16,
@@ -171,7 +186,7 @@ cgbench_dataset = {
         use_subtitle_time=True,
         use_frame_time=True
     ),
-    'CGBench_OpenEnded_16frame_subs_subt_ft': partial(
+    'CGBench_OpenEnded_16frame_subs_subt_ft': _video_spec(
         CGBench_OpenEnded,
         dataset='CG-Bench_OpenEnded',
         nframe=16,
@@ -182,139 +197,139 @@ cgbench_dataset = {
 }
 
 megabench_dataset = {
-    'MEGABench_core_16frame': partial(MEGABench, dataset='MEGABench', nframe=16, subset_name="core"),
-    'MEGABench_open_16frame': partial(MEGABench, dataset='MEGABench', nframe=16, subset_name="open"),
-    'MEGABench_core_64frame': partial(MEGABench, dataset='MEGABench', nframe=64, subset_name="core"),
-    'MEGABench_open_64frame': partial(MEGABench, dataset='MEGABench', nframe=64, subset_name="open")
+    'MEGABench_core_16frame': _video_spec(MEGABench, dataset='MEGABench', nframe=16, subset_name="core"),
+    'MEGABench_open_16frame': _video_spec(MEGABench, dataset='MEGABench', nframe=16, subset_name="open"),
+    'MEGABench_core_64frame': _video_spec(MEGABench, dataset='MEGABench', nframe=64, subset_name="core"),
+    'MEGABench_open_64frame': _video_spec(MEGABench, dataset='MEGABench', nframe=64, subset_name="open")
 }
 
 moviechat1k_dataset = {
-    'moviechat1k_breakpoint_8frame': partial(MovieChat1k, dataset='MovieChat1k', subset='breakpoint', nframe=8),
-    'moviechat1k_global_14frame': partial(MovieChat1k, dataset='MovieChat1k', subset='global', nframe=14),
-    'moviechat1k_global_8frame_limit0.01': partial(
+    'moviechat1k_breakpoint_8frame': _video_spec(MovieChat1k, dataset='MovieChat1k', subset='breakpoint', nframe=8),
+    'moviechat1k_global_14frame': _video_spec(MovieChat1k, dataset='MovieChat1k', subset='global', nframe=14),
+    'moviechat1k_global_8frame_limit0.01': _video_spec(
         MovieChat1k, dataset='MovieChat1k', subset='global', nframe=8, limit=0.01
     )
 }
 
 vdc_dataset = {
-    'VDC_8frame': partial(VDC, dataset='VDC', nframe=8),
-    'VDC_1fps': partial(VDC, dataset='VDC', fps=1.0),
+    'VDC_8frame': _video_spec(VDC, dataset='VDC', nframe=8),
+    'VDC_1fps': _video_spec(VDC, dataset='VDC', fps=1.0),
 }
 
 worldsense_dataset = {
-    'WorldSense_8frame': partial(WorldSense, dataset='WorldSense', nframe=8),
-    'WorldSense_8frame_subs': partial(WorldSense, dataset='WorldSense', nframe=8, use_subtitle=True),
-    'WorldSense_8frame_audio': partial(WorldSense, dataset='WorldSense', nframe=8, use_audio=True),
-    'WorldSense_32frame': partial(WorldSense, dataset='WorldSense', nframe=32),
-    'WorldSense_32frame_subs': partial(WorldSense, dataset='WorldSense', nframe=32, use_subtitle=True),
-    'WorldSense_32frame_audio': partial(WorldSense, dataset='WorldSense', nframe=32, use_audio=True),
-    'WorldSense_1fps': partial(WorldSense, dataset='WorldSense', fps=1.0),
-    'WorldSense_1fps_subs': partial(WorldSense, dataset='WorldSense', fps=1.0, use_subtitle=True),
-    'WorldSense_1fps_audio': partial(WorldSense, dataset='WorldSense', fps=1.0, use_audio=True),
-    'WorldSense_0.5fps': partial(WorldSense, dataset='WorldSense', fps=0.5),
-    'WorldSense_0.5fps_subs': partial(WorldSense, dataset='WorldSense', fps=0.5, use_subtitle=True),
-    'WorldSense_0.5fps_audio': partial(WorldSense, dataset='WorldSense', fps=0.5, use_audio=True)
+    'WorldSense_8frame': _video_spec(WorldSense, dataset='WorldSense', nframe=8),
+    'WorldSense_8frame_subs': _video_spec(WorldSense, dataset='WorldSense', nframe=8, use_subtitle=True),
+    'WorldSense_8frame_audio': _video_spec(WorldSense, dataset='WorldSense', nframe=8, use_audio=True),
+    'WorldSense_32frame': _video_spec(WorldSense, dataset='WorldSense', nframe=32),
+    'WorldSense_32frame_subs': _video_spec(WorldSense, dataset='WorldSense', nframe=32, use_subtitle=True),
+    'WorldSense_32frame_audio': _video_spec(WorldSense, dataset='WorldSense', nframe=32, use_audio=True),
+    'WorldSense_1fps': _video_spec(WorldSense, dataset='WorldSense', fps=1.0),
+    'WorldSense_1fps_subs': _video_spec(WorldSense, dataset='WorldSense', fps=1.0, use_subtitle=True),
+    'WorldSense_1fps_audio': _video_spec(WorldSense, dataset='WorldSense', fps=1.0, use_audio=True),
+    'WorldSense_0.5fps': _video_spec(WorldSense, dataset='WorldSense', fps=0.5),
+    'WorldSense_0.5fps_subs': _video_spec(WorldSense, dataset='WorldSense', fps=0.5, use_subtitle=True),
+    'WorldSense_0.5fps_audio': _video_spec(WorldSense, dataset='WorldSense', fps=0.5, use_audio=True)
 }
 
 qbench_video_dataset = {
-    'QBench_Video_8frame': partial(QBench_Video, dataset='QBench_Video', nframe=8),
-    'QBench_Video_16frame': partial(QBench_Video, dataset='QBench_Video', nframe=16),
+    'QBench_Video_8frame': _video_spec(QBench_Video, dataset='QBench_Video', nframe=8),
+    'QBench_Video_16frame': _video_spec(QBench_Video, dataset='QBench_Video', nframe=16),
 }
 
 video_mmlu_dataset = {
-    'Video_MMLU_CAP_16frame': partial(Video_MMLU_CAP, dataset='Video_MMLU_CAP', nframe=16),
-    'Video_MMLU_CAP_64frame': partial(Video_MMLU_CAP, dataset='Video_MMLU_CAP', nframe=64),
-    'Video_MMLU_QA_16frame': partial(Video_MMLU_QA, dataset='Video_MMLU_QA', nframe=16),
-    'Video_MMLU_QA_64frame': partial(Video_MMLU_QA, dataset='Video_MMLU_QA', nframe=64),
+    'Video_MMLU_CAP_16frame': _video_spec(Video_MMLU_CAP, dataset='Video_MMLU_CAP', nframe=16),
+    'Video_MMLU_CAP_64frame': _video_spec(Video_MMLU_CAP, dataset='Video_MMLU_CAP', nframe=64),
+    'Video_MMLU_QA_16frame': _video_spec(Video_MMLU_QA, dataset='Video_MMLU_QA', nframe=16),
+    'Video_MMLU_QA_64frame': _video_spec(Video_MMLU_QA, dataset='Video_MMLU_QA', nframe=64),
 }
 
 video_tt_dataset = {
-    'Video_TT_16frame': partial(VideoTT, dataset='Video-TT', nframe=16),
-    'Video_TT_32frame': partial(VideoTT, dataset='Video-TT', nframe=32),
-    'Video_TT_64frame': partial(VideoTT, dataset='Video-TT', nframe=64),
+    'Video_TT_16frame': _video_spec(VideoTT, dataset='Video-TT', nframe=16),
+    'Video_TT_32frame': _video_spec(VideoTT, dataset='Video-TT', nframe=32),
+    'Video_TT_64frame': _video_spec(VideoTT, dataset='Video-TT', nframe=64),
 }
 
 video_holmes_dataset = {
-    'Video_Holmes_32frame': partial(Video_Holmes, dataset='Video_Holmes', nframe=32),
-    'Video_Holmes_64frame': partial(Video_Holmes, dataset='Video_Holmes', nframe=64),
+    'Video_Holmes_32frame': _video_spec(Video_Holmes, dataset='Video_Holmes', nframe=32),
+    'Video_Holmes_64frame': _video_spec(Video_Holmes, dataset='Video_Holmes', nframe=64),
 }
 
 cg_av_counting_dataset = {
-    'CG-AV-Counting_32frame': partial(CGAVCounting, dataset='CG-AV-Counting', nframe=32, use_frame_time=False),
-    'CG-AV-Counting_64frame': partial(CGAVCounting, dataset='CG-AV-Counting', nframe=64, use_frame_time=False)
+    'CG-AV-Counting_32frame': _video_spec(CGAVCounting, dataset='CG-AV-Counting', nframe=32, use_frame_time=False),
+    'CG-AV-Counting_64frame': _video_spec(CGAVCounting, dataset='CG-AV-Counting', nframe=64, use_frame_time=False)
 }
 
 egoexobench_dataset = {
-    'EgoExoBench_64frame': partial(EgoExoBench_MCQ, dataset='EgoExoBench_MCQ', nframe=64, skip_EgoExo4D=False),  # noqa: E501
-    'EgoExoBench_64frame_skip_EgoExo4D': partial(EgoExoBench_MCQ, dataset='EgoExoBench_MCQ', nframe=64, skip_EgoExo4D=True)  # noqa: E501
+    'EgoExoBench_64frame': _video_spec(EgoExoBench_MCQ, dataset='EgoExoBench_MCQ', nframe=64, skip_EgoExo4D=False),  # noqa: E501
+    'EgoExoBench_64frame_skip_EgoExo4D': _video_spec(EgoExoBench_MCQ, dataset='EgoExoBench_MCQ', nframe=64, skip_EgoExo4D=True)  # noqa: E501
 
 }
 
 revsi_dataset = {
-    'revsi_16_frame': partial(ReVSI, dataset='ReVSI', nframe=16),
-    'revsi_32_frame': partial(ReVSI, dataset='ReVSI', nframe=32),
-    'revsi_64_frame': partial(ReVSI, dataset='ReVSI', nframe=64),
-    'revsi_all_frame': partial(ReVSI, dataset='ReVSI', nframe=None),
+    'revsi_16_frame': _video_spec(ReVSI, dataset='ReVSI', nframe=16),
+    'revsi_32_frame': _video_spec(ReVSI, dataset='ReVSI', nframe=32),
+    'revsi_64_frame': _video_spec(ReVSI, dataset='ReVSI', nframe=64),
+    'revsi_all_frame': _video_spec(ReVSI, dataset='ReVSI', nframe=None),
 }
 
 dream_1k_dataset = {
-    'DREAM-1K_8frame': partial(DREAM, dataset='DREAM-1K', nframe=8),
-    'DREAM-1K_64frame': partial(DREAM, dataset='DREAM-1K', nframe=64),
-    'DREAM-1K_2fps': partial(DREAM, dataset='DREAM-1K', fps=2.0),
-    'DREAM-1K_1fps': partial(DREAM, dataset='DREAM-1K', fps=1.0),
-    'DREAM-1K_0.5fps': partial(DREAM, dataset='DREAM-1K', fps=0.5),
+    'DREAM-1K_8frame': _video_spec(DREAM, dataset='DREAM-1K', nframe=8),
+    'DREAM-1K_64frame': _video_spec(DREAM, dataset='DREAM-1K', nframe=64),
+    'DREAM-1K_2fps': _video_spec(DREAM, dataset='DREAM-1K', fps=2.0),
+    'DREAM-1K_1fps': _video_spec(DREAM, dataset='DREAM-1K', fps=1.0),
+    'DREAM-1K_0.5fps': _video_spec(DREAM, dataset='DREAM-1K', fps=0.5),
 }
 
 av_speakerbench_dataset = {
     # frame-sampled variants
-    'AV-SpeakerBench_audiovisual_8frame': partial(
+    'AV-SpeakerBench_audiovisual_8frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=8, use_audio=True
     ),
-    'AV-SpeakerBench_audiovisual_16frame': partial(
+    'AV-SpeakerBench_audiovisual_16frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=16, use_audio=True
     ),
-    'AV-SpeakerBench_visual_8frame': partial(
+    'AV-SpeakerBench_visual_8frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=8, use_audio=False
     ),
-    'AV-SpeakerBench_visual_16frame': partial(
+    'AV-SpeakerBench_visual_16frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=16, use_audio=False
     ),
-    'AV-SpeakerBench_audio_only_8frame': partial(
+    'AV-SpeakerBench_audio_only_8frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=8, use_audio=True, audio_only=True
     ),
-    'AV-SpeakerBench_audio_only_16frame': partial(
+    'AV-SpeakerBench_audio_only_16frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=16, use_audio=True, audio_only=True
     ),
     # fps-based variants
-    'AV-SpeakerBench_audiovisual_1fps': partial(
+    'AV-SpeakerBench_audiovisual_1fps': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', fps=1.0, use_audio=True
     ),
-    'AV-SpeakerBench_visual_1fps': partial(
+    'AV-SpeakerBench_visual_1fps': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', fps=1.0, use_audio=False
     ),
-    'AV-SpeakerBench_audio_only_1fps': partial(
+    'AV-SpeakerBench_audio_only_1fps': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', fps=1.0, use_audio=True, audio_only=True
     ),
     # shorthand aliases mapping to audiovisual
-    'AV-SpeakerBench_8frame': partial(
+    'AV-SpeakerBench_8frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=8, use_audio=True
     ),
-    'AV-SpeakerBench_16frame': partial(
+    'AV-SpeakerBench_16frame': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', nframe=16, use_audio=True
     ),
-    'AV-SpeakerBench_1fps': partial(
+    'AV-SpeakerBench_1fps': _video_spec(
         AVSpeakerBench, dataset='AV-SpeakerBench', fps=1.0, use_audio=True
     ),
 }
 
 omtg_dataset = {
-    "OMTGBench_1fps": partial(OMTGBench, dataset="OMTGBench", fps=1.0),
-    "OMTGBench_2fps": partial(OMTGBench, dataset="OMTGBench", fps=2.0),
+    "OMTGBench_1fps": _video_spec(OMTGBench, dataset="OMTGBench", fps=1.0),
+    "OMTGBench_2fps": _video_spec(OMTGBench, dataset="OMTGBench", fps=2.0),
 }
 
 mvu_eval_dataset = {
-    'MVU-Eval_8frame': partial(MVUEval, dataset='MVU-Eval', nframe=8),
-    'MVU-Eval_16frame': partial(MVUEval, dataset='MVU-Eval', nframe=16),
+    'MVU-Eval_8frame': _video_spec(MVUEval, dataset='MVU-Eval', nframe=8),
+    'MVU-Eval_16frame': _video_spec(MVUEval, dataset='MVU-Eval', nframe=16),
 }
 
 VSI_FRAME_VARIANTS = [
@@ -331,7 +346,7 @@ def _build_video_variants(subsets, cls, variants=VSI_FRAME_VARIANTS):
     out = {}
     for variant in subsets:
         for suffix, params in variants:
-            out[f"{variant}_{suffix}"] = partial(cls, dataset=variant, **params)
+            out[f"{variant}_{suffix}"] = _video_spec(cls, dataset=variant, **params)
     return out
 
 
@@ -348,18 +363,18 @@ vsisuper_count_subsets = VsiSuperCount.supported_datasets()
 vsisuper_count_dataset = _build_video_variants(vsisuper_count_subsets, VsiSuperCount)
 
 sitebenchvideo_dataset = {
-    'SiteBenchVideo_64frame': partial(SiteBenchVideo, dataset='SiteBenchVideo', nframe=64),
-    'SiteBenchVideo_32frame': partial(SiteBenchVideo, dataset='SiteBenchVideo', nframe=32),
-    'SiteBenchVideo_1fps': partial(SiteBenchVideo, dataset='SiteBenchVideo', fps=1),
+    'SiteBenchVideo_64frame': _video_spec(SiteBenchVideo, dataset='SiteBenchVideo', nframe=64),
+    'SiteBenchVideo_32frame': _video_spec(SiteBenchVideo, dataset='SiteBenchVideo', nframe=32),
+    'SiteBenchVideo_1fps': _video_spec(SiteBenchVideo, dataset='SiteBenchVideo', fps=1),
 }
 
 mmsi_video_dataset = {
     # The 300 frame setting is aligned with Sufficient-Coverage policy proposed in MMSI-Video-Bench paper
-    'MMSIVideoBench_300frame': partial(MMSIVideoBench, dataset='MMSIVideoBench', nframe=300),
-    'MMSIVideoBench_64frame': partial(MMSIVideoBench, dataset='MMSIVideoBench', nframe=64),
-    'MMSIVideoBench_50frame': partial(MMSIVideoBench, dataset='MMSIVideoBench', nframe=50),
-    'MMSIVideoBench_32frame': partial(MMSIVideoBench, dataset='MMSIVideoBench', nframe=32),
-    'MMSIVideoBench_1fps': partial(MMSIVideoBench, dataset='MMSIVideoBench', fps=1),
+    'MMSIVideoBench_300frame': _video_spec(MMSIVideoBench, dataset='MMSIVideoBench', nframe=300),
+    'MMSIVideoBench_64frame': _video_spec(MMSIVideoBench, dataset='MMSIVideoBench', nframe=64),
+    'MMSIVideoBench_50frame': _video_spec(MMSIVideoBench, dataset='MMSIVideoBench', nframe=50),
+    'MMSIVideoBench_32frame': _video_spec(MMSIVideoBench, dataset='MMSIVideoBench', nframe=32),
+    'MMSIVideoBench_1fps': _video_spec(MMSIVideoBench, dataset='MMSIVideoBench', fps=1),
 }
 
 sti_subsets = STIBench.supported_datasets()
@@ -381,8 +396,6 @@ dsr_variants = [
     ("1fps", dict(fps=1.0)),
 ]
 dsr_dataset = _build_video_variants(dsr_subsets, DSRBench, dsr_variants)
-supported_video_datasets = {}
-
 dataset_groups = [
     mmbench_video_dataset, mvbench_dataset, videomme_dataset, videommev2_dataset, videommmu_dataset,
     longvideobench_dataset, mlvu_dataset, tempcompass_dataset, cgbench_dataset, worldsense_dataset, tamperbench_dataset,
@@ -397,5 +410,14 @@ dataset_groups += [
     sti_dataset, dsr_dataset, revsi_dataset
 ]
 
+PREDEFINED_DATASET_SPECS = {}
+
 for grp in dataset_groups:
-    supported_video_datasets.update(grp)
+    for alias, spec in grp.items():
+        PREDEFINED_DATASET_SPECS[alias] = DatasetSpec(
+            dataset_alias_name=alias,
+            dataset_name=spec.dataset_name,
+            dataset_class_name=spec.dataset_class_name,
+            build_config=spec.build_config,
+            source=spec.source,
+        )

--- a/vlmeval/dataset/video_holmes.py
+++ b/vlmeval/dataset/video_holmes.py
@@ -164,7 +164,7 @@ class Video_Holmes(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)

--- a/vlmeval/dataset/videomme.py
+++ b/vlmeval/dataset/videomme.py
@@ -173,7 +173,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)

--- a/vlmeval/dataset/videommev2.py
+++ b/vlmeval/dataset/videommev2.py
@@ -317,7 +317,7 @@ class VideoMMEv2(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             if self.resize_target_area:

--- a/vlmeval/dataset/videommmu.py
+++ b/vlmeval/dataset/videommmu.py
@@ -594,7 +594,7 @@ class VideoMMMU(VideoBaseDataset):
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(id_)

--- a/vlmeval/dataset/videott.py
+++ b/vlmeval/dataset/videott.py
@@ -144,7 +144,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)

--- a/vlmeval/dataset/vsibench.py
+++ b/vlmeval/dataset/vsibench.py
@@ -164,7 +164,7 @@ class VsiBench(VideoBaseDataset):
 
         indices = []
 
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             if self.sample_strategy == 'uniform_tail':
                 indices = np.linspace(0, video_nframes - 1, self.nframe, dtype=int).tolist()
                 if (video_nframes - 1) != indices[-1]:
@@ -506,7 +506,7 @@ class VsiSuperBase(VideoBaseDataset):
 
         indices = []
 
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
 
             indices = np.linspace(0, video_nframes - 1, self.nframe, dtype=int).tolist()
             frame_paths = self.frame_paths(video_path)

--- a/vlmeval/dataset/worldsense.py
+++ b/vlmeval/dataset/worldsense.py
@@ -214,7 +214,7 @@ Respond with only the letter (A, B, C, or D) of the correct option.
             'fps': vid.get_avg_fps(),
             'n_frames': len(vid),
         }
-        if self.nframe > 0 and self.fps < 0:
+        if self.nframe > 0 and self.fps <= 0:
             step_size = len(vid) / (self.nframe + 1)
             indices = [int(i * step_size) for i in range(1, self.nframe + 1)]
             frame_paths = self.frame_paths(video)

--- a/vlmeval/inference.py
+++ b/vlmeval/inference.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from vlmeval.config import supported_VLM
 from vlmeval.smp import (dump, get_logger, get_pred_file_format, get_pred_file_path,
-                         get_rank_and_world_size, load)
+                         get_rank_and_world_size, load, resolve_dataset_alias_name)
 from vlmeval.utils import track_progress_rich
 
 logger = get_logger(__name__)
@@ -27,10 +27,14 @@ def parse_args():
 
 
 # Only API model is accepted
-def infer_data_api(model, work_dir, model_name, dataset, index_set=None, api_nproc=4, retry_failed=True):
+def infer_data_api(
+    model, work_dir, model_name, dataset, index_set=None, api_nproc=4, retry_failed=True,
+    dataset_alias_name=None
+):
     rank, world_size = get_rank_and_world_size()
     assert rank == 0 and world_size == 1
     dataset_name = dataset.dataset_name
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     data = dataset.data
     if index_set is not None:
         data = data[data['index'].isin(index_set)]
@@ -56,12 +60,12 @@ def infer_data_api(model, work_dir, model_name, dataset, index_set=None, api_npr
             struct = dataset.build_prompt(item)
         structs.append(struct)
 
-    out_file = f'{work_dir}/{model_name}_{dataset_name}_checkpoint.pkl'
+    out_file = f'{work_dir}/{model_name}_{dataset_alias_name}_checkpoint.pkl'
 
     # To reuse records in MMBench_V11
     if dataset_name in ['MMBench', 'MMBench_CN']:
         pred_format = get_pred_file_format()
-        v11_pred = f'{work_dir}/{model_name}_{dataset_name}_V11.{pred_format}'
+        v11_pred = f'{work_dir}/{model_name}_{dataset_alias_name}_V11.{pred_format}'
         if osp.exists(v11_pred):
             try:
                 reuse_inds = load('https://opencompass.openxlab.space/utils/mmb_reuse.pkl')
@@ -98,10 +102,13 @@ def infer_data_api(model, work_dir, model_name, dataset, index_set=None, api_npr
     return result
 
 
-def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
-               retry_failed=True):
+def infer_data(
+    model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
+    retry_failed=True, dataset_alias_name=None
+):
     dataset_name = dataset.dataset_name
-    prev_file = f'{work_dir}/{model_name}_{dataset_name}_PREV.pkl'
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
+    prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     res = load(prev_file) if osp.exists(prev_file) else {}
     if osp.exists(out_file):
         res.update(load(out_file))
@@ -154,7 +161,8 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
             dataset=dataset,
             index_set=set(indices),
             api_nproc=api_nproc,
-            retry_failed=retry_failed)
+            retry_failed=retry_failed,
+            dataset_alias_name=dataset_alias_name)
         for idx in indices:
             assert idx in supp
         res.update(supp)
@@ -208,14 +216,17 @@ def _is_structured_record(v):
 
 # A wrapper for infer_data, do the pre & post processing
 def infer_data_job(
-    model, work_dir, model_name, dataset, verbose=False, api_nproc=4, retry_failed=True, use_vllm=False
+    model, work_dir, model_name, dataset, verbose=False, api_nproc=4, retry_failed=True, use_vllm=False,
+    result_file=None, dataset_alias_name=None
 ):
     rank, world_size = get_rank_and_world_size()
     dataset_name = dataset.dataset_name
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     # 使用环境变量控制的文件格式
-    result_file = get_pred_file_path(work_dir, model_name, dataset_name, use_env_format=True)
+    if result_file is None:
+        result_file = get_pred_file_path(work_dir, model_name, dataset_alias_name, use_env_format=True)
 
-    prev_file = f'{work_dir}/{model_name}_{dataset_name}_PREV.pkl'
+    prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     if osp.exists(result_file):
         if rank == 0:
             data = load(result_file)
@@ -226,13 +237,13 @@ def infer_data_job(
         if world_size > 1:
             dist.barrier()
 
-    tmpl = osp.join(work_dir, '{}' + f'{world_size}_{dataset_name}.pkl')
+    tmpl = osp.join(work_dir, '{}' + f'{world_size}_{dataset_alias_name}.pkl')
     out_file = tmpl.format(rank)
 
     model = infer_data(
         model=model, work_dir=work_dir, model_name=model_name, dataset=dataset,
         out_file=out_file, verbose=verbose, api_nproc=api_nproc, use_vllm=use_vllm,
-        retry_failed=retry_failed)
+        retry_failed=retry_failed, dataset_alias_name=dataset_alias_name)
     if world_size > 1:
         dist.barrier()
 
@@ -286,7 +297,7 @@ def infer_data_job(
         for i in range(world_size):
             os.remove(tmpl.format(i))
         # Clean up API checkpoint file
-        checkpoint_file = f'{work_dir}/{model_name}_{dataset_name}_checkpoint.pkl'
+        checkpoint_file = f'{work_dir}/{model_name}_{dataset_alias_name}_checkpoint.pkl'
         if osp.exists(checkpoint_file):
             os.remove(checkpoint_file)
         # Clean up PREV file

--- a/vlmeval/inference.py
+++ b/vlmeval/inference.py
@@ -29,11 +29,11 @@ def parse_args():
 # Only API model is accepted
 def infer_data_api(
     model, work_dir, model_name, dataset, index_set=None, api_nproc=4, retry_failed=True,
-    dataset_alias_name=None
+    dataset_name=None, dataset_alias_name=None
 ):
     rank, world_size = get_rank_and_world_size()
     assert rank == 0 and world_size == 1
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     data = dataset.data
     if index_set is not None:
@@ -104,9 +104,9 @@ def infer_data_api(
 
 def infer_data(
     model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
-    retry_failed=True, dataset_alias_name=None
+    retry_failed=True, dataset_name=None, dataset_alias_name=None
 ):
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     res = load(prev_file) if osp.exists(prev_file) else {}
@@ -162,6 +162,7 @@ def infer_data(
             index_set=set(indices),
             api_nproc=api_nproc,
             retry_failed=retry_failed,
+            dataset_name=dataset_name,
             dataset_alias_name=dataset_alias_name)
         for idx in indices:
             assert idx in supp
@@ -217,10 +218,10 @@ def _is_structured_record(v):
 # A wrapper for infer_data, do the pre & post processing
 def infer_data_job(
     model, work_dir, model_name, dataset, verbose=False, api_nproc=4, retry_failed=True, use_vllm=False,
-    result_file=None, dataset_alias_name=None
+    result_file=None, dataset_name=None, dataset_alias_name=None
 ):
     rank, world_size = get_rank_and_world_size()
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     # 使用环境变量控制的文件格式
     if result_file is None:
@@ -243,7 +244,7 @@ def infer_data_job(
     model = infer_data(
         model=model, work_dir=work_dir, model_name=model_name, dataset=dataset,
         out_file=out_file, verbose=verbose, api_nproc=api_nproc, use_vllm=use_vllm,
-        retry_failed=retry_failed, dataset_alias_name=dataset_alias_name)
+        retry_failed=retry_failed, dataset_name=dataset_name, dataset_alias_name=dataset_alias_name)
     if world_size > 1:
         dist.barrier()
 

--- a/vlmeval/inference_api.py
+++ b/vlmeval/inference_api.py
@@ -154,6 +154,7 @@ class DatasetConfig:
     result_file: str
     judge_kwargs: dict  # judge model parameters.
     dataset_alias_name: str | None = None
+    dataset_class_name: str | None = None
     verbose: bool = False
 
     dataset_type: DatasetType = "image"
@@ -260,7 +261,9 @@ class APIEvalPipeline:
                 run_dir=cfg.work_dir,
                 model_name=cfg.model_name,
                 dataset_name=dataset_alias_name,
-                logical_dataset_name=cfg.dataset_name,
+                resolved_dataset_name=cfg.dataset_name,
+                dataset_alias_name=dataset_alias_name,
+                dataset_class_name=cfg.dataset_class_name,
                 status=status,
             )
             if metrics_source is not None:

--- a/vlmeval/inference_api.py
+++ b/vlmeval/inference_api.py
@@ -135,7 +135,8 @@ class InferenceTask:
     sample_index: str
     prompt_struct: Any     # Constructed prompt
 
-    dataset_name: str      # Dataset name (for naming task)
+    dataset_name: str      # Logical dataset name passed to model APIs.
+    dataset_alias_name: str
     model_name: str        # Model name (for naming task)
     dataset_type: DatasetType = "image"
 
@@ -143,7 +144,7 @@ class InferenceTask:
 @dataclass
 class DatasetConfig:
     """Dataset Config and Status."""
-    dataset_name: str
+    dataset_name: str  # Logical dataset name.
     dataset_obj: Any  # The constructed dataset.
 
     model_name: str
@@ -152,6 +153,7 @@ class DatasetConfig:
     work_dir: str
     result_file: str
     judge_kwargs: dict  # judge model parameters.
+    dataset_alias_name: str | None = None
     verbose: bool = False
 
     dataset_type: DatasetType = "image"
@@ -177,6 +179,8 @@ class DatasetConfig:
     results_dict: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
+        if self.dataset_alias_name is None:
+            self.dataset_alias_name = self.dataset_name
         self.total_samples = len(self.dataset_obj.data)
 
 
@@ -223,11 +227,11 @@ class APIEvalPipeline:
         # The inference tasks queue (Prefetch 20% data).
         self.queue = asyncio.Queue(maxsize=int(concurrency * 1.2))
         self.states: Dict[str, DatasetConfig] = {
-            cfg.dataset_name: cfg for cfg in dataset_configs
+            cfg.dataset_alias_name: cfg for cfg in dataset_configs
         }
         # File locks to save checkpoints threading-safety.
         self.file_locks: Dict[str, threading.Lock] = {
-            cfg.dataset_name: threading.Lock() for cfg in dataset_configs
+            cfg.dataset_alias_name: threading.Lock() for cfg in dataset_configs
         }
 
         # Runtime status
@@ -240,22 +244,23 @@ class APIEvalPipeline:
             Path(cfg.work_dir).mkdir(parents=True, exist_ok=True)
             if not self.run_eval:
                 cfg.eval_status = EvalStatus.Skipped
-            self._upsert_dataset_status(cfg.dataset_name, status='pending')
+            self._upsert_dataset_status(cfg.dataset_alias_name, status='pending')
 
     def _upsert_dataset_status(
         self,
-        dataset_name: str,
+        dataset_alias_name: str,
         status: str,
         metrics_source=None,
         skip_reason: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        cfg = self.states[dataset_name]
+        cfg = self.states[dataset_alias_name]
         try:
             summary_kwargs = dict(
                 run_dir=cfg.work_dir,
                 model_name=cfg.model_name,
-                dataset_name=dataset_name,
+                dataset_name=dataset_alias_name,
+                logical_dataset_name=cfg.dataset_name,
                 status=status,
             )
             if metrics_source is not None:
@@ -268,13 +273,13 @@ class APIEvalPipeline:
             upsert_dataset_status(**summary_kwargs)
         except Exception as summary_err:
             logger.warning(
-                f'Failed to update status.json for {cfg.model_name} x {dataset_name}: {summary_err}'
+                f'Failed to update status.json for {cfg.model_name} x {dataset_alias_name}: {summary_err}'
             )
 
     def _release_dataset_memory(self, cfg: DatasetConfig):
         """Release dataset after evaluation."""
         import gc
-        dataset_name = cfg.dataset_name
+        dataset_name = cfg.dataset_alias_name
 
         if hasattr(cfg.dataset_obj, 'data') and cfg.dataset_obj.data is not None:
             try:
@@ -309,25 +314,25 @@ class APIEvalPipeline:
         except Exception as e:
             logger.warning(f"Failed to shutdown executors: {e}")
 
-    def _get_checkpoint_file(self, dataset_name: str) -> Path:
-        cfg = self.states[dataset_name]
-        return Path(cfg.work_dir) / f"{cfg.model_name}_{dataset_name}_checkpoint.pkl"
+    def _get_checkpoint_file(self, dataset_alias_name: str) -> Path:
+        cfg = self.states[dataset_alias_name]
+        return Path(cfg.work_dir) / f"{cfg.model_name}_{dataset_alias_name}_checkpoint.pkl"
 
-    def _load_checkpoint(self, dataset_name: str) -> Dict[str, Any]:
+    def _load_checkpoint(self, dataset_alias_name: str) -> Dict[str, Any]:
         """Load finished inference result from previous runs."""
-        cfg = self.states[dataset_name]
+        cfg = self.states[dataset_alias_name]
         results = {}
 
         # 1. Try to load checkpoint at first.
-        checkpoint_file = self._get_checkpoint_file(dataset_name)
+        checkpoint_file = self._get_checkpoint_file(dataset_alias_name)
         if checkpoint_file.exists():
             try:
                 results = load(str(checkpoint_file))
                 if self.retry_failed:
                     results = {k: v for k, v in results.items() if FAIL_MSG not in str(v)}
-                logger.info(f"   [{dataset_name}] Loaded {len(results)} results from checkpoint")
+                logger.info(f"   [{dataset_alias_name}] Loaded {len(results)} results from checkpoint")
             except Exception as e:
-                logger.warning(f"   [{dataset_name}] Failed to load checkpoint: {e}")
+                logger.warning(f"   [{dataset_alias_name}] Failed to load checkpoint: {e}")
 
         # Try to load from the result file.
         result_path = Path(cfg.result_file)
@@ -347,18 +352,18 @@ class APIEvalPipeline:
                             for idx, pred in zip(data['index'], data['prediction'])
                         }
                     results.update(existing_results)
-                    logger.info(f"   [{dataset_name}] Loaded {len(existing_results)} "
+                    logger.info(f"   [{dataset_alias_name}] Loaded {len(existing_results)} "
                                 "results from result file")
             except Exception as e:
-                logger.warning(f"   [{dataset_name}] Failed to load result file: {e}")
+                logger.warning(f"   [{dataset_alias_name}] Failed to load result file: {e}")
 
         return results
 
-    def _save_checkpoint(self, dataset_name: str, result: dict):
+    def _save_checkpoint(self, dataset_alias_name: str, result: dict):
         """Save results to checkpoint file threading-safety."""
-        checkpoint_file = self._get_checkpoint_file(dataset_name)
+        checkpoint_file = self._get_checkpoint_file(dataset_alias_name)
 
-        with self.file_locks[dataset_name]:
+        with self.file_locks[dataset_alias_name]:
             if checkpoint_file.exists():
                 results = load(str(checkpoint_file))
             else:
@@ -368,11 +373,11 @@ class APIEvalPipeline:
 
             dump(results, str(checkpoint_file))
 
-    def _save_final_result(self, dataset_name: str) -> bool:
+    def _save_final_result(self, dataset_alias_name: str) -> bool:
         """Save the final inference result file."""
-        cfg = self.states[dataset_name]
+        cfg = self.states[dataset_alias_name]
 
-        with self.file_locks[dataset_name]:
+        with self.file_locks[dataset_alias_name]:
             if 'image' in cfg.dataset_obj.data:
                 dataset_data = cfg.dataset_obj.data.drop('image', axis=1)
             else:
@@ -386,7 +391,7 @@ class APIEvalPipeline:
 
             if missing_indices:
                 logger.warning(
-                    f"   [{dataset_name}] Missing results for {len(missing_indices)} samples: "
+                    f"   [{dataset_alias_name}] Missing results for {len(missing_indices)} samples: "
                     f"{missing_indices[:5]}{'...' if len(missing_indices) > 5 else ''}"
                 )
                 return False
@@ -395,22 +400,22 @@ class APIEvalPipeline:
             dataset_data['prediction'] = predictions
 
             dump(dataset_data, cfg.result_file)
-            logger.info(f"   [{dataset_name}] Saved final results to {cfg.result_file}")
+            logger.info(f"   [{dataset_alias_name}] Saved final results to {cfg.result_file}")
 
             # Delete checkpoint file.
-            checkpoint_file = self._get_checkpoint_file(dataset_name)
+            checkpoint_file = self._get_checkpoint_file(dataset_alias_name)
             if checkpoint_file.exists():
                 checkpoint_file.unlink()
 
             return True
 
-    def _create_symlinks(self, dataset_name: str):
+    def _create_symlinks(self, dataset_alias_name: str):
         """Create symbolic links for dataset results in the model base directory.
 
         Links are created as relative paths so that moving the output root
         directory does not break them.
         """
-        cfg = self.states[dataset_name]
+        cfg = self.states[dataset_alias_name]
         pred_root = Path(cfg.work_dir)
         model_base_dir = pred_root.parent
 
@@ -420,7 +425,7 @@ class APIEvalPipeline:
             for f in pred_root.iterdir():
                 if not f.is_file():
                     continue
-                if f'{cfg.model_name}_{dataset_name}' not in f.name:
+                if f'{cfg.model_name}_{dataset_alias_name}' not in f.name:
                     continue
                 # Skip temporary intermediate files
                 if f.name.endswith(('_checkpoint.pkl', '_PREV.pkl', '_structs.pkl')):
@@ -431,24 +436,24 @@ class APIEvalPipeline:
                     link_addr.unlink()
                 link_addr.symlink_to(rel_target)
         except Exception as e:
-            logger.warning(f"   [{dataset_name}] Failed to create symlinks: {e}")
+            logger.warning(f"   [{dataset_alias_name}] Failed to create symlinks: {e}")
 
     async def _producer(self):
         """Generate all samples to inference."""
         logger.info("📦 Initializing tasks and checking checkpoints...")
 
         for cfg in self.dataset_configs:
-            dataset_name = cfg.dataset_name
+            dataset_alias_name = cfg.dataset_alias_name
             dataset_type = cfg.dataset_type
 
             logger.info(
-                f"   [{dataset_name}] Start build prompt [type={dataset_type}]"
+                f"   [{dataset_alias_name}] Start build prompt [type={dataset_type}]"
             )
             if self.run_infer:
-                self._upsert_dataset_status(dataset_name, status='infer')
+                self._upsert_dataset_status(dataset_alias_name, status='infer')
 
             # 1. Try to load checkpoint
-            existing_results = self._load_checkpoint(dataset_name)
+            existing_results = self._load_checkpoint(dataset_alias_name)
             skipped = len(existing_results)
             cfg.results_dict = existing_results
             cfg.processed = len(existing_results)
@@ -457,26 +462,26 @@ class APIEvalPipeline:
             # 2. Check whether to need infer.
             if not self.run_infer or cfg.processed == cfg.total_samples:
                 if cfg.processed < cfg.total_samples:
-                    logger.warning(f"   [{dataset_name}] is incompleted "
+                    logger.warning(f"   [{dataset_alias_name}] is incompleted "
                                    f"({cfg.processed}/{cfg.total_samples}). "
                                    "The evaluation may be inaccurate.")
                 else:
-                    logger.info(f"   [{dataset_name}] All samples completed "
+                    logger.info(f"   [{dataset_alias_name}] All samples completed "
                                 f"({cfg.processed}/{cfg.total_samples}). "
                                 "Will trigger eval directly.")
                 # Save result file if not exists.
                 if not Path(cfg.result_file).exists():
-                    self._save_final_result(dataset_name)
-                self._create_symlinks(dataset_name)
+                    self._save_final_result(dataset_alias_name)
+                self._create_symlinks(dataset_alias_name)
                 if cfg.eval_status == EvalStatus.Skipped:
                     self._upsert_dataset_status(
-                        dataset_name,
+                        dataset_alias_name,
                         status='done',
                         skip_reason='mode_infer',
                     )
                 else:
                     # Trigger evaluation.
-                    asyncio.create_task(self._trigger_eval(dataset_name))
+                    asyncio.create_task(self._trigger_eval(dataset_alias_name))
                 continue
 
             # 3. Dispatch according to dataset type.
@@ -491,14 +496,14 @@ class APIEvalPipeline:
             if tasks_generated == 0:
                 cfg.eval_status = EvalStatus.Skipped
                 self._upsert_dataset_status(
-                    dataset_name,
+                    dataset_alias_name,
                     status='done',
                     skip_reason='no_inference_tasks_generated',
                 )
 
             self.total_tasks_generated += tasks_generated
             logger.info(
-                f"   [{dataset_name}] Generated {tasks_generated} tasks "
+                f"   [{dataset_alias_name}] Generated {tasks_generated} tasks "
                 f"(Skipped {skipped}) [type={dataset_type}]"
             )
 
@@ -514,6 +519,7 @@ class APIEvalPipeline:
         model = cfg.model_obj
         dataset = cfg.dataset_obj
         dataset_name = cfg.dataset_name
+        dataset_alias_name = cfg.dataset_alias_name
 
         if hasattr(model, 'set_dump_image'):
             model.set_dump_image(dataset.dump_image)
@@ -523,9 +529,9 @@ class APIEvalPipeline:
             and model.use_custom_prompt(dataset_name)
         )
         if use_custom_prompt:
-            logger.info(f"   [{dataset_name}] Using model custom prompt")
+            logger.info(f"   [{dataset_alias_name}] Using model custom prompt")
         else:
-            logger.info(f"   [{dataset_name}] Using vanilla dataset prompt")
+            logger.info(f"   [{dataset_alias_name}] Using vanilla dataset prompt")
 
         tasks_generated = 0
         for i in range(len(dataset)):
@@ -542,7 +548,7 @@ class APIEvalPipeline:
                     prompt_struct = dataset.build_prompt(item)
             except Exception as e:
                 import traceback
-                logger.error(f"   [{dataset_name}] Failed to build prompt "
+                logger.error(f"   [{dataset_alias_name}] Failed to build prompt "
                              f"for sample {idx_str}: {repr(e)}")
                 logger.debug(traceback.format_exception(e))
                 # Skip dataset if has fatal sample.
@@ -550,6 +556,7 @@ class APIEvalPipeline:
 
             task = InferenceTask(
                 dataset_name=dataset_name,
+                dataset_alias_name=dataset_alias_name,
                 model_name=cfg.model_name,
                 sample_index=idx_str,
                 prompt_struct=prompt_struct,
@@ -564,7 +571,8 @@ class APIEvalPipeline:
         """Produce video dataset inference task."""
         dataset = cfg.dataset_obj
         dataset_name = cfg.dataset_name
-        process_name = f"{dataset_name} prompt process"
+        dataset_alias_name = cfg.dataset_alias_name
+        process_name = f"{dataset_alias_name} prompt process"
 
         model = cfg.model_obj
         if cfg.video_llm is not None:
@@ -572,7 +580,7 @@ class APIEvalPipeline:
         else:
             video_llm = getattr(model, 'VIDEO_LLM', False)
 
-        logger.info(f"   [{dataset_name}] Video mode: video_llm={video_llm}")
+        logger.info(f"   [{dataset_alias_name}] Video mode: video_llm={video_llm}")
 
         parent_conn, child_conn = mp.Pipe(duplex=True)
         process = mp.Process(
@@ -586,7 +594,7 @@ class APIEvalPipeline:
             child_conn.close()
             raise
         child_conn.close()
-        self.producer_processes[dataset_name] = process
+        self.producer_processes[dataset_alias_name] = process
 
         tasks_generated = 0
         try:
@@ -611,7 +619,7 @@ class APIEvalPipeline:
                         continue
                 except Exception as e:
                     import traceback
-                    logger.error(f"   [{dataset_name}] Failed to build prompt "
+                    logger.error(f"   [{dataset_alias_name}] Failed to build prompt "
                                  f"for sample {idx_str}: {repr(e)}")
                     logger.debug(traceback.format_exception(e))
                     # Skip dataset if has fatal sample.
@@ -619,6 +627,7 @@ class APIEvalPipeline:
 
                 task = InferenceTask(
                     dataset_name=dataset_name,
+                    dataset_alias_name=dataset_alias_name,
                     model_name=cfg.model_name,
                     sample_index=idx_str,
                     prompt_struct=prompt_struct,
@@ -627,7 +636,7 @@ class APIEvalPipeline:
                 await self.queue.put(task)
                 tasks_generated += 1
         finally:
-            self.producer_processes.pop(dataset_name, None)
+            self.producer_processes.pop(dataset_alias_name, None)
             if process.is_alive():
                 try:
                     parent_conn.send(None)
@@ -644,8 +653,9 @@ class APIEvalPipeline:
         """Produce multi-turns dataset inference task."""
         dataset = cfg.dataset_obj
         dataset_name = cfg.dataset_name
+        dataset_alias_name = cfg.dataset_alias_name
 
-        logger.info(f"   [{dataset_name}] Multi-turn dialogue mode")
+        logger.info(f"   [{dataset_alias_name}] Multi-turn dialogue mode")
 
         tasks_generated = 0
         for i in range(len(dataset)):
@@ -659,7 +669,7 @@ class APIEvalPipeline:
                 prompt_struct = dataset.build_prompt(item)
             except Exception as e:
                 import traceback
-                logger.error(f"   [{dataset_name}] Failed to build prompt "
+                logger.error(f"   [{dataset_alias_name}] Failed to build prompt "
                              f"for sample {idx_str}: {repr(e)}")
                 logger.debug(traceback.format_exception(e))
                 # Skip dataset if has fatal sample.
@@ -667,6 +677,7 @@ class APIEvalPipeline:
 
             task = InferenceTask(
                 dataset_name=dataset_name,
+                dataset_alias_name=dataset_alias_name,
                 model_name=cfg.model_name,
                 sample_index=idx_str,
                 prompt_struct=prompt_struct,
@@ -688,7 +699,7 @@ class APIEvalPipeline:
                 break
 
             self.active_workers += 1
-            cfg = self.states[task.dataset_name]
+            cfg = self.states[task.dataset_alias_name]
             try:
                 model = cfg.model_obj
                 start_time = time.time()
@@ -720,7 +731,7 @@ class APIEvalPipeline:
                     "index": task.sample_index,
                     "prediction": output
                 }
-                self._save_checkpoint(task.dataset_name, result_item)
+                self._save_checkpoint(task.dataset_alias_name, result_item)
 
                 # Update status
                 cfg.results_dict[task.sample_index] = output
@@ -734,19 +745,19 @@ class APIEvalPipeline:
                     if len(output_preview) > 100:
                         output_preview = output_preview[:100] + '...'
                     logger.info(
-                        f"[{task.dataset_name}] Sample {task.sample_index}: "
+                        f"[{task.dataset_alias_name}] Sample {task.sample_index}: "
                         f"{output_preview} (took {inference_time:.2f}s)")
 
                 # Save final result and create symlinks when all samples are done.
                 if cfg.processed == cfg.total_samples:
-                    self._save_final_result(task.dataset_name)
-                    self._create_symlinks(task.dataset_name)
+                    self._save_final_result(task.dataset_alias_name)
+                    self._create_symlinks(task.dataset_alias_name)
                     if cfg.eval_status == EvalStatus.Pending:
-                        asyncio.create_task(self._trigger_eval(task.dataset_name))
+                        asyncio.create_task(self._trigger_eval(task.dataset_alias_name))
                     else:
                         if cfg.eval_status == EvalStatus.Skipped:
                             self._upsert_dataset_status(
-                                task.dataset_name,
+                                task.dataset_alias_name,
                                 status='done',
                                 skip_reason='mode_infer',
                             )
@@ -755,16 +766,16 @@ class APIEvalPipeline:
 
             except Exception as e:
                 logger.error(
-                    f"❌ Worker error on {task.dataset_name}/{task.sample_index}: {e}",
+                    f"❌ Worker error on {task.dataset_alias_name}/{task.sample_index}: {e}",
                     exc_info=True
                 )
             finally:
                 self.active_workers -= 1
                 self.queue.task_done()
 
-    async def _trigger_eval(self, dataset_name: str):
+    async def _trigger_eval(self, dataset_alias_name: str):
         """Evaluate the specified dataset."""
-        cfg = self.states[dataset_name]
+        cfg = self.states[dataset_alias_name]
 
         # Avoid multiple trigger.
         if cfg.eval_status != EvalStatus.Pending:
@@ -772,22 +783,22 @@ class APIEvalPipeline:
 
         cfg.eval_status = EvalStatus.Running
         cfg.eval_start_time = time.time()
-        self._upsert_dataset_status(dataset_name, status='eval')
+        self._upsert_dataset_status(dataset_alias_name, status='eval')
 
         # Create evaluation log.
         eval_log_dir = Path(cfg.work_dir) / 'eval_logs'
         eval_log_dir.mkdir(parents=True, exist_ok=True)
-        eval_log_path = str(eval_log_dir / f"{cfg.model_name}_{dataset_name}_eval.log")
-        logger.info(f"    [{dataset_name}] Trigger evaluation.")
+        eval_log_path = str(eval_log_dir / f"{cfg.model_name}_{dataset_alias_name}_eval.log")
+        logger.info(f"    [{dataset_alias_name}] Trigger evaluation.")
 
         if self.debug:
-            await self._run_eval_in_main_process(dataset_name)
+            await self._run_eval_in_main_process(dataset_alias_name)
         else:
-            await self._run_eval_in_subprocess(dataset_name, eval_log_path)
+            await self._run_eval_in_subprocess(dataset_alias_name, eval_log_path)
 
-    async def _run_eval_in_main_process(self, dataset_name: str):
-        cfg = self.states[dataset_name]
-        logger.info(f"🔔 [Eval Start - Debug Mode] {dataset_name}")
+    async def _run_eval_in_main_process(self, dataset_alias_name: str):
+        cfg = self.states[dataset_alias_name]
+        logger.info(f"🔔 [Eval Start - Debug Mode] {dataset_alias_name}")
 
         def run_eval():
             try:
@@ -801,20 +812,20 @@ class APIEvalPipeline:
 
         try:
             eval_result = run_eval()
-            self._handle_eval_result(dataset_name, eval_result)
+            self._handle_eval_result(dataset_alias_name, eval_result)
 
         except Exception as e:
             cfg.eval_status = EvalStatus.Error
             cfg.eval_duration = time.time() - cfg.eval_start_time
-            logger.error(f"❌ [Eval Failed] {dataset_name}: {e}")
+            logger.error(f"❌ [Eval Failed] {dataset_alias_name}: {e}")
             self._upsert_dataset_status(
-                dataset_name,
+                dataset_alias_name,
                 status='done',
                 error_message=str(e),
             )
 
-    async def _run_eval_in_subprocess(self, dataset_name: str, eval_log_path: str):
-        cfg = self.states[dataset_name]
+    async def _run_eval_in_subprocess(self, dataset_alias_name: str, eval_log_path: str):
+        cfg = self.states[dataset_alias_name]
         process = None
         parent_conn = None
         child_conn = None
@@ -840,55 +851,55 @@ class APIEvalPipeline:
                     child_conn.close()
                     raise
                 child_conn.close()
-                self.eval_processes[dataset_name] = process
+                self.eval_processes[dataset_alias_name] = process
 
                 eval_result = await async_recv_process_message(
                     parent_conn,
                     process,
-                    f"{dataset_name} eval process",
+                    f"{dataset_alias_name} eval process",
                 )
                 await async_wait_process(process)
                 if process.exitcode != 0:
                     raise RuntimeError(
                         f"evaluation process exited with code {process.exitcode}"
                     )
-                self._handle_eval_result(dataset_name, eval_result, eval_log_path)
+                self._handle_eval_result(dataset_alias_name, eval_result, eval_log_path)
 
         except Exception as e:
             cfg.eval_status = EvalStatus.Error
             cfg.eval_duration = time.time() - cfg.eval_start_time
             logger.error(
-                f"❌ [Eval Failed] {dataset_name}: {e}\n"
+                f"❌ [Eval Failed] {dataset_alias_name}: {e}\n"
                 f"   Check log file: {eval_log_path}"
             )
             self._upsert_dataset_status(
-                dataset_name,
+                dataset_alias_name,
                 status='done',
                 error_message=str(e),
             )
         finally:
-            self.eval_processes.pop(dataset_name, None)
+            self.eval_processes.pop(dataset_alias_name, None)
             if process is not None and process.is_alive():
                 terminate_processes(
                     [process],
-                    name=f"{dataset_name} eval process",
+                    name=f"{dataset_alias_name} eval process",
                     logger=logger,
                 )
             if parent_conn is not None:
                 parent_conn.close()
 
     def _handle_eval_result(self,
-                            dataset_name: str,
+                            dataset_alias_name: str,
                             eval_result: dict | pd.DataFrame,
                             eval_log_path: str | None = None):
         """After evaluation"""
-        cfg = self.states[dataset_name]
+        cfg = self.states[dataset_alias_name]
 
         if eval_result['success']:
             cfg.eval_status = EvalStatus.Done
             cfg.eval_duration = time.time() - cfg.eval_start_time
             logger.info(
-                f"✅ [Eval Finish] {dataset_name} (Took {cfg.eval_duration:.1f}s)"
+                f"✅ [Eval Finish] {dataset_alias_name} (Took {cfg.eval_duration:.1f}s)"
             )
 
             # Print evaluation result.
@@ -897,22 +908,22 @@ class APIEvalPipeline:
                 logger.info(f"   Results: {json.dumps(result, indent=2, default=str)}")
             else:
                 logger.info(f"   Results:\n{result}")
-            self._upsert_dataset_status(dataset_name, status='done', metrics_source=result)
+            self._upsert_dataset_status(dataset_alias_name, status='done', metrics_source=result)
         else:
             cfg.eval_status = EvalStatus.Error
             cfg.eval_duration = time.time() - cfg.eval_start_time
             logger.error(
-                f"❌ [Eval Failed] {dataset_name}: {eval_result['error']}\n"
+                f"❌ [Eval Failed] {dataset_alias_name}: {eval_result['error']}\n"
                 f"   Check log file: {eval_log_path}"
             )
             self._upsert_dataset_status(
-                dataset_name,
+                dataset_alias_name,
                 status='done',
                 error_message=eval_result['error'],
             )
 
         # Update symlinks to capture evaluation output files.
-        self._create_symlinks(dataset_name)
+        self._create_symlinks(dataset_alias_name)
         # Release dataset data after evaluation.
         self._release_dataset_memory(cfg)
 
@@ -934,7 +945,7 @@ class APIEvalPipeline:
                     logger.info(f'Infer task queue: {self.queue.qsize()}')
                     logger.info(f'Active workers: {self.active_workers}')
                 if not all_eval_done:
-                    logger.info(', '.join(f'{cfg.dataset_name}: {cfg.eval_status.name}'
+                    logger.info(', '.join(f'{cfg.dataset_alias_name}: {cfg.eval_status.name}'
                                           for cfg in self.states.values()))
                 self._log_snapshot()
                 last_log = time.time()
@@ -976,7 +987,7 @@ class APIEvalPipeline:
                 eval_str = f"Done ({cfg.eval_duration:.1f}s)"
 
             # Format output
-            name_str = cfg.dataset_name[:20].ljust(20)
+            name_str = cfg.dataset_alias_name[:20].ljust(20)
             line = [name_str, f"Infer: {infer_str} | Eval: {eval_str:<20}"]
             lines.append(line)
 

--- a/vlmeval/inference_mt.py
+++ b/vlmeval/inference_mt.py
@@ -7,7 +7,8 @@ import torch.distributed as dist
 from tqdm import tqdm
 
 from vlmeval.config import supported_VLM
-from vlmeval.smp import dump, get_pred_file_path, get_rank_and_world_size, load
+from vlmeval.smp import (dump, get_pred_file_path, get_rank_and_world_size, load,
+                         resolve_dataset_alias_name)
 from vlmeval.utils import track_progress_rich
 
 FAIL_MSG = 'Failed to obtain answer via API.'
@@ -43,10 +44,14 @@ def chat_mt(model, messages, dataset_name):
 
 
 # Only API model is accepted
-def infer_data_api(model, work_dir, model_name, dataset, index_set=None, api_nproc=4, retry_failed=True):
+def infer_data_api(
+    model, work_dir, model_name, dataset, index_set=None, api_nproc=4, retry_failed=True,
+    dataset_alias_name=None
+):
     rank, world_size = get_rank_and_world_size()
     assert rank == 0 and world_size == 1
     dataset_name = dataset.dataset_name
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     data = dataset.data
     if index_set is not None:
         data = data[data['index'].isin(index_set)]
@@ -60,7 +65,7 @@ def infer_data_api(model, work_dir, model_name, dataset, index_set=None, api_npr
     index_str_to_orig = {str(i): i for i in indices}
     structs = [dataset.build_prompt(data.iloc[i]) for i in range(lt)]
 
-    out_file = f'{work_dir}/{model_name}_{dataset_name}_checkpoint.pkl'
+    out_file = f'{work_dir}/{model_name}_{dataset_alias_name}_checkpoint.pkl'
     res = {}
     if osp.exists(out_file):
         res = load(out_file)
@@ -86,10 +91,13 @@ def infer_data_api(model, work_dir, model_name, dataset, index_set=None, api_npr
     return result
 
 
-def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
-               retry_failed=True):
+def infer_data(
+    model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
+    retry_failed=True, dataset_alias_name=None
+):
     dataset_name = dataset.dataset_name
-    prev_file = f'{work_dir}/{model_name}_{dataset_name}_PREV.pkl'
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
+    prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     res = load(prev_file) if osp.exists(prev_file) else {}
     if osp.exists(out_file):
         res.update(load(out_file))
@@ -143,7 +151,8 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
             dataset=dataset,
             index_set=set(indices),
             api_nproc=api_nproc,
-            retry_failed=retry_failed)
+            retry_failed=retry_failed,
+            dataset_alias_name=dataset_alias_name)
         for idx in indices:
             assert idx in supp
         res.update(supp)
@@ -180,13 +189,16 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
 
 # A wrapper for infer_data, do the pre & post processing
 def infer_data_job_mt(
-    model, work_dir, model_name, dataset, verbose=False, api_nproc=4, retry_failed=True, use_vllm=False
+    model, work_dir, model_name, dataset, verbose=False, api_nproc=4, retry_failed=True, use_vllm=False,
+    result_file=None, dataset_alias_name=None
 ):
     rank, world_size = get_rank_and_world_size()
     dataset_name = dataset.dataset_name
-    result_file = get_pred_file_path(work_dir, model_name, dataset_name, use_env_format=True)
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
+    if result_file is None:
+        result_file = get_pred_file_path(work_dir, model_name, dataset_alias_name, use_env_format=True)
 
-    prev_file = f'{work_dir}/{model_name}_{dataset_name}_PREV.pkl'
+    prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     if osp.exists(result_file):
         if rank == 0:
             data = load(result_file)
@@ -197,13 +209,13 @@ def infer_data_job_mt(
         if world_size > 1:
             dist.barrier()
 
-    tmpl = osp.join(work_dir, '{}' + f'{world_size}_{dataset_name}.pkl')
+    tmpl = osp.join(work_dir, '{}' + f'{world_size}_{dataset_alias_name}.pkl')
     out_file = tmpl.format(rank)
 
     model = infer_data(
         model=model, work_dir=work_dir, model_name=model_name, dataset=dataset,
         out_file=out_file, verbose=verbose, api_nproc=api_nproc, use_vllm=use_vllm,
-        retry_failed=retry_failed)
+        retry_failed=retry_failed, dataset_alias_name=dataset_alias_name)
     if world_size > 1:
         dist.barrier()
 
@@ -224,7 +236,7 @@ def infer_data_job_mt(
         for i in range(world_size):
             os.remove(tmpl.format(i))
         # Clean up API checkpoint file
-        checkpoint_file = f'{work_dir}/{model_name}_{dataset_name}_checkpoint.pkl'
+        checkpoint_file = f'{work_dir}/{model_name}_{dataset_alias_name}_checkpoint.pkl'
         if osp.exists(checkpoint_file):
             os.remove(checkpoint_file)
         # Clean up PREV file

--- a/vlmeval/inference_mt.py
+++ b/vlmeval/inference_mt.py
@@ -46,11 +46,11 @@ def chat_mt(model, messages, dataset_name):
 # Only API model is accepted
 def infer_data_api(
     model, work_dir, model_name, dataset, index_set=None, api_nproc=4, retry_failed=True,
-    dataset_alias_name=None
+    dataset_name=None, dataset_alias_name=None
 ):
     rank, world_size = get_rank_and_world_size()
     assert rank == 0 and world_size == 1
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     data = dataset.data
     if index_set is not None:
@@ -93,9 +93,9 @@ def infer_data_api(
 
 def infer_data(
     model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
-    retry_failed=True, dataset_alias_name=None
+    retry_failed=True, dataset_name=None, dataset_alias_name=None
 ):
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     res = load(prev_file) if osp.exists(prev_file) else {}
@@ -152,6 +152,7 @@ def infer_data(
             index_set=set(indices),
             api_nproc=api_nproc,
             retry_failed=retry_failed,
+            dataset_name=dataset_name,
             dataset_alias_name=dataset_alias_name)
         for idx in indices:
             assert idx in supp
@@ -190,10 +191,10 @@ def infer_data(
 # A wrapper for infer_data, do the pre & post processing
 def infer_data_job_mt(
     model, work_dir, model_name, dataset, verbose=False, api_nproc=4, retry_failed=True, use_vllm=False,
-    result_file=None, dataset_alias_name=None
+    result_file=None, dataset_name=None, dataset_alias_name=None
 ):
     rank, world_size = get_rank_and_world_size()
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     if result_file is None:
         result_file = get_pred_file_path(work_dir, model_name, dataset_alias_name, use_env_format=True)
@@ -215,7 +216,7 @@ def infer_data_job_mt(
     model = infer_data(
         model=model, work_dir=work_dir, model_name=model_name, dataset=dataset,
         out_file=out_file, verbose=verbose, api_nproc=api_nproc, use_vllm=use_vllm,
-        retry_failed=retry_failed, dataset_alias_name=dataset_alias_name)
+        retry_failed=retry_failed, dataset_name=dataset_name, dataset_alias_name=dataset_alias_name)
     if world_size > 1:
         dist.barrier()
 

--- a/vlmeval/inference_video.py
+++ b/vlmeval/inference_video.py
@@ -29,10 +29,10 @@ def parse_args():
 
 # Only API model is accepted
 def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_nproc=4, retry_failed=True,
-                   dataset_alias_name=None):
+                   dataset_name=None, dataset_alias_name=None):
     rank, world_size = get_rank_and_world_size()
     assert rank == 0 and world_size == 1
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     model = supported_VLM[model_name]() if isinstance(model, str) else model
     assert getattr(model, 'is_api', False)
@@ -99,8 +99,8 @@ def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_np
 
 
 def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
-               retry_failed=True, dataset_alias_name=None):
-    dataset_name = dataset.dataset_name
+               retry_failed=True, dataset_name=None, dataset_alias_name=None):
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     res = load(prev_file) if osp.exists(prev_file) else {}
@@ -146,6 +146,7 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
             samples_dict={k: sample_map[k] for k in sample_indices_subrem},
             api_nproc=api_nproc,
             retry_failed=retry_failed,
+            dataset_name=dataset_name,
             dataset_alias_name=dataset_alias_name)
         for k in sample_indices_subrem:
             assert k in supp
@@ -238,13 +239,14 @@ def infer_data_job_video(model,
                          model_name,
                          dataset,
                          result_file=None,
+                         dataset_name=None,
                          dataset_alias_name=None,
                          verbose=False,
                          api_nproc=4,
                          use_vllm=False,
                          retry_failed=True):
 
-    dataset_name = dataset.dataset_name
+    dataset_name = dataset_name or dataset.dataset_name
     dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     rank, world_size = get_rank_and_world_size()
 
@@ -279,6 +281,7 @@ def infer_data_job_video(model,
         api_nproc=api_nproc,
         use_vllm=use_vllm,
         retry_failed=retry_failed,
+        dataset_name=dataset_name,
         dataset_alias_name=dataset_alias_name)
 
     if world_size > 1:

--- a/vlmeval/inference_video.py
+++ b/vlmeval/inference_video.py
@@ -10,7 +10,8 @@ import torch.distributed as dist
 from tqdm import tqdm
 
 from vlmeval.config import supported_VLM
-from vlmeval.smp import dump, get_pred_file_path, get_rank_and_world_size, load
+from vlmeval.smp import (dump, get_pred_file_path, get_rank_and_world_size, load,
+                         resolve_dataset_alias_name)
 from vlmeval.utils import track_progress_rich
 
 FAIL_MSG = 'Failed to obtain answer via API.'
@@ -27,10 +28,12 @@ def parse_args():
 
 
 # Only API model is accepted
-def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_nproc=4, retry_failed=True):
+def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_nproc=4, retry_failed=True,
+                   dataset_alias_name=None):
     rank, world_size = get_rank_and_world_size()
     assert rank == 0 and world_size == 1
     dataset_name = dataset.dataset_name
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     model = supported_VLM[model_name]() if isinstance(model, str) else model
     assert getattr(model, 'is_api', False)
 
@@ -57,9 +60,9 @@ def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_np
     packstr = 'pack' if getattr(dataset, 'pack', False) else 'nopack'
     build_prompt_input = [(samples_dict[idx], getattr(model, 'VIDEO_LLM', False)) for idx in indices]
     if dataset.nframe > 0:
-        struct_tmp_file = f'{work_dir}/{model_name}_{dataset_name}_{dataset.nframe}frame_{packstr}_structs.pkl'
+        struct_tmp_file = f'{work_dir}/{model_name}_{dataset_alias_name}_{dataset.nframe}frame_{packstr}_structs.pkl'
     else:
-        struct_tmp_file = f'{work_dir}/{model_name}_{dataset_name}_{dataset.fps}fps_{packstr}_structs.pkl'
+        struct_tmp_file = f'{work_dir}/{model_name}_{dataset_alias_name}_{dataset.fps}fps_{packstr}_structs.pkl'
     structs = track_progress_rich(
         dataset.build_prompt,
         tasks=build_prompt_input,
@@ -69,9 +72,9 @@ def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_np
     )
 
     if dataset.nframe > 0:
-        out_file = f'{work_dir}/{model_name}_{dataset_name}_{dataset.nframe}frame_{packstr}_checkpoint.pkl'
+        out_file = f'{work_dir}/{model_name}_{dataset_alias_name}_{dataset.nframe}frame_{packstr}_checkpoint.pkl'
     else:
-        out_file = f'{work_dir}/{model_name}_{dataset_name}_{dataset.fps}fps_{packstr}_checkpoint.pkl'
+        out_file = f'{work_dir}/{model_name}_{dataset_alias_name}_{dataset.fps}fps_{packstr}_checkpoint.pkl'
     res = load(out_file) if osp.exists(out_file) else {}
     if retry_failed:
         res = {k: v for k, v in res.items() if FAIL_MSG not in str(v)}
@@ -96,9 +99,10 @@ def infer_data_api(model, work_dir, model_name, dataset, samples_dict={}, api_np
 
 
 def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, api_nproc=4, use_vllm=False,
-               retry_failed=True):
+               retry_failed=True, dataset_alias_name=None):
     dataset_name = dataset.dataset_name
-    prev_file = f'{work_dir}/{model_name}_{dataset_name}_PREV.pkl'
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
+    prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     res = load(prev_file) if osp.exists(prev_file) else {}
     if osp.exists(out_file):
         res.update(load(out_file))
@@ -141,7 +145,8 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
             dataset=dataset,
             samples_dict={k: sample_map[k] for k in sample_indices_subrem},
             api_nproc=api_nproc,
-            retry_failed=retry_failed)
+            retry_failed=retry_failed,
+            dataset_alias_name=dataset_alias_name)
         for k in sample_indices_subrem:
             assert k in supp
         res.update(supp)
@@ -186,9 +191,10 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
                 print(f'using {model_name} default setting for video, dataset.nframe is ommitted')
             if getattr(model, 'fps', None) is None and dataset.fps > 0:
                 print(f'using {model_name} default setting for video, dataset.fps is ommitted')
+        sample_dataset_name = dataset_name
         if 'SUB_DATASET' in dataset.data.iloc[sample_map[idx]]:
-            dataset_name = dataset.data.iloc[sample_map[idx]]['SUB_DATASET']
-        if hasattr(model, 'use_custom_prompt') and model.use_custom_prompt(dataset_name):
+            sample_dataset_name = dataset.data.iloc[sample_map[idx]]['SUB_DATASET']
+        if hasattr(model, 'use_custom_prompt') and model.use_custom_prompt(sample_dataset_name):
             if dataset.nframe == 0:
                 raise ValueError(f'nframe must be set for custom prompt, fps is not suitable for {model_name}')
             struct = model.build_prompt(
@@ -205,13 +211,13 @@ def infer_data(model, model_name, work_dir, dataset, out_file, verbose=False, ap
         if os.environ.get('SKIP_ERR', False) == '1':
             FAIL_MSG = 'Failed to obtain answer'
             try:
-                response = model.generate(message=struct, dataset=dataset_name)
+                response = model.generate(message=struct, dataset=sample_dataset_name)
             except RuntimeError as err:
                 torch.cuda.synchronize()
                 warnings.error(f'{type(err)} {str(err)}')
                 response = f'{FAIL_MSG}: {type(err)} {str(err)}'
         else:
-            response = model.generate(message=struct, dataset=dataset_name)
+            response = model.generate(message=struct, dataset=sample_dataset_name)
         torch.cuda.empty_cache()
 
         if verbose:
@@ -232,18 +238,20 @@ def infer_data_job_video(model,
                          model_name,
                          dataset,
                          result_file=None,
+                         dataset_alias_name=None,
                          verbose=False,
                          api_nproc=4,
                          use_vllm=False,
                          retry_failed=True):
 
     dataset_name = dataset.dataset_name
+    dataset_alias_name = resolve_dataset_alias_name(dataset_name, dataset_alias_name)
     rank, world_size = get_rank_and_world_size()
 
     if result_file is None:
-        result_file = get_pred_file_path(work_dir, model_name, dataset_name, use_env_format=True)
+        result_file = get_pred_file_path(work_dir, model_name, dataset_alias_name, use_env_format=True)
 
-    prev_file = f'{work_dir}/{model_name}_{dataset_name}_PREV.pkl'
+    prev_file = f'{work_dir}/{model_name}_{dataset_alias_name}_PREV.pkl'
     if osp.exists(result_file):
         if retry_failed:
             if rank == 0:
@@ -270,7 +278,8 @@ def infer_data_job_video(model,
         verbose=verbose,
         api_nproc=api_nproc,
         use_vllm=use_vllm,
-        retry_failed=retry_failed)
+        retry_failed=retry_failed,
+        dataset_alias_name=dataset_alias_name)
 
     if world_size > 1:
         dist.barrier()
@@ -298,11 +307,11 @@ def infer_data_job_video(model,
         packstr = 'pack' if getattr(dataset, 'pack', False) else 'nopack'
         if dataset.nframe > 0:
             checkpoint_file = (
-                f'{work_dir}/{model_name}_{dataset_name}_{dataset.nframe}frame_{packstr}_checkpoint.pkl'
+                f'{work_dir}/{model_name}_{dataset_alias_name}_{dataset.nframe}frame_{packstr}_checkpoint.pkl'
             )
         else:
             checkpoint_file = (
-                f'{work_dir}/{model_name}_{dataset_name}_{dataset.fps}fps_{packstr}_checkpoint.pkl'
+                f'{work_dir}/{model_name}_{dataset_alias_name}_{dataset.fps}fps_{packstr}_checkpoint.pkl'
             )
         if osp.exists(checkpoint_file):
             os.remove(checkpoint_file)

--- a/vlmeval/smp/__init__.py
+++ b/vlmeval/smp/__init__.py
@@ -1,5 +1,4 @@
-from .dataset_alias import (DatasetAliasContext, DatasetSpec,  # noqa: F401
-                            get_predefined_dataset_spec, resolve_dataset_alias,
+from .dataset_alias import (DatasetSpec, get_predefined_dataset_spec,  # noqa: F401
                             resolve_dataset_alias_name, resolve_dataset_spec)
 from .file import *  # noqa: F401, F403
 from .log import *  # noqa: F401, F403

--- a/vlmeval/smp/__init__.py
+++ b/vlmeval/smp/__init__.py
@@ -1,5 +1,6 @@
-from .dataset_alias import (DatasetAliasContext, resolve_dataset_alias,  # noqa: F401
-                            resolve_dataset_alias_name)
+from .dataset_alias import (DatasetAliasContext, DatasetSpec,  # noqa: F401
+                            get_predefined_dataset_spec, resolve_dataset_alias,
+                            resolve_dataset_alias_name, resolve_dataset_spec)
 from .file import *  # noqa: F401, F403
 from .log import *  # noqa: F401, F403
 from .misc import *  # noqa: F401, F403

--- a/vlmeval/smp/__init__.py
+++ b/vlmeval/smp/__init__.py
@@ -1,3 +1,5 @@
+from .dataset_alias import (DatasetAliasContext, resolve_dataset_alias,  # noqa: F401
+                            resolve_dataset_alias_name)
 from .file import *  # noqa: F401, F403
 from .log import *  # noqa: F401, F403
 from .misc import *  # noqa: F401, F403

--- a/vlmeval/smp/dataset_alias.py
+++ b/vlmeval/smp/dataset_alias.py
@@ -1,5 +1,8 @@
 import copy as cp
+import re
 from dataclasses import dataclass
+
+SAFE_DATASET_ALIAS_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]*$')
 
 PRESET_OVERRIDE_ALLOWLIST = {
     'nframe',
@@ -43,6 +46,17 @@ def _non_empty_str(value, field_name, display_name):
             f'`{field_name}` must be a non-empty string for dataset config {display_name}'
         )
     return value
+
+
+def validate_dataset_alias_name(dataset_alias_name):
+    if not isinstance(dataset_alias_name, str) or not dataset_alias_name.strip():
+        raise ValueError('Dataset alias must be a non-empty string')
+    if not SAFE_DATASET_ALIAS_RE.fullmatch(dataset_alias_name):
+        raise ValueError(
+            f'Dataset alias {dataset_alias_name} is not a safe filename component. '
+            'Use only letters, digits, ".", "_", and "-", and start with a letter or digit.'
+        )
+    return dataset_alias_name
 
 
 def _copy_spec(spec, *, dataset_alias_name=None, source=None):
@@ -124,6 +138,7 @@ def _resolve_explicit_config(dataset_alias_name, value):
 
 
 def resolve_dataset_spec(dataset_alias_name, data_config=None):
+    dataset_alias_name = validate_dataset_alias_name(dataset_alias_name)
     config = data_config or {}
     if dataset_alias_name in config:
         value = config[dataset_alias_name]
@@ -156,4 +171,7 @@ def resolve_dataset_alias(dataset_alias_name, data_config=None):
 
 
 def resolve_dataset_alias_name(dataset_name, dataset_alias_name=None):
-    return dataset_alias_name or dataset_name
+    resolved_name = dataset_alias_name or dataset_name
+    if resolved_name is None:
+        return None
+    return validate_dataset_alias_name(resolved_name)

--- a/vlmeval/smp/dataset_alias.py
+++ b/vlmeval/smp/dataset_alias.py
@@ -14,13 +14,6 @@ class DatasetSpec:
     source: str
 
 
-@dataclass(frozen=True)
-class DatasetAliasContext:
-    dataset_name: str
-    dataset_alias_name: str
-    dataset_class_name: str | None = None
-
-
 def _non_empty_str(value, field_name, display_name):
     if not isinstance(value, str) or not value.strip():
         raise ValueError(
@@ -131,15 +124,6 @@ def resolve_dataset_spec(dataset_alias_name, data_config=None):
         dataset_class_name=None,
         build_config={'dataset': dataset_alias_name},
         source='direct_dataset',
-    )
-
-
-def resolve_dataset_alias(dataset_alias_name, data_config=None):
-    spec = resolve_dataset_spec(dataset_alias_name, data_config)
-    return DatasetAliasContext(
-        dataset_name=spec.dataset_name,
-        dataset_alias_name=spec.dataset_alias_name,
-        dataset_class_name=spec.dataset_class_name,
     )
 
 

--- a/vlmeval/smp/dataset_alias.py
+++ b/vlmeval/smp/dataset_alias.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DatasetAliasContext:
+    dataset_name: str
+    dataset_alias_name: str
+
+
+def resolve_dataset_alias(dataset_alias_name, data_config=None):
+    config = data_config or {}
+    dataset_name = dataset_alias_name
+    if dataset_alias_name in config:
+        value = config[dataset_alias_name]
+        if isinstance(value, dict):
+            dataset_name = value.get('dataset', dataset_alias_name)
+    return DatasetAliasContext(
+        dataset_name=dataset_name,
+        dataset_alias_name=dataset_alias_name,
+    )
+
+
+def resolve_dataset_alias_name(dataset_name, dataset_alias_name=None):
+    return dataset_alias_name or dataset_name

--- a/vlmeval/smp/dataset_alias.py
+++ b/vlmeval/smp/dataset_alias.py
@@ -4,25 +4,6 @@ from dataclasses import dataclass
 
 SAFE_DATASET_ALIAS_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]*$')
 
-PRESET_OVERRIDE_ALLOWLIST = {
-    'nframe',
-    'fps',
-    'pack',
-    'use_subtitle',
-    'with_subtitle',
-    'subtitle_interleave',
-    'use_audio',
-    'audio_only',
-    'subset',
-    'subset_name',
-    'limit',
-    'reasoning',
-    'resize_target_area',
-    'skip_EgoExo4D',
-    'use_frame_time',
-    'use_subtitle_time',
-}
-
 
 @dataclass(frozen=True)
 class DatasetSpec:
@@ -100,16 +81,8 @@ def _resolve_preset_config(dataset_alias_name, value):
             f'Unknown dataset preset {preset_name} for dataset config {dataset_alias_name}'
         )
 
-    overrides = {k: v for k, v in value.items() if k != 'preset'}
-    unknown = sorted(k for k in overrides if k not in PRESET_OVERRIDE_ALLOWLIST)
-    if unknown:
-        raise ValueError(
-            f'Unsupported preset override(s) for dataset config {dataset_alias_name}: '
-            f'{", ".join(unknown)}'
-        )
-
     build_config = cp.deepcopy(preset_spec.build_config)
-    build_config.update(overrides)
+    build_config.update({k: v for k, v in value.items() if k != 'preset'})
     return DatasetSpec(
         dataset_alias_name=dataset_alias_name,
         dataset_name=preset_spec.dataset_name,

--- a/vlmeval/smp/dataset_alias.py
+++ b/vlmeval/smp/dataset_alias.py
@@ -1,22 +1,157 @@
+import copy as cp
 from dataclasses import dataclass
+
+PRESET_OVERRIDE_ALLOWLIST = {
+    'nframe',
+    'fps',
+    'pack',
+    'use_subtitle',
+    'with_subtitle',
+    'subtitle_interleave',
+    'use_audio',
+    'audio_only',
+    'subset',
+    'subset_name',
+    'limit',
+    'reasoning',
+    'resize_target_area',
+    'skip_EgoExo4D',
+    'use_frame_time',
+    'use_subtitle_time',
+}
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    dataset_alias_name: str
+    dataset_name: str
+    dataset_class_name: str | None
+    build_config: dict
+    source: str
 
 
 @dataclass(frozen=True)
 class DatasetAliasContext:
     dataset_name: str
     dataset_alias_name: str
+    dataset_class_name: str | None = None
+
+
+def _non_empty_str(value, field_name, display_name):
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f'`{field_name}` must be a non-empty string for dataset config {display_name}'
+        )
+    return value
+
+
+def _copy_spec(spec, *, dataset_alias_name=None, source=None):
+    return DatasetSpec(
+        dataset_alias_name=dataset_alias_name or spec.dataset_alias_name,
+        dataset_name=spec.dataset_name,
+        dataset_class_name=spec.dataset_class_name,
+        build_config=cp.deepcopy(spec.build_config),
+        source=source or spec.source,
+    )
+
+
+def get_predefined_dataset_spec(name):
+    # Delayed import avoids a vlmeval.smp -> vlmeval.dataset -> vlmeval.smp cycle.
+    from vlmeval.dataset.video_dataset_config import PREDEFINED_DATASET_SPECS
+
+    spec = PREDEFINED_DATASET_SPECS.get(name)
+    if spec is None:
+        return None
+    return _copy_spec(spec)
+
+
+def _resolve_preset_config(dataset_alias_name, value):
+    preset_name = value.get('preset')
+    if not isinstance(preset_name, str) or not preset_name.strip():
+        raise ValueError(
+            f'`preset` must be a non-empty string for dataset config {dataset_alias_name}'
+        )
+    if 'class' in value:
+        raise ValueError(
+            f'`class` cannot be set when using preset for dataset config {dataset_alias_name}'
+        )
+    if 'dataset' in value:
+        raise ValueError(
+            f'`dataset` cannot be set when using preset for dataset config {dataset_alias_name}'
+        )
+
+    preset_spec = get_predefined_dataset_spec(preset_name)
+    if preset_spec is None:
+        raise ValueError(
+            f'Unknown dataset preset {preset_name} for dataset config {dataset_alias_name}'
+        )
+
+    overrides = {k: v for k, v in value.items() if k != 'preset'}
+    unknown = sorted(k for k in overrides if k not in PRESET_OVERRIDE_ALLOWLIST)
+    if unknown:
+        raise ValueError(
+            f'Unsupported preset override(s) for dataset config {dataset_alias_name}: '
+            f'{", ".join(unknown)}'
+        )
+
+    build_config = cp.deepcopy(preset_spec.build_config)
+    build_config.update(overrides)
+    return DatasetSpec(
+        dataset_alias_name=dataset_alias_name,
+        dataset_name=preset_spec.dataset_name,
+        dataset_class_name=preset_spec.dataset_class_name,
+        build_config=build_config,
+        source='preset_config',
+    )
+
+
+def _resolve_explicit_config(dataset_alias_name, value):
+    if value == {}:
+        raise ValueError(
+            f'Empty dataset config {dataset_alias_name} is not supported. '
+            'Use direct --data shortcut or set a preset explicitly.'
+        )
+    cls_name = _non_empty_str(value.get('class'), 'class', dataset_alias_name)
+    dataset_name = _non_empty_str(value.get('dataset'), 'dataset', dataset_alias_name)
+    build_config = cp.deepcopy(value)
+    return DatasetSpec(
+        dataset_alias_name=dataset_alias_name,
+        dataset_name=dataset_name,
+        dataset_class_name=cls_name,
+        build_config=build_config,
+        source='explicit_config',
+    )
+
+
+def resolve_dataset_spec(dataset_alias_name, data_config=None):
+    config = data_config or {}
+    if dataset_alias_name in config:
+        value = config[dataset_alias_name]
+        if not isinstance(value, dict):
+            raise ValueError(f'Dataset config {dataset_alias_name} must be a dict')
+        if 'preset' in value:
+            return _resolve_preset_config(dataset_alias_name, value)
+        return _resolve_explicit_config(dataset_alias_name, value)
+
+    predefined_spec = get_predefined_dataset_spec(dataset_alias_name)
+    if predefined_spec is not None:
+        return predefined_spec
+
+    return DatasetSpec(
+        dataset_alias_name=dataset_alias_name,
+        dataset_name=dataset_alias_name,
+        dataset_class_name=None,
+        build_config={'dataset': dataset_alias_name},
+        source='direct_dataset',
+    )
 
 
 def resolve_dataset_alias(dataset_alias_name, data_config=None):
-    config = data_config or {}
-    dataset_name = dataset_alias_name
-    if dataset_alias_name in config:
-        value = config[dataset_alias_name]
-        if isinstance(value, dict):
-            dataset_name = value.get('dataset', dataset_alias_name)
+    spec = resolve_dataset_spec(dataset_alias_name, data_config)
     return DatasetAliasContext(
-        dataset_name=dataset_name,
-        dataset_alias_name=dataset_alias_name,
+        dataset_name=spec.dataset_name,
+        dataset_alias_name=spec.dataset_alias_name,
+        dataset_class_name=spec.dataset_class_name,
     )
 
 

--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -706,6 +706,16 @@ def get_intermediate_file_path(eval_file, suffix, target_format=None):
     return eval_file.replace(f'.{original_ext}', f'{suffix}.{target_format}')
 
 
+def get_composite_child_eval_file(eval_file, parent_name, child_name):
+    path = Path(eval_file)
+    stem = path.stem
+    if parent_name and stem.endswith(parent_name):
+        child_stem = stem[:-len(parent_name)] + child_name
+    else:
+        child_stem = f'{stem}_{child_name}'
+    return str(path.with_name(f'{child_stem}{path.suffix}'))
+
+
 def prepare_reuse_files(
     pred_root_meta,
     eval_id,

--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -706,13 +706,10 @@ def get_intermediate_file_path(eval_file, suffix, target_format=None):
     return eval_file.replace(f'.{original_ext}', f'{suffix}.{target_format}')
 
 
-def get_composite_child_eval_file(eval_file, parent_name, child_name):
+def get_composite_child_eval_file(eval_file, child_name):
     path = Path(eval_file)
     stem = path.stem
-    if parent_name and stem.endswith(parent_name):
-        child_stem = stem[:-len(parent_name)] + child_name
-    else:
-        child_stem = f'{stem}_{child_name}'
+    child_stem = f'_{stem}_SUB_{child_name}'
     return str(path.with_name(f'{child_stem}{path.suffix}'))
 
 

--- a/vlmeval/smp/status_report.py
+++ b/vlmeval/smp/status_report.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -225,18 +224,44 @@ def flatten_summary_metrics(metrics_source: Any) -> dict[str, Any]:
     return out
 
 
-def _resolve_dataset_reporter(dataset_name: str, dataset_obj=None):
+def _resolve_dataset_reporter(
+    dataset_name: str,
+    dataset_class_name: str | None = None,
+    dataset_obj=None,
+    dataset_alias_name: str | None = None,
+):
     reporter = dataset_obj.__class__ if dataset_obj is not None else None
     if reporter is None:
         try:
             import vlmeval.dataset as dataset_module
-            from vlmeval.dataset.video_dataset_config import supported_video_datasets
 
-            if dataset_name in supported_video_datasets:
-                video_ds = supported_video_datasets[dataset_name]
-                if isinstance(video_ds, partial):
-                    reporter = video_ds.func
-            else:
+            if dataset_class_name:
+                reporter = getattr(dataset_module, dataset_class_name, None)
+                if reporter is None:
+                    for dataset_cls in dataset_module.DATASET_CLASSES:
+                        if dataset_cls.__name__ == dataset_class_name:
+                            reporter = dataset_cls
+                            break
+
+            if reporter is None:
+                try:
+                    from .dataset_alias import get_predefined_dataset_spec
+                    for name in (dataset_alias_name, dataset_name):
+                        if not name:
+                            continue
+                        spec = get_predefined_dataset_spec(name)
+                        if spec is not None and spec.dataset_class_name:
+                            reporter = getattr(dataset_module, spec.dataset_class_name, None)
+                            if reporter is None:
+                                for dataset_cls in dataset_module.DATASET_CLASSES:
+                                    if dataset_cls.__name__ == spec.dataset_class_name:
+                                        reporter = dataset_cls
+                                        break
+                            break
+                except Exception:
+                    reporter = None
+
+            if reporter is None:
                 for dataset_cls in dataset_module.DATASET_CLASSES:
                     if dataset_name in dataset_cls.supported_datasets():
                         reporter = dataset_cls
@@ -306,7 +331,10 @@ def upsert_dataset_status(
     skip_reason: str | None = _UNSET,
     error_message: str | None = _UNSET,
     dataset_obj=None,
+    resolved_dataset_name: str | None = _UNSET,
     logical_dataset_name: str | None = _UNSET,
+    dataset_alias_name: str | None = _UNSET,
+    dataset_class_name: str | None = _UNSET,
 ):
     if status is not None and status not in SUMMARY_STATUS_ORDER:
         raise ValueError(f'Invalid summary status: {status}. '
@@ -324,7 +352,31 @@ def upsert_dataset_status(
 
         datasets = run_status.setdefault('datasets', {})
         dataset_status = datasets.setdefault(dataset_name, {})
-        reporter = _resolve_dataset_reporter(dataset_name, dataset_obj=dataset_obj)
+        existing_alias_name = dataset_status.get('dataset_alias_name', dataset_name)
+        existing_logical_name = (
+            dataset_status.get('dataset_name')
+            or dataset_status.get('logical_dataset_name')
+            or dataset_name
+        )
+        next_dataset_alias_name = _merge_optional(
+            dataset_status, 'dataset_alias_name', dataset_alias_name
+        )
+        if next_dataset_alias_name is None:
+            next_dataset_alias_name = existing_alias_name
+        if resolved_dataset_name is _UNSET:
+            resolved_dataset_name = logical_dataset_name
+        next_dataset_name = _merge_optional(dataset_status, 'dataset_name', resolved_dataset_name)
+        if next_dataset_name is None:
+            next_dataset_name = existing_logical_name
+        next_dataset_class_name = _merge_optional(
+            dataset_status, 'dataset_class_name', dataset_class_name
+        )
+        reporter = _resolve_dataset_reporter(
+            next_dataset_name,
+            dataset_class_name=next_dataset_class_name,
+            dataset_obj=dataset_obj,
+            dataset_alias_name=next_dataset_alias_name,
+        )
 
         if status is not None and _status_rank(status) < _status_rank(
                 dataset_status.get('status')):
@@ -349,11 +401,6 @@ def upsert_dataset_status(
         next_judge_model = _merge_optional(dataset_status, 'judge_model', judge_model)
         next_source_run = _merge_optional(dataset_status, 'source_run', source_run)
         next_reuse_aux = _merge_optional(dataset_status, 'reuse_aux', reuse_aux)
-        next_logical_dataset_name = _merge_optional(
-            dataset_status,
-            'logical_dataset_name',
-            logical_dataset_name,
-        )
         has_metrics_update = metrics_source is not _UNSET and metrics_source is not None
         has_skip_reason_update = skip_reason is not _UNSET and skip_reason is not None
         has_error_update = error_message is not _UNSET and error_message is not None
@@ -379,7 +426,10 @@ def upsert_dataset_status(
         _set_or_pop(dataset_status, 'judge_model', next_judge_model)
         _set_or_pop(dataset_status, 'source_run', next_source_run)
         _set_or_pop(dataset_status, 'reuse_aux', next_reuse_aux)
-        _set_or_pop(dataset_status, 'logical_dataset_name', next_logical_dataset_name)
+        _set_or_pop(dataset_status, 'dataset_alias_name', next_dataset_alias_name)
+        _set_or_pop(dataset_status, 'dataset_name', next_dataset_name)
+        _set_or_pop(dataset_status, 'dataset_class_name', next_dataset_class_name)
+        dataset_status.pop('logical_dataset_name', None)
         _set_or_pop(dataset_status, 'skip_reason', next_skip_reason)
         _set_or_pop(dataset_status, 'error_message', next_error_message)
         _set_or_pop(dataset_status, 'primary_metric', primary_metric)
@@ -422,8 +472,16 @@ def collect_run_benchmark_report(run_dir):
             dataset_name=dataset_name,
             prediction_file=dataset_status.get('prediction_file'),
         )
-        logical_dataset_name = dataset_status.get('logical_dataset_name', dataset_name)
-        reporter = _resolve_dataset_reporter(logical_dataset_name)
+        logical_dataset_name = (
+            dataset_status.get('dataset_name')
+            or dataset_status.get('logical_dataset_name')
+            or dataset_name
+        )
+        reporter = _resolve_dataset_reporter(
+            logical_dataset_name,
+            dataset_class_name=dataset_status.get('dataset_class_name'),
+            dataset_alias_name=dataset_status.get('dataset_alias_name', dataset_name),
+        )
         infer_report = reporter.report_infer_err(pred_path)
         infer_failed = infer_report.get('failed', 0)
         infer_total = infer_report.get('total', 0)

--- a/vlmeval/smp/status_report.py
+++ b/vlmeval/smp/status_report.py
@@ -306,6 +306,7 @@ def upsert_dataset_status(
     skip_reason: str | None = _UNSET,
     error_message: str | None = _UNSET,
     dataset_obj=None,
+    logical_dataset_name: str | None = _UNSET,
 ):
     if status is not None and status not in SUMMARY_STATUS_ORDER:
         raise ValueError(f'Invalid summary status: {status}. '
@@ -348,6 +349,11 @@ def upsert_dataset_status(
         next_judge_model = _merge_optional(dataset_status, 'judge_model', judge_model)
         next_source_run = _merge_optional(dataset_status, 'source_run', source_run)
         next_reuse_aux = _merge_optional(dataset_status, 'reuse_aux', reuse_aux)
+        next_logical_dataset_name = _merge_optional(
+            dataset_status,
+            'logical_dataset_name',
+            logical_dataset_name,
+        )
         has_metrics_update = metrics_source is not _UNSET and metrics_source is not None
         has_skip_reason_update = skip_reason is not _UNSET and skip_reason is not None
         has_error_update = error_message is not _UNSET and error_message is not None
@@ -373,6 +379,7 @@ def upsert_dataset_status(
         _set_or_pop(dataset_status, 'judge_model', next_judge_model)
         _set_or_pop(dataset_status, 'source_run', next_source_run)
         _set_or_pop(dataset_status, 'reuse_aux', next_reuse_aux)
+        _set_or_pop(dataset_status, 'logical_dataset_name', next_logical_dataset_name)
         _set_or_pop(dataset_status, 'skip_reason', next_skip_reason)
         _set_or_pop(dataset_status, 'error_message', next_error_message)
         _set_or_pop(dataset_status, 'primary_metric', primary_metric)
@@ -415,7 +422,8 @@ def collect_run_benchmark_report(run_dir):
             dataset_name=dataset_name,
             prediction_file=dataset_status.get('prediction_file'),
         )
-        reporter = _resolve_dataset_reporter(dataset_name)
+        logical_dataset_name = dataset_status.get('logical_dataset_name', dataset_name)
+        reporter = _resolve_dataset_reporter(logical_dataset_name)
         infer_report = reporter.report_infer_err(pred_path)
         infer_failed = infer_report.get('failed', 0)
         infer_total = infer_report.get('total', 0)


### PR DESCRIPTION
# Pull Request Description

## Summary

This PR refactors VLMEvalKit dataset config handling to separate **output aliases** from **logical dataset names**.

Previously, the key under config `data` could be treated both as the output artifact name and as the logical dataset identity. That becomes ambiguous when users want custom output names for the same dataset configuration. This PR introduces a structured `DatasetSpec` resolution flow so output naming, dataset construction, evaluation, status tracking, and reporter recovery use the right identity consistently.

## Motivation

For configs like:

```json
{
  "data": {
    "Video-MME-custom": {
      "class": "VideoMME",
      "dataset": "Video-MME",
      "nframe": 16
    }
  }
}
```

`Video-MME-custom` should only be an output alias, while `Video-MME` should remain the logical dataset name used by dataset construction, prompts, judge/evaluate logic, and reporter lookup.

This PR makes that distinction explicit.

## Main Changes

### Dataset alias resolution

- Add `DatasetSpec` and alias resolution helpers in `vlmeval/smp/dataset_alias.py`.
- Resolve every dataset entry into:
  - `dataset_alias_name`: output-side alias.
  - `dataset_name`: logical dataset name.
  - `dataset_class_name`: class name used for strict build and reporter/status recovery.
  - `build_config`: dataset construction config.
  - `source`: direct dataset, explicit config, preset config, or predefined shortcut.
- Validate output aliases as safe filename components:
  - allowed: letters, digits, `.`, `_`, `-`
  - must start with a letter or digit

### Config and preset behavior

- `data` keys are now output aliases.
- Explicit dataset config must provide non-empty `class` and `dataset`.
- Empty dict dataset config is no longer supported.
- Predefined video shortcuts can be reused in config with:

```json
{
  "MyAlias": {
    "preset": "MMBench_Video_8frame_nopack"
  }
}
```

- Preset configs cannot override `class` or `dataset`.

### Video shortcut unification

- Replace predefined video shortcut callable/partial handling with `DatasetSpec`.
- Add `PREDEFINED_DATASET_SPECS`.
- Add a manifest fixture to guard predefined video shortcut migration coverage.

### Inference path updates

- Propagate both alias and logical dataset name through local, API, MT, and video inference paths.
- Use alias for output files, checkpoints, status keys, reuse artifacts, and symlinks.
- Use logical dataset name for dataset construction, model custom prompt checks, generation calls, judge/evaluate logic, and dataset-specific behavior.

### Composite dataset evaluation

- Stop deriving child eval files with string replacement on logical dataset names.
- Add alias-safe child eval file naming:

```text
_{parent_stem}_SUB_{child_name}{suffix}
```

This avoids overwriting parent prediction files or colliding when an alias does not contain the logical dataset name.

### Status and reporter handling

- Store alias, logical dataset name, and dataset class name in status.
- After dataset construction, record the effective runtime dataset class name.
- Improve reporter recovery for aliases, wrappers, custom datasets, and predefined shortcuts.

### Video sampling validation

- Add build config validation for video datasets.
- Treat `fps <= 0` as unset for ordinary video datasets.
- Require exactly one valid sampling mode in ordinary cases:
  - `nframe > 0`, or
  - `fps > 0`
- Keep special dataset behavior via class-level validation overrides where needed.

### Dataset-specific fixes

- Add explicit validation for special video datasets such as DREAM and MVUEval.
- Fix CGBench / CG-AV-Counting local `fps=0` handling.
- Make model-dependent document VQA datasets accept explicit `model` constructor parameter:
  - DUDE / DUDE_MINI
  - SLIDEVQA / SLIDEVQA_MINI
  - MMLongBench_DOC
- Add explicit `SiteBenchImage.__init__` signature to keep strict config validation meaningful.

### Documentation

- Update English and Chinese config docs.
- Update `run.py --help`.
- Document:
  - `data` key as output alias
  - logical dataset name from `dataset`
  - preset usage
  - unsupported empty dict shortcut config
  - alias filename safety rule

## Tests

Ran:

```bash
pytest tests/test_dataset_alias.py tests/test_inference_api.py
flake8 --max-line-length=120 --ignore=W503 tests/test_dataset_alias.py vlmeval/smp/dataset_alias.py run.py
git diff --check
```

Also passed pre-commit hooks during commits:

```text
flake8
isort
yapf
trim trailing whitespace
check yaml
fix end of files
check for merge conflicts
mixed line ending
```

