### PR TITLE
[Fix] Update SciDocBench dataset URL and MD5

### DIFF
--- a/vlmeval/dataset/scidocbench.py
+++ b/vlmeval/dataset/scidocbench.py
@@ -782,10 +782,10 @@ class SciDocBench(ImageBaseDataset):
     TYPE = 'VQA'
 
     DATASET_URL = {
-        'SciDocBench': 'https://opencompass.openxlab.space/utils/VLMEvalKit/SciDocBench.tsv',
+        'SciDocBench': 'https://opencompass.openxlab.space/utils/VLMEval/SciDocBench.tsv',
     }
     DATASET_MD5 = {
-        'SciDocBench': None,
+        'SciDocBench': '31cbebfc13b886b33963728ad3715728',
     }
 
     def dump_image(self, line):


### PR DESCRIPTION
  ## Summary
  - Update SciDocBench `DATASET_URL` to the current `utils/VLMEval` path.
  - Add the MD5 checksum for the downloaded SciDocBench TSV.

  ## Verification
  - `pre-commit` hooks passed during commit.
  - Instantiated `SciDocBench('SciDocBench')` with temporary `LMUData`.
  - Loaded 150 rows and successfully built prompt 0.
  - Verified downloaded TSV MD5: `31cbebfc13b886b33963728ad3715728`.