### PR TITLE
[Fix] Handle missing images in Physics_yale

### DIFF
--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -1159,8 +1159,8 @@ class Physics_yale(ImageBaseDataset):
 
         # The image field can store the base64 encoded image or another question index (for saving space)
         if 'image' in data:
-            images = [toliststr(x) for x in data['image']]
-            data['image'] = [x[0] if len(x) == 1 else x for x in images]
+            images = [toliststr(x) if not pd.isna(x) else None for x in data['image']]
+            data['image'] = [x[0] if x is not None and len(x) == 1 else x for x in images]
             self.meta_only = False
 
         if 'image_path' in data:
@@ -1183,6 +1183,8 @@ class Physics_yale(ImageBaseDataset):
 
         if self.meta_only:
             tgt_path = toliststr(line['image_path'])
+        elif pd.isna(line['image']):
+            tgt_path = None
         else:
             tgt_path = self.dump_image(line)
 


### PR DESCRIPTION
## Summary

- preserve missing `image` values while normalizing Physics_yale data
- build text-only prompts for samples without images
- retain the `image_path` path for meta-only datasets introduced in #1470

## Motivation

The registered `Physics` dataset (MD5 `528d66b7365f9d4db2b58fdeadeade71`) contains 999 samples with an empty `image` field. Since #1470, `Physics_yale.__init__` calls `toliststr()` for every value, so the default `skip_noimg=False` path raises `NotImplementedError` before prompt construction.

This restores the earlier text-only behavior without reverting the meta-only `image_path` support.

## Validation

Replayed all 1,297 rows of the registered dataset layout in the `vlmevalkit_ocr` environment: 999 text-only prompts and 298 image prompts.