### PR TITLE
[Model] Add VQToken for LLaVA-OneVision

### DIFF
--- a/docs/en/Quickstart.md
+++ b/docs/en/Quickstart.md
@@ -18,7 +18,7 @@ The optional VQToken adapter requires Python 3.10 or 3.11 and its public
 LLaVA-OneVision runtime:
 
 ```bash
-pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd"
+pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@0314eb9989a7ea843f31bfe0984113529e3f9140"
 hf auth login
 # Loader/image sanity check; use a video dataset command to exercise VQToken.
 vlmutil check VQToken-LLaVA-OneVision-0.5B
@@ -27,6 +27,10 @@ python run.py --data MVBench_8frame --model VQToken-LLaVA-OneVision-0.5B --mode 
 
 The released paper checkpoint uses Hugging Face's access-request flow, so
 accept its terms before running the check or an evaluation.
+`VQToken-LLaVA-OneVision-0.5B` enables the checkpoint's learned VQ-Attention
+path by default. The centroid-only path remains available as an explicit
+ablation via `vqtoken_mode='centroids'`. For learned attention, sampled frames
+must not exceed K; with adaptive selection they must not exceed the minimum K.
 
 **Setup Keys.**
 

--- a/docs/en/Quickstart.md
+++ b/docs/en/Quickstart.md
@@ -18,7 +18,7 @@ The optional VQToken adapter requires Python 3.10 or 3.11 and its public
 LLaVA-OneVision runtime:
 
 ```bash
-pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a"
+pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd"
 hf auth login
 # Loader/image sanity check; use a video dataset command to exercise VQToken.
 vlmutil check VQToken-LLaVA-OneVision-0.5B

--- a/docs/en/Quickstart.md
+++ b/docs/en/Quickstart.md
@@ -14,6 +14,20 @@ cd VLMEvalKit
 pip install -e .
 ```
 
+The optional VQToken adapter requires Python 3.10 or 3.11 and its public
+LLaVA-OneVision runtime:
+
+```bash
+pip install "llava[runtime] @ git+https://github.com/Hai-chao-Zhang/VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a"
+hf auth login
+# Loader/image sanity check; use a video dataset command to exercise VQToken.
+vlmutil check VQToken-LLaVA-OneVision-0.5B
+python run.py --data MVBench_8frame --model VQToken-LLaVA-OneVision-0.5B --mode infer
+```
+
+The released paper checkpoint uses Hugging Face's access-request flow, so
+accept its terms before running the check or an evaluation.
+
 **Setup Keys.**
 
 To infer with API models (GPT-4v, Gemini-Pro-V, etc.) or use LLM APIs as the **judge or choice extractor**, you need to first setup API keys. VLMEvalKit will use an judge **LLM** to extract answer from the output if you set the key, otherwise it uses the **exact matching** mode (find "Yes", "No", "A", "B", "C"... in the output strings). **The exact matching can only be applied to the Yes-or-No tasks and the Multi-choice tasks.**

--- a/tests/test_vqtoken.py
+++ b/tests/test_vqtoken.py
@@ -1,0 +1,370 @@
+import importlib.util
+import sys
+import unittest
+import warnings
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+
+def load_vqtoken_module():
+    """Load the optional wrapper without importing every VLMEvalKit backend."""
+    package_names = ['vlmeval', 'vlmeval.vlm', 'vlmeval.vlm.llava']
+    packages = {}
+    for package_name in package_names:
+        package = ModuleType(package_name)
+        package.__path__ = []
+        packages[package_name] = package
+
+    llava_module = ModuleType('vlmeval.vlm.llava.llava')
+
+    class FakeLLaVAOneVision:
+        pass
+
+    llava_module.LLaVA_OneVision = FakeLLaVAOneVision
+    packages['vlmeval.vlm.llava.llava'] = llava_module
+
+    module_name = 'vlmeval.vlm.llava.vqtoken'
+    module_path = Path(__file__).parents[1] / 'vlmeval' / 'vlm' / 'llava' / 'vqtoken.py'
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, packages):
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(module_name, None)
+    return module
+
+
+def load_llava_module():
+    """Load the OneVision parent with lightweight VLMEvalKit import stubs."""
+    packages = {}
+    for package_name in ['vlmeval', 'vlmeval.vlm', 'vlmeval.vlm.llava']:
+        package = ModuleType(package_name)
+        package.__path__ = []
+        packages[package_name] = package
+
+    dataset_module = ModuleType('vlmeval.dataset')
+    dataset_module.DATASET_MODALITY = lambda dataset: 'VIDEO' if dataset == 'video-dataset' else 'IMAGE'
+    dataset_module.DATASET_TYPE = lambda dataset: 'VQA'
+    packages['vlmeval.dataset'] = dataset_module
+
+    smp_module = ModuleType('vlmeval.smp')
+    smp_module.cn_string = lambda value: False
+    smp_module.encode_image_to_base64 = lambda image: ''
+    smp_module.splitlen = lambda value: 2
+    packages['vlmeval.smp'] = smp_module
+
+    base_module = ModuleType('vlmeval.vlm.base')
+
+    class FakeBaseModel:
+        pass
+
+    base_module.BaseModel = FakeBaseModel
+    packages['vlmeval.vlm.base'] = base_module
+
+    packages['numpy'] = ModuleType('numpy')
+    packages['pandas'] = ModuleType('pandas')
+    torch_module = ModuleType('torch')
+    torch_module.ones_like = lambda value: value
+    packages['torch'] = torch_module
+    pil_module = ModuleType('PIL')
+    pil_module.Image = SimpleNamespace()
+    packages['PIL'] = pil_module
+
+    module_name = 'vlmeval.vlm.llava.llava'
+    module_path = Path(__file__).parents[1] / 'vlmeval' / 'vlm' / 'llava' / 'llava.py'
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, packages):
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(module_name, None)
+    return module
+
+
+class FakeTensor:
+
+    def half(self):
+        return self
+
+    def cuda(self):
+        return self
+
+    def unsqueeze(self, dim):
+        return self
+
+
+class FakeVideoFrames:
+
+    shape = (4, 8, 10, 3)
+
+    def __len__(self):
+        return self.shape[0]
+
+
+class FakeConversation:
+
+    roles = ('user', 'assistant')
+    sep = '<sep>'
+    sep2 = '<sep2>'
+    sep_style = 'single'
+
+    def __init__(self):
+        self.messages = []
+
+    def append_message(self, role, content):
+        self.messages.append((role, content))
+
+    def get_prompt(self):
+        return '\n'.join(content or '' for _, content in self.messages)
+
+
+class TestVQToken(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.vqtoken = load_vqtoken_module()
+
+    def test_wrapper_passes_public_centroid_config(self):
+        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
+            'modes': ('centroids', ),
+            'selection_methods': ('fixed', 'elbow', 'silhouette'),
+        })
+        parent_class = self.vqtoken.LLaVA_OneVision
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               return_value=runtime), mock.patch.object(parent_class, '__init__',
+                                                                        return_value=None) as parent_init:
+            model = self.vqtoken.LLaVA_OneVision_VQToken(
+                vqtoken_selection_method='elbow',
+                vqtoken_min_clusters=12,
+                vqtoken_max_clusters=32,
+            )
+
+        kwargs = parent_init.call_args.kwargs
+        self.assertEqual(kwargs['model_path'], 'haichaozhang/VQ-Token-llava-ov-0.5b')
+        self.assertEqual(kwargs['model_name'], 'llava_qwen')
+        self.assertEqual(
+            model._get_model_overwrite_config(),
+            {
+                'use_vqtoken': True,
+                'vqtoken_mode': 'centroids',
+                'vqtoken_selection_method': 'elbow',
+                'vqtoken_min_clusters': 12,
+                'vqtoken_max_clusters': 32,
+                'use_embedded_vision': True,
+                'mm_spatial_pool_stride': 2,
+                'mm_spatial_pool_mode': 'bilinear',
+            },
+        )
+        self.assertEqual(model.nframe, 32)
+        self.assertFalse(model.force_sample)
+
+    def test_wrapper_forces_uniform_sampling_without_timestamp_prompt(self):
+        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
+            'modes': ('centroids', ),
+            'selection_methods': ('fixed', 'elbow', 'silhouette'),
+        })
+        parent_class = self.vqtoken.LLaVA_OneVision
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               return_value=runtime), mock.patch.object(parent_class, '__init__', return_value=None):
+            model = self.vqtoken.LLaVA_OneVision_VQToken()
+
+        with mock.patch.object(parent_class, 'load_video', create=True,
+                               return_value=('frames', 'times', 1.0)) as parent_load:
+            result = model.load_video('demo.mp4', 32, fps=1, force_sample=False)
+
+        self.assertEqual(result, ('frames', 'times', 1.0))
+        parent_load.assert_called_once_with('demo.mp4', 32, 1, True)
+
+    def test_invalid_or_non_public_configuration_is_rejected(self):
+        invalid = [
+            ('attention', 12, 32),
+            ('fixed', 0, 32),
+            ('elbow', 33, 32),
+            ('fixed', True, 32),
+        ]
+        for config in invalid:
+            with self.subTest(config=config), self.assertRaises(ValueError):
+                self.vqtoken.validate_cluster_config(*config)
+
+    def test_fixed_selection_uses_max_clusters_as_k(self):
+        self.vqtoken.validate_cluster_config('fixed', 12, 8)
+
+    def test_custom_checkpoint_embedded_vision_is_opt_in(self):
+        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
+            'modes': ('centroids', ),
+            'selection_methods': ('fixed', 'elbow', 'silhouette'),
+        })
+        parent_class = self.vqtoken.LLaVA_OneVision
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               return_value=runtime), mock.patch.object(parent_class, '__init__', return_value=None):
+            inferred = self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/custom')
+            explicit = self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/custom', use_embedded_vision=True)
+
+        self.assertFalse(inferred._get_model_overwrite_config()['use_embedded_vision'])
+        self.assertTrue(explicit._get_model_overwrite_config()['use_embedded_vision'])
+
+    def test_local_checkpoint_embedded_vision_is_detected(self):
+        detector = mock.MagicMock(return_value=True)
+        runtime = SimpleNamespace(
+            VQTOKEN_CAPABILITIES={
+                'modes': ('centroids', ),
+                'selection_methods': ('fixed', 'elbow', 'silhouette'),
+            },
+            has_embedded_vision_weights=detector,
+        )
+        parent_class = self.vqtoken.LLaVA_OneVision
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               return_value=runtime), mock.patch.object(parent_class, '__init__', return_value=None):
+            model = self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/checkpoint')
+
+        detector.assert_called_once_with('local/checkpoint')
+        self.assertTrue(model._get_model_overwrite_config()['use_embedded_vision'])
+
+    def test_invalid_frame_count_is_rejected(self):
+        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
+            'modes': ('centroids', ),
+            'selection_methods': ('fixed', 'elbow', 'silhouette'),
+        })
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               return_value=runtime), self.assertRaisesRegex(ValueError, 'max_frames_num'):
+            self.vqtoken.LLaVA_OneVision_VQToken(max_frames_num=0)
+
+    def test_missing_runtime_has_actionable_error(self):
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               side_effect=ImportError), self.assertRaisesRegex(ImportError, 'Hai-chao-Zhang/VQToken'):
+            self.vqtoken.require_vqtoken_runtime()
+
+    def test_old_runtime_is_rejected(self):
+        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={'modes': (), 'selection_methods': ()})
+        with mock.patch.object(self.vqtoken, 'import_module',
+                               return_value=runtime), self.assertRaisesRegex(ImportError, 'too old'):
+            self.vqtoken.require_vqtoken_runtime()
+
+
+class TestOneVisionVideoBoundary(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.llava = load_llava_module()
+
+    def make_model(self):
+        model = self.llava.LLaVA_OneVision.__new__(self.llava.LLaVA_OneVision)
+        frames = FakeVideoFrames()
+        model.load_video = mock.MagicMock(return_value=(frames, '0.00s,1.00s,2.00s,3.00s', 4.0))
+        model.nframe = 32
+        model.force_sample = True
+        model.DEFAULT_IMAGE_TOKEN = '<image>'
+        model.IMAGE_TOKEN_INDEX = -200
+        model.image_processor = SimpleNamespace(preprocess=lambda *args, **kwargs: {'pixel_values': FakeTensor()})
+        model.conv_template = 'qwen_1_5'
+        model.conv_templates = {'qwen_1_5': FakeConversation()}
+        model.tokenizer = object()
+        model.tokenizer_image_token = mock.MagicMock(return_value=FakeTensor())
+        model.KeywordStoppingCriteria = lambda *args, **kwargs: object()
+        model.SeparatorStyle = SimpleNamespace(TWO='two')
+        model.model = SimpleNamespace(generate=mock.MagicMock(return_value=FakeTensor()))
+        model.tokenizer = SimpleNamespace(batch_decode=lambda *args, **kwargs: ['answer'])
+        return model
+
+    def test_video_generation_uses_one_multimodal_item(self):
+        model = self.make_model()
+        message = [
+            {
+                'type': 'video',
+                'value': 'demo.mp4'
+            },
+            {
+                'type': 'text',
+                'value': 'What happens?'
+            },
+        ]
+
+        self.assertEqual(model.generate_inner_video(message), 'answer')
+
+        prompt = model.tokenizer_image_token.call_args.args[0]
+        generation = model.model.generate.call_args.kwargs
+        self.assertIn('and 4 frames are uniformly sampled', prompt)
+        self.assertEqual(len(generation['images']), 1)
+        self.assertIs(generation['attention_mask'], model.tokenizer_image_token.return_value)
+        self.assertEqual(generation['image_sizes'], [(10, 8)])
+        self.assertEqual(generation['modalities'], ['video'])
+
+    def test_video_message_routes_without_dataset_name(self):
+        model = self.make_model()
+        model.generate_inner_video = mock.MagicMock(return_value='video-answer')
+        model.generate_inner_image = mock.MagicMock(return_value='image-answer')
+
+        result = model.generate_inner([{'type': 'video', 'value': 'demo.mp4'}], dataset=None)
+
+        self.assertEqual(result, 'video-answer')
+        model.generate_inner_video.assert_called_once()
+        model.generate_inner_image.assert_not_called()
+
+    def test_explicit_megabench_video_routes_as_video(self):
+        model = self.make_model()
+        model.generate_inner_video = mock.MagicMock(return_value='video-answer')
+        model.generate_inner_image = mock.MagicMock(return_value='image-answer')
+
+        result = model.generate_inner([{'type': 'video', 'value': 'demo.mp4'}], dataset='MEGABench')
+
+        self.assertEqual(result, 'video-answer')
+        model.generate_inner_video.assert_called_once()
+        model.generate_inner_image.assert_not_called()
+
+    def test_parent_loader_merges_only_subclass_overrides(self):
+        conversation_module = ModuleType('llava.conversation')
+        conversation_module.SeparatorStyle = SimpleNamespace(TWO='two')
+        conversation_module.conv_templates = {'qwen_1_5': FakeConversation()}
+
+        mm_utils_module = ModuleType('llava.mm_utils')
+        mm_utils_module.KeywordsStoppingCriteria = lambda *args, **kwargs: object()
+        mm_utils_module.get_model_name_from_path = lambda path: 'derived-name'
+        mm_utils_module.process_images = lambda *args, **kwargs: None
+        mm_utils_module.tokenizer_image_token = lambda *args, **kwargs: FakeTensor()
+
+        fake_model = mock.MagicMock()
+        fake_model.config = SimpleNamespace()
+        loader = mock.MagicMock(return_value=(object(), fake_model, object(), 4096))
+        builder_module = ModuleType('llava.model.builder')
+        builder_module.load_pretrained_model = loader
+
+        llava_package = ModuleType('llava')
+        llava_package.__path__ = []
+        llava_model_package = ModuleType('llava.model')
+        llava_model_package.__path__ = []
+        modules = {
+            'llava': llava_package,
+            'llava.conversation': conversation_module,
+            'llava.mm_utils': mm_utils_module,
+            'llava.model': llava_model_package,
+            'llava.model.builder': builder_module,
+        }
+
+        class CustomOneVision(self.llava.LLaVA_OneVision):
+
+            def __init__(self):
+                self.settings = {'use_vqtoken': True}
+                super().__init__(model_path='org/llava-model', model_name='llava_qwen')
+
+            def _get_model_overwrite_config(self):
+                return dict(self.settings)
+
+        with warnings.catch_warnings(), mock.patch.dict(sys.modules, modules):
+            self.llava.LLaVA_OneVision(model_path='org/llava-model')
+            base_overrides = loader.call_args.kwargs['overwrite_config']
+            custom = CustomOneVision()
+            custom_overrides = loader.call_args.kwargs['overwrite_config']
+
+        self.assertIsNone(base_overrides)
+        self.assertEqual(custom_overrides, {'use_vqtoken': True})
+        custom_overrides['use_vqtoken'] = False
+        self.assertTrue(custom._get_model_overwrite_config()['use_vqtoken'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_vqtoken.py
+++ b/tests/test_vqtoken.py
@@ -46,7 +46,8 @@ def load_llava_module():
         packages[package_name] = package
 
     dataset_module = ModuleType('vlmeval.dataset')
-    dataset_module.DATASET_MODALITY = lambda dataset: 'VIDEO' if dataset == 'video-dataset' else 'IMAGE'
+    dataset_module.DATASET_MODALITY = (
+        lambda dataset: 'VIDEO' if dataset == 'video-dataset' else 'IMAGE')
     dataset_module.DATASET_TYPE = lambda dataset: 'VQA'
     packages['vlmeval.dataset'] = dataset_module
 
@@ -129,19 +130,21 @@ class TestVQToken(unittest.TestCase):
     def setUpClass(cls):
         cls.vqtoken = load_vqtoken_module()
 
-    def test_wrapper_passes_public_centroid_config(self):
-        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
-            'modes': ('centroids', ),
-            'selection_methods': ('fixed', 'elbow', 'silhouette'),
-        })
+    def test_wrapper_passes_public_learned_attention_config(self):
+        runtime = SimpleNamespace(
+            VQTOKEN_CAPABILITIES={
+                'modes': ('attention', 'centroids'),
+                'selection_methods': ('fixed', 'elbow', 'silhouette'),
+            })
         parent_class = self.vqtoken.LLaVA_OneVision
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               return_value=runtime), mock.patch.object(parent_class, '__init__',
-                                                                        return_value=None) as parent_init:
+        with mock.patch.object(
+                self.vqtoken, 'import_module', return_value=runtime), mock.patch.object(
+                    parent_class, '__init__', return_value=None) as parent_init:
             model = self.vqtoken.LLaVA_OneVision_VQToken(
                 vqtoken_selection_method='elbow',
                 vqtoken_min_clusters=12,
                 vqtoken_max_clusters=32,
+                max_frames_num=12,
             )
 
         kwargs = parent_init.call_args.kwargs
@@ -151,7 +154,7 @@ class TestVQToken(unittest.TestCase):
             model._get_model_overwrite_config(),
             {
                 'use_vqtoken': True,
-                'vqtoken_mode': 'centroids',
+                'vqtoken_mode': 'attention',
                 'vqtoken_selection_method': 'elbow',
                 'vqtoken_min_clusters': 12,
                 'vqtoken_max_clusters': 32,
@@ -160,21 +163,24 @@ class TestVQToken(unittest.TestCase):
                 'mm_spatial_pool_mode': 'bilinear',
             },
         )
-        self.assertEqual(model.nframe, 32)
+        self.assertEqual(model.nframe, 12)
         self.assertFalse(model.force_sample)
 
     def test_wrapper_forces_uniform_sampling_without_timestamp_prompt(self):
-        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
-            'modes': ('centroids', ),
-            'selection_methods': ('fixed', 'elbow', 'silhouette'),
-        })
+        runtime = SimpleNamespace(
+            VQTOKEN_CAPABILITIES={
+                'modes': ('attention', 'centroids'),
+                'selection_methods': ('fixed', 'elbow', 'silhouette'),
+            })
         parent_class = self.vqtoken.LLaVA_OneVision
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               return_value=runtime), mock.patch.object(parent_class, '__init__', return_value=None):
+        with mock.patch.object(
+                self.vqtoken, 'import_module', return_value=runtime), mock.patch.object(
+                    parent_class, '__init__', return_value=None):
             model = self.vqtoken.LLaVA_OneVision_VQToken()
 
-        with mock.patch.object(parent_class, 'load_video', create=True,
-                               return_value=('frames', 'times', 1.0)) as parent_load:
+        with mock.patch.object(
+                parent_class, 'load_video', create=True,
+                return_value=('frames', 'times', 1.0)) as parent_load:
             result = model.load_video('demo.mp4', 32, fps=1, force_sample=False)
 
         self.assertEqual(result, ('frames', 'times', 1.0))
@@ -182,7 +188,7 @@ class TestVQToken(unittest.TestCase):
 
     def test_invalid_or_non_public_configuration_is_rejected(self):
         invalid = [
-            ('attention', 12, 32),
+            ('random', 12, 32),
             ('fixed', 0, 32),
             ('elbow', 33, 32),
             ('fixed', True, 32),
@@ -200,10 +206,13 @@ class TestVQToken(unittest.TestCase):
             'selection_methods': ('fixed', 'elbow', 'silhouette'),
         })
         parent_class = self.vqtoken.LLaVA_OneVision
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               return_value=runtime), mock.patch.object(parent_class, '__init__', return_value=None):
-            inferred = self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/custom')
-            explicit = self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/custom', use_embedded_vision=True)
+        with mock.patch.object(
+                self.vqtoken, 'import_module', return_value=runtime), mock.patch.object(
+                    parent_class, '__init__', return_value=None):
+            inferred = self.vqtoken.LLaVA_OneVision_VQToken(
+                model_path='local/custom', vqtoken_mode='centroids')
+            explicit = self.vqtoken.LLaVA_OneVision_VQToken(
+                model_path='local/custom', vqtoken_mode='centroids', use_embedded_vision=True)
 
         self.assertFalse(inferred._get_model_overwrite_config()['use_embedded_vision'])
         self.assertTrue(explicit._get_model_overwrite_config()['use_embedded_vision'])
@@ -218,9 +227,11 @@ class TestVQToken(unittest.TestCase):
             has_embedded_vision_weights=detector,
         )
         parent_class = self.vqtoken.LLaVA_OneVision
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               return_value=runtime), mock.patch.object(parent_class, '__init__', return_value=None):
-            model = self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/checkpoint')
+        with mock.patch.object(
+                self.vqtoken, 'import_module', return_value=runtime), mock.patch.object(
+                    parent_class, '__init__', return_value=None):
+            model = self.vqtoken.LLaVA_OneVision_VQToken(
+                model_path='local/checkpoint', vqtoken_mode='centroids')
 
         detector.assert_called_once_with('local/checkpoint')
         self.assertTrue(model._get_model_overwrite_config()['use_embedded_vision'])
@@ -230,20 +241,102 @@ class TestVQToken(unittest.TestCase):
             'modes': ('centroids', ),
             'selection_methods': ('fixed', 'elbow', 'silhouette'),
         })
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               return_value=runtime), self.assertRaisesRegex(ValueError, 'max_frames_num'):
+        with mock.patch.object(
+                self.vqtoken, 'import_module',
+                return_value=runtime), self.assertRaisesRegex(ValueError, 'max_frames_num'):
             self.vqtoken.LLaVA_OneVision_VQToken(max_frames_num=0)
 
     def test_missing_runtime_has_actionable_error(self):
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               side_effect=ImportError), self.assertRaisesRegex(ImportError, 'Hai-chao-Zhang/VQToken'):
+        with mock.patch.object(
+                self.vqtoken, 'import_module',
+                side_effect=ImportError), self.assertRaisesRegex(ImportError,
+                                                                 'Hai-chao-Zhang/VQToken'):
             self.vqtoken.require_vqtoken_runtime()
 
     def test_old_runtime_is_rejected(self):
         runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={'modes': (), 'selection_methods': ()})
-        with mock.patch.object(self.vqtoken, 'import_module',
-                               return_value=runtime), self.assertRaisesRegex(ImportError, 'too old'):
+        with mock.patch.object(
+                self.vqtoken, 'import_module',
+                return_value=runtime), self.assertRaisesRegex(ImportError, 'too old'):
             self.vqtoken.require_vqtoken_runtime()
+
+    def test_centroid_only_runtime_is_rejected_for_default_attention(self):
+        runtime = SimpleNamespace(VQTOKEN_CAPABILITIES={
+            'modes': ('centroids', ),
+            'selection_methods': ('fixed', 'elbow', 'silhouette'),
+        })
+        with mock.patch.object(
+                self.vqtoken, 'import_module',
+                return_value=runtime), self.assertRaisesRegex(ImportError, 'too old'):
+            self.vqtoken.require_vqtoken_runtime()
+        with mock.patch.object(self.vqtoken, 'import_module', return_value=runtime):
+            self.assertIs(self.vqtoken.require_vqtoken_runtime('centroids'), runtime)
+
+    def test_attention_frame_budget_is_validated_before_loading(self):
+        parent_class = self.vqtoken.LLaVA_OneVision
+        invalid = [
+            {
+                'max_frames_num': 33,
+                'vqtoken_max_clusters': 32
+            },
+            {
+                'max_frames_num': 13,
+                'vqtoken_selection_method': 'silhouette',
+                'vqtoken_min_clusters': 12,
+                'vqtoken_max_clusters': 32,
+            },
+        ]
+        for kwargs in invalid:
+            with self.subTest(kwargs=kwargs), mock.patch.object(
+                    self.vqtoken, 'import_module') as runtime_import, mock.patch.object(
+                        parent_class, '__init__',
+                        return_value=None) as parent_init, self.assertRaisesRegex(
+                            ValueError, 'max_frames_num'):
+                self.vqtoken.LLaVA_OneVision_VQToken(**kwargs)
+            runtime_import.assert_not_called()
+            parent_init.assert_not_called()
+
+    def test_unknown_checkpoint_cannot_silently_use_random_attention(self):
+        detector = mock.MagicMock(return_value=False)
+        runtime = SimpleNamespace(
+            VQTOKEN_CAPABILITIES={
+                'modes': ('attention', 'centroids'),
+                'selection_methods': ('fixed', 'elbow', 'silhouette'),
+            },
+            has_released_vq_attention_weights=detector,
+        )
+        parent_class = self.vqtoken.LLaVA_OneVision
+        with mock.patch.object(
+                self.vqtoken, 'import_module', return_value=runtime), mock.patch.object(
+                    parent_class, '__init__',
+                    return_value=None) as parent_init, self.assertRaisesRegex(
+                        ValueError, 'released checkpoint'):
+            self.vqtoken.LLaVA_OneVision_VQToken(model_path='local/base-only')
+
+        detector.assert_called_once_with('local/base-only')
+        parent_init.assert_not_called()
+
+    def test_verified_local_checkpoint_can_use_attention(self):
+        attention_detector = mock.MagicMock(return_value=True)
+        runtime = SimpleNamespace(
+            VQTOKEN_CAPABILITIES={
+                'modes': ('attention', 'centroids'),
+                'selection_methods': ('fixed', 'elbow', 'silhouette'),
+            },
+            has_released_vq_attention_weights=attention_detector,
+        )
+        parent_class = self.vqtoken.LLaVA_OneVision
+        with mock.patch.object(
+                self.vqtoken, 'import_module', return_value=runtime), mock.patch.object(
+                    parent_class, '__init__', return_value=None):
+            model = self.vqtoken.LLaVA_OneVision_VQToken(
+                model_path='local/released-snapshot', use_embedded_vision=False)
+
+        attention_detector.assert_called_once_with('local/released-snapshot')
+        self.assertEqual(model._get_model_overwrite_config()['vqtoken_mode'], 'attention')
+
+    def test_runtime_dependency_is_pinned_to_attention_compatible_commit(self):
+        self.assertIn('0314eb9989a7ea843f31bfe0984113529e3f9140', self.vqtoken.RUNTIME_INSTALL)
 
 
 class TestOneVisionVideoBoundary(unittest.TestCase):
@@ -260,7 +353,8 @@ class TestOneVisionVideoBoundary(unittest.TestCase):
         model.force_sample = True
         model.DEFAULT_IMAGE_TOKEN = '<image>'
         model.IMAGE_TOKEN_INDEX = -200
-        model.image_processor = SimpleNamespace(preprocess=lambda *args, **kwargs: {'pixel_values': FakeTensor()})
+        model.image_processor = SimpleNamespace(
+            preprocess=lambda *args, **kwargs: {'pixel_values': FakeTensor()})
         model.conv_template = 'qwen_1_5'
         model.conv_templates = {'qwen_1_5': FakeConversation()}
         model.tokenizer = object()
@@ -310,7 +404,11 @@ class TestOneVisionVideoBoundary(unittest.TestCase):
         model.generate_inner_video = mock.MagicMock(return_value='video-answer')
         model.generate_inner_image = mock.MagicMock(return_value='image-answer')
 
-        result = model.generate_inner([{'type': 'video', 'value': 'demo.mp4'}], dataset='MEGABench')
+        result = model.generate_inner(
+            [{
+                'type': 'video',
+                'value': 'demo.mp4'
+            }], dataset='MEGABench')
 
         self.assertEqual(result, 'video-answer')
         model.generate_inner_video.assert_called_once()
@@ -349,7 +447,7 @@ class TestOneVisionVideoBoundary(unittest.TestCase):
 
             def __init__(self):
                 self.settings = {'use_vqtoken': True}
-                super().__init__(model_path='org/llava-model', model_name='llava_qwen')
+                super().__init__(model_path='local/checkpoint', model_name='llava_qwen')
 
             def _get_model_overwrite_config(self):
                 return dict(self.settings)

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -1055,6 +1055,10 @@ llava_series = {
     "llava-onevision-qwen2-0.5b-ov-hf": partial(
         vlm.LLaVA_OneVision_HF, model_path="llava-hf/llava-onevision-qwen2-0.5b-ov-hf"
     ),
+    "VQToken-LLaVA-OneVision-0.5B": partial(
+        vlm.LLaVA_OneVision_VQToken,
+        model_path="haichaozhang/VQ-Token-llava-ov-0.5b",
+    ),
     "llava-onevision-qwen2-0.5b-si-hf": partial(
         vlm.LLaVA_OneVision_HF, model_path="llava-hf/llava-onevision-qwen2-0.5b-si-hf"
     ),

--- a/vlmeval/vlm/__init__.py
+++ b/vlmeval/vlm/__init__.py
@@ -38,7 +38,7 @@ from .liquid import LFM2VL
 from .llama4 import llama4
 from .llama_vision import llama_vision
 from .llava import (LLaVA, LLaVA_Next, LLaVA_Next2, LLaVA_OneVision, LLaVA_OneVision_1_5,
-                    LLaVA_OneVision_HF, LLaVA_XTuner)
+                    LLaVA_OneVision_HF, LLaVA_OneVision_VQToken, LLaVA_XTuner)
 from .logics import Logics_Thinking
 from .long_vita import LongVITA
 from .mantis import Mantis

--- a/vlmeval/vlm/llava/__init__.py
+++ b/vlmeval/vlm/llava/__init__.py
@@ -1,8 +1,9 @@
 from .llava import (LLaVA, LLaVA_Next, LLaVA_Next2, LLaVA_OneVision, LLaVA_OneVision_1_5,
                     LLaVA_OneVision_HF)
 from .llava_xtuner import LLaVA_XTuner
+from .vqtoken import LLaVA_OneVision_VQToken
 
 __all__ = [
     'LLaVA', 'LLaVA_Next', 'LLaVA_XTuner', 'LLaVA_Next2', 'LLaVA_OneVision', 'LLaVA_OneVision_HF',
-    'LLaVA_OneVision_1_5'
+    'LLaVA_OneVision_1_5', 'LLaVA_OneVision_VQToken'
 ]

--- a/vlmeval/vlm/llava/llava.py
+++ b/vlmeval/vlm/llava/llava.py
@@ -489,7 +489,12 @@ class LLaVA_OneVision(BaseModel):
     DEFAULT_IMAGE_TOKEN = "<image>"
     IMAGE_TOKEN_INDEX = -200
 
-    def __init__(self, model_path="lmms-lab/llava-onevision-qwen2-7b-si", **kwargs):
+    def __init__(
+        self,
+        model_path="lmms-lab/llava-onevision-qwen2-7b-si",
+        model_name=None,
+        **kwargs,
+    ):
         assert model_path is not None
         try:
             from llava.conversation import SeparatorStyle, conv_templates
@@ -508,15 +513,17 @@ class LLaVA_OneVision(BaseModel):
         video_kwargs_default.update(kwargs)
         self.video_kwargs = video_kwargs_default
 
-        overwrite_config = None
+        resolved_overwrite_config = {}
         if "video" in model_path.lower():
             if self.video_kwargs["overwrite"]:
-                overwrite_config = {}
-                overwrite_config["mm_spatial_pool_mode"] = self.video_kwargs[
+                resolved_overwrite_config["mm_spatial_pool_mode"] = self.video_kwargs[
                     "mm_spatial_pool_mode"
                 ]
+        resolved_overwrite_config.update(self._get_model_overwrite_config())
+        if not resolved_overwrite_config:
+            resolved_overwrite_config = None
 
-        model_name = get_model_name_from_path(model_path)
+        model_name = model_name or get_model_name_from_path(model_path)
         import warnings
 
         # filter warning align with official code
@@ -526,7 +533,7 @@ class LLaVA_OneVision(BaseModel):
             None,
             model_name,
             device_map="auto",
-            overwrite_config=overwrite_config,
+            overwrite_config=resolved_overwrite_config,
         )
         model.eval()
         model.tie_weights()
@@ -556,6 +563,10 @@ class LLaVA_OneVision(BaseModel):
         )
         self.KeywordStoppingCriteria = KeywordsStoppingCriteria
         self.SeparatorStyle = SeparatorStyle
+
+    def _get_model_overwrite_config(self):
+        """Return model-specific config overrides for subclasses."""
+        return {}
 
     def generate_inner_image(self, message, dataset=None):
         content, images = "", []
@@ -628,7 +639,7 @@ class LLaVA_OneVision(BaseModel):
 
         time_instruciton = (
             f"The video lasts for {video_time:.2f} seconds,"
-            f"and {len(video_frames[0])} frames are uniformly sampled from it."
+            f"and {len(video_frames)} frames are uniformly sampled from it."
             f"These frames are located at {frame_time}."
             f"Please answer the following questions related to this video.\n"
         )
@@ -657,8 +668,8 @@ class LLaVA_OneVision(BaseModel):
             prompt_question, self.tokenizer, self.IMAGE_TOKEN_INDEX, return_tensors="pt"
         )
         input_ids = input_ids.unsqueeze(0).cuda()
-        image_sizes = [frame.size for frame in video_frames]
-        modalities = ["video"] * len(video_frames)
+        image_sizes = [(int(video_frames.shape[2]), int(video_frames.shape[1]))]
+        modalities = ["video"]
 
         stop_str = conv.sep if conv.sep_style != self.SeparatorStyle.TWO else conv.sep2
         keywords = [stop_str]
@@ -669,6 +680,7 @@ class LLaVA_OneVision(BaseModel):
         # Pass image sizes along with other parameters
         cont = self.model.generate(
             input_ids,
+            attention_mask=torch.ones_like(input_ids),
             images=image_tensors,
             image_sizes=image_sizes,  # Pass the image sizes here
             do_sample=False,
@@ -704,10 +716,11 @@ class LLaVA_OneVision(BaseModel):
         return spare_frames, frame_time, video_time
 
     def generate_inner(self, message, dataset=None):
-        if DATASET_MODALITY(dataset) == 'VIDEO' and 'megabench' not in dataset.lower():
+        if any(msg.get('type') == 'video' for msg in message):
             return self.generate_inner_video(message, dataset)
-        else:
-            return self.generate_inner_image(message, dataset)
+        if dataset is not None and DATASET_MODALITY(dataset) == 'VIDEO' and 'megabench' not in dataset.lower():
+            return self.generate_inner_video(message, dataset)
+        return self.generate_inner_image(message, dataset)
 
 
 class LLaVA_OneVision_HF(BaseModel):

--- a/vlmeval/vlm/llava/llava.py
+++ b/vlmeval/vlm/llava/llava.py
@@ -538,7 +538,7 @@ class LLaVA_OneVision(BaseModel):
         model.eval()
         model.tie_weights()
 
-        if "llava" in model_path.lower():
+        if "llava" in model_path.lower() or "llava" in model_name.lower():
             conv_mode = "qwen_1_5"
         if 'llava-video' in model_path.lower():
             self.nframe = 64

--- a/vlmeval/vlm/llava/vqtoken.py
+++ b/vlmeval/vlm/llava/vqtoken.py
@@ -1,0 +1,98 @@
+"""VLMEvalKit adapter for the public centroid VQToken release."""
+
+from importlib import import_module
+
+from .llava import LLaVA_OneVision
+
+SUPPORTED_SELECTION_METHODS = frozenset({'fixed', 'elbow', 'silhouette'})
+RUNTIME_INSTALL = ('llava[runtime] @ git+https://github.com/Hai-chao-Zhang/'
+                   'VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a')
+
+
+def validate_cluster_config(selection_method, min_clusters, max_clusters):
+    """Validate the public centroid-only VQToken configuration."""
+    if selection_method not in SUPPORTED_SELECTION_METHODS:
+        raise ValueError('vqtoken_selection_method must be one of '
+                         f'{sorted(SUPPORTED_SELECTION_METHODS)}, got {selection_method!r}')
+    if isinstance(min_clusters, bool) or not isinstance(min_clusters, int) or min_clusters < 1:
+        raise ValueError('vqtoken_min_clusters must be a positive integer')
+    if isinstance(max_clusters, bool) or not isinstance(max_clusters, int) or max_clusters < 1:
+        raise ValueError('vqtoken_max_clusters must be a positive integer')
+    if selection_method != 'fixed' and max_clusters < min_clusters:
+        raise ValueError('adaptive VQToken requires max_clusters to be greater than or equal to min_clusters')
+
+
+def require_vqtoken_runtime():
+    """Load the optional VQToken runtime and verify its public capabilities."""
+    try:
+        runtime = import_module('VQToken')
+    except ImportError as err:
+        raise ImportError(
+            f'VQToken requires its public LLaVA runtime. Install with: pip install "{RUNTIME_INSTALL}"') from err
+
+    capabilities = getattr(runtime, 'VQTOKEN_CAPABILITIES', {})
+    modes = set(capabilities.get('modes', ()))
+    methods = set(capabilities.get('selection_methods', ()))
+    if 'centroids' not in modes or not SUPPORTED_SELECTION_METHODS.issubset(methods):
+        raise ImportError('The installed VQToken runtime is too old for VLMEvalKit. '
+                          f'Upgrade with: pip install --upgrade "{RUNTIME_INSTALL}"')
+    return runtime
+
+
+class LLaVA_OneVision_VQToken(LLaVA_OneVision):
+    """Run VQToken centroid compression with the released OneVision checkpoint."""
+
+    def __init__(
+        self,
+        model_path='haichaozhang/VQ-Token-llava-ov-0.5b',
+        vqtoken_selection_method='fixed',
+        vqtoken_min_clusters=12,
+        vqtoken_max_clusters=32,
+        max_frames_num=32,
+        use_embedded_vision=None,
+        **kwargs,
+    ):
+        validate_cluster_config(
+            vqtoken_selection_method,
+            vqtoken_min_clusters,
+            vqtoken_max_clusters,
+        )
+        runtime = require_vqtoken_runtime()
+        if isinstance(max_frames_num, bool) or not isinstance(max_frames_num, int) or max_frames_num < 1:
+            raise ValueError('max_frames_num must be a positive integer')
+        if use_embedded_vision is None:
+            use_embedded_vision = model_path.rstrip('/') in {
+                'haichaozhang/VQ-Token-llava-ov-0.5b',
+                'lmms-lab/llava-onevision-qwen2-0.5b-ov',
+            }
+            detector = getattr(runtime, 'has_embedded_vision_weights', None)
+            if not use_embedded_vision and callable(detector):
+                use_embedded_vision = detector(model_path)
+
+        self._vqtoken_overwrite_config = {
+            'use_vqtoken': True,
+            'vqtoken_mode': 'centroids',
+            'vqtoken_selection_method': vqtoken_selection_method,
+            'vqtoken_min_clusters': vqtoken_min_clusters,
+            'vqtoken_max_clusters': vqtoken_max_clusters,
+            'use_embedded_vision': use_embedded_vision,
+            'mm_spatial_pool_stride': 2,
+            'mm_spatial_pool_mode': 'bilinear',
+        }
+        super().__init__(
+            model_path=model_path,
+            model_name='llava_qwen',
+            **kwargs,
+        )
+        self.nframe = max_frames_num
+        # The released evaluator uniformly samples exactly ``nframe`` frames,
+        # but does not add LLaVA-Video's timestamp instruction to the prompt.
+        self.force_sample = False
+
+    def _get_model_overwrite_config(self):
+        """Return a copy so the parent cannot mutate the adapter's settings."""
+        return dict(self._vqtoken_overwrite_config)
+
+    def load_video(self, video_path, max_frames_num, fps=1, force_sample=False):
+        """Match the released VQToken evaluator's uniform frame sampling."""
+        return super().load_video(video_path, max_frames_num, fps, True)

--- a/vlmeval/vlm/llava/vqtoken.py
+++ b/vlmeval/vlm/llava/vqtoken.py
@@ -1,16 +1,18 @@
-"""VLMEvalKit adapter for the public centroid VQToken release."""
+"""VLMEvalKit adapter for the public learned VQToken release."""
 
 from importlib import import_module
 
 from .llava import LLaVA_OneVision
 
 SUPPORTED_SELECTION_METHODS = frozenset({'fixed', 'elbow', 'silhouette'})
+SUPPORTED_VQTOKEN_MODES = frozenset({'attention', 'centroids'})
+RELEASED_MODEL_PATH = 'haichaozhang/VQ-Token-llava-ov-0.5b'
 RUNTIME_INSTALL = ('llava[runtime] @ git+https://github.com/Hai-chao-Zhang/'
-                   'VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd')
+                   'VQToken.git@0314eb9989a7ea843f31bfe0984113529e3f9140')
 
 
 def validate_cluster_config(selection_method, min_clusters, max_clusters):
-    """Validate the public centroid-only VQToken configuration."""
+    """Validate the public VQToken cluster-budget configuration."""
     if selection_method not in SUPPORTED_SELECTION_METHODS:
         raise ValueError('vqtoken_selection_method must be one of '
                          f'{sorted(SUPPORTED_SELECTION_METHODS)}, got {selection_method!r}')
@@ -19,32 +21,46 @@ def validate_cluster_config(selection_method, min_clusters, max_clusters):
     if isinstance(max_clusters, bool) or not isinstance(max_clusters, int) or max_clusters < 1:
         raise ValueError('vqtoken_max_clusters must be a positive integer')
     if selection_method != 'fixed' and max_clusters < min_clusters:
-        raise ValueError('adaptive VQToken requires max_clusters to be greater than or equal to min_clusters')
+        raise ValueError(
+            'adaptive VQToken requires max_clusters to be greater than or equal to min_clusters')
 
 
-def require_vqtoken_runtime():
+def validate_attention_frame_budget(selection_method, min_clusters, max_clusters, max_frames_num):
+    """Fail early when the learned attention path could receive more frames than K."""
+    smallest_budget = max_clusters if selection_method == 'fixed' else min_clusters
+    if max_frames_num > smallest_budget:
+        raise ValueError('learned VQ-Attention requires max_frames_num to be no greater than '
+                         f'the smallest possible token budget ({smallest_budget})')
+
+
+def require_vqtoken_runtime(required_mode='attention'):
     """Load the optional VQToken runtime and verify its public capabilities."""
+    if required_mode not in SUPPORTED_VQTOKEN_MODES:
+        raise ValueError('vqtoken_mode must be one of '
+                         f'{sorted(SUPPORTED_VQTOKEN_MODES)}, got {required_mode!r}')
     try:
         runtime = import_module('VQToken')
     except ImportError as err:
-        raise ImportError(
-            f'VQToken requires its public LLaVA runtime. Install with: pip install "{RUNTIME_INSTALL}"') from err
+        message = ('VQToken requires its public LLaVA runtime. Install with: '
+                   f'pip install "{RUNTIME_INSTALL}"')
+        raise ImportError(message) from err
 
     capabilities = getattr(runtime, 'VQTOKEN_CAPABILITIES', {})
     modes = set(capabilities.get('modes', ()))
     methods = set(capabilities.get('selection_methods', ()))
-    if 'centroids' not in modes or not SUPPORTED_SELECTION_METHODS.issubset(methods):
+    if required_mode not in modes or not SUPPORTED_SELECTION_METHODS.issubset(methods):
         raise ImportError('The installed VQToken runtime is too old for VLMEvalKit. '
                           f'Upgrade with: pip install --upgrade "{RUNTIME_INSTALL}"')
     return runtime
 
 
 class LLaVA_OneVision_VQToken(LLaVA_OneVision):
-    """Run VQToken centroid compression with the released OneVision checkpoint."""
+    """Run learned VQ-Attention with the released OneVision checkpoint."""
 
     def __init__(
         self,
-        model_path='haichaozhang/VQ-Token-llava-ov-0.5b',
+        model_path=RELEASED_MODEL_PATH,
+        vqtoken_mode='attention',
         vqtoken_selection_method='fixed',
         vqtoken_min_clusters=12,
         vqtoken_max_clusters=32,
@@ -57,12 +73,33 @@ class LLaVA_OneVision_VQToken(LLaVA_OneVision):
             vqtoken_min_clusters,
             vqtoken_max_clusters,
         )
-        runtime = require_vqtoken_runtime()
-        if isinstance(max_frames_num, bool) or not isinstance(max_frames_num, int) or max_frames_num < 1:
+        if isinstance(max_frames_num,
+                      bool) or not isinstance(max_frames_num, int) or max_frames_num < 1:
             raise ValueError('max_frames_num must be a positive integer')
+        if vqtoken_mode not in SUPPORTED_VQTOKEN_MODES:
+            raise ValueError('vqtoken_mode must be one of '
+                             f'{sorted(SUPPORTED_VQTOKEN_MODES)}, got {vqtoken_mode!r}')
+        if vqtoken_mode == 'attention':
+            validate_attention_frame_budget(
+                vqtoken_selection_method,
+                vqtoken_min_clusters,
+                vqtoken_max_clusters,
+                max_frames_num,
+            )
+        runtime = require_vqtoken_runtime(vqtoken_mode)
+        if vqtoken_mode == 'attention':
+            is_released_checkpoint = model_path.rstrip('/') == RELEASED_MODEL_PATH
+            detector = getattr(runtime, 'has_released_vq_attention_weights', None)
+            if not is_released_checkpoint and callable(detector):
+                is_released_checkpoint = detector(model_path)
+            if not is_released_checkpoint:
+                raise ValueError('learned VQ-Attention requires the released checkpoint '
+                                 f'{RELEASED_MODEL_PATH!r} or a local checkpoint with its exact '
+                                 'VQ-Attention weights; use vqtoken_mode="centroids" only for '
+                                 'an intentional centroid ablation')
         if use_embedded_vision is None:
             use_embedded_vision = model_path.rstrip('/') in {
-                'haichaozhang/VQ-Token-llava-ov-0.5b',
+                RELEASED_MODEL_PATH,
                 'lmms-lab/llava-onevision-qwen2-0.5b-ov',
             }
             detector = getattr(runtime, 'has_embedded_vision_weights', None)
@@ -71,7 +108,7 @@ class LLaVA_OneVision_VQToken(LLaVA_OneVision):
 
         self._vqtoken_overwrite_config = {
             'use_vqtoken': True,
-            'vqtoken_mode': 'centroids',
+            'vqtoken_mode': vqtoken_mode,
             'vqtoken_selection_method': vqtoken_selection_method,
             'vqtoken_min_clusters': vqtoken_min_clusters,
             'vqtoken_max_clusters': vqtoken_max_clusters,

--- a/vlmeval/vlm/llava/vqtoken.py
+++ b/vlmeval/vlm/llava/vqtoken.py
@@ -6,7 +6,7 @@ from .llava import LLaVA_OneVision
 
 SUPPORTED_SELECTION_METHODS = frozenset({'fixed', 'elbow', 'silhouette'})
 RUNTIME_INSTALL = ('llava[runtime] @ git+https://github.com/Hai-chao-Zhang/'
-                   'VQToken.git@a8e3e13e8415b575556dd779e890b77a74ecf52a')
+                   'VQToken.git@fe6c28fa5907ec97b4ac3f6fe0aaef80affbd9fd')
 
 
 def validate_cluster_config(selection_method, min_clusters, max_clusters):


### PR DESCRIPTION
## Summary

This adds `VQToken-LLaVA-OneVision-0.5B` as an independent VLMEvalKit model integration. It loads the released checkpoint with `model_name="llava_qwen"` and enables its learned VQ-Attention path by default, with fixed, elbow, or silhouette cluster-count selection.

The integration also fixes the inherited OneVision video boundary used by this method: one input video is one multimodal item, frame count and `(width, height)` are correct, generation receives an attention mask, and explicit video messages—including MEGABench—take the video path. The wrapper reproduces the released evaluator's uniform 32-frame sampling without adding a timestamp prompt.

## Runtime dependency and safety checks

- Depends on [Hai-chao-Zhang/VQToken#3](https://github.com/Hai-chao-Zhang/VQToken/pull/3).
- The install command pins public commit `0314eb9989a7ea843f31bfe0984113529e3f9140`, so reviewers can reproduce the learned-attention runtime before that PR merges.
- The released model defaults to `vqtoken_mode="attention"`; `vqtoken_mode="centroids"` remains available only as an explicit codebook-only ablation.
- Learned attention fails early unless the model is the released Hugging Face repository or a local checkpoint whose headers contain the exact released VQ-Attention weights. This prevents a base/unknown checkpoint from silently running randomly initialized attention.
- The adapter validates the runtime contract before model loading: sampled frames must be no greater than fixed K, or no greater than minimum K for adaptive selection.
- Unpublished long-video/controller/MLP experiments are not included.

## Validation

- `pytest -q tests/test_vqtoken.py`: 18 passed.
- `flake8 vlmeval/vlm/llava/vqtoken.py tests/test_vqtoken.py`: passed.
- `compileall` and `git diff --check`: passed.
- Exact pinned runtime import confirmed runtime version 2 with `attention` and all three public selection methods.

The earlier ungated-base A100 smoke only established the adapter/video boundary and centroid-ablation mechanics; it is not presented as learned-attention or paper-checkpoint benchmark evidence.

## Access note

The default paper checkpoint is public but Hugging Face currently reports `gated=auto`, so users must accept its access terms and authenticate before running `vlmutil check` or an evaluation. Smoke tests are not benchmark claims.
