### PR TITLE
[Benchmark] Add support for CAPEval

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -9,6 +9,7 @@ from vlmeval.smp import LMUDataRoot, dump, get_intermediate_file_path, load, loc
 from .asclepius import Asclepius
 from .av_speakerbench import AVSpeakerBench
 from .babyvision import BabyVision
+from .capeval import CAPEval
 from .CGAVCounting.cg_av_counting import CGAVCounting
 from .cgbench import (CGBench_MCQ_Grounding, CGBench_MCQ_Grounding_Mini, CGBench_OpenEnded,
                       CGBench_OpenEnded_Mini)
@@ -310,7 +311,7 @@ IMAGE_DATASET = [
     SciDocBench, OmniMat,
     MMRarebenchDiagnosis, MMRarebenchTreatment, MMRarebenchCrossmodal, MMRarebenchExamination,
     MRareBenchDiagnosis, MRareBenchEvidenceVerif,
-    BabyVision, SUPERChemDataset,
+    BabyVision, SUPERChemDataset, CAPEval,
 ]
 
 # add by EASI team

--- a/vlmeval/dataset/capeval.py
+++ b/vlmeval/dataset/capeval.py
@@ -1,0 +1,250 @@
+"""CAPEval dataset for VLMEvalKit.
+
+Caption inference uses the official prompt. Checklist judging uses VLMEvalKit
+``build_judge`` with the official CAPEval single-pass protocol (same prompt /
+parser / C-P formulas as the paper).
+
+Data is auto-downloaded from Hugging Face to ``$LMUData/CAPEval/``
+(``checklist.jsonl`` + ``image/``). No extra clone or ``CAPEVAL_HOME`` is required.
+"""
+
+from __future__ import annotations
+import os.path as osp
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from vlmeval.dataset.image_base import ImageBaseDataset
+from vlmeval.dataset.utils import DEBUG_MESSAGE, build_judge
+from vlmeval.smp import LMUDataRoot, dump, get_intermediate_file_path, load, modelscope_flag_set
+from vlmeval.utils import track_progress_rich
+from .utils.capeval.evaluator import (CAPEval_atomeval, assemble_records, captions_from_eval_file,
+                                      load_cached_answers, pending_units, prepare_units,
+                                      records_to_score_df)
+from .utils.capeval.prompts import (CAPTION_PROMPT, PROMPT_VERSION, SINGLE_PASS_SYSTEM,
+                                    build_single_pass_user_prompt)
+from .utils.capeval.schema import EVALUATOR_VERSION, load_jsonl
+
+HF_REPO = 'LiuzhipengUCAS/CAPEval'
+EXPECTED_N_IMAGES = 300
+IMAGE_SUFFIXES = {'.jpg', '.jpeg', '.png', '.webp', '.bmp', '.gif', '.tif', '.tiff'}
+
+
+def _data_root() -> Path:
+    return Path(LMUDataRoot()) / 'CAPEval'
+
+
+def _count_images(image_dir: Path) -> int:
+    if not image_dir.is_dir():
+        return 0
+    return sum(
+        1 for p in image_dir.iterdir()
+        if p.is_file() and not p.name.startswith('.') and p.suffix.lower() in IMAGE_SUFFIXES
+    )
+
+
+def locate_capeval_files(root: Path) -> Optional[Tuple[Path, Path]]:
+    """Return ``(checklist.jsonl, image_dir)`` if a complete copy exists under ``root``."""
+    checklist_cands = [
+        root / 'checklist.jsonl',
+        root / 'data' / 'checklist.jsonl',
+    ]
+    image_cands = [
+        root / 'image',
+        root / 'images',
+        root / 'data' / 'image',
+        root / 'data' / 'images',
+    ]
+    checklist = next((p for p in checklist_cands if p.is_file()), None)
+    image_dir = next((p for p in image_cands if p.is_dir()), None)
+    if checklist is None or image_dir is None:
+        return None
+    if _count_images(image_dir) < EXPECTED_N_IMAGES:
+        return None
+    return checklist, image_dir
+
+
+def _snapshot_download(local_dir: Path) -> str:
+    """Same HF / ModelScope pattern as ViewSpatialBench, VsiBench, Video-MME, etc."""
+    repo = HF_REPO
+    if modelscope_flag_set():
+        from modelscope import dataset_snapshot_download
+        return dataset_snapshot_download(dataset_id=repo, local_dir=str(local_dir))
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        raise ImportError(
+            'CAPEval auto-download needs huggingface_hub (already in VLMEvalKit '
+            'requirements.txt). Install it, or place checklist.jsonl + image/ under '
+            f'$LMUData/CAPEval/ ({local_dir}).'
+        ) from e
+    return snapshot_download(repo_id=repo, repo_type='dataset', local_dir=str(local_dir))
+
+
+def ensure_capeval_data() -> Tuple[Path, Path]:
+    """Download CAPEval to ``$LMUData/CAPEval`` if needed.
+
+    Layout (Hugging Face ``LiuzhipengUCAS/CAPEval``)::
+
+        $LMUData/CAPEval/checklist.jsonl
+        $LMUData/CAPEval/image/*.jpg|jpeg|png|webp
+    """
+    root = _data_root()
+    found = locate_capeval_files(root)
+    if found is not None:
+        return found
+
+    root.mkdir(parents=True, exist_ok=True)
+    _snapshot_download(root)
+    found = locate_capeval_files(root)
+    if found is None:
+        raise FileNotFoundError(
+            f'Failed to prepare CAPEval under {root}. '
+            f'Expected checklist.jsonl and {EXPECTED_N_IMAGES} images '
+            f'(Hugging Face dataset {HF_REPO}).'
+        )
+    return found
+
+
+def _safe_model_name(model_name: str) -> str:
+    return str(model_name).replace('/', '_').replace(':', '_')
+
+
+class CAPEval(ImageBaseDataset):
+    """Caption → checklist judge. Dataset name for ``run.py --data``: ``CAPEval``."""
+
+    TYPE = 'VQA'
+    MODALITY = 'IMAGE'
+    DEFAULT_JUDGE = 'qwen-72b'
+    # Upstream hook in inference.py (same as BabyVision / MMESCI / SUPERChem):
+    # skip model.build_prompt so the official caption instruction is not replaced.
+    force_use_dataset_prompt = True
+    DATASET_URL = {'CAPEval': f'https://huggingface.co/datasets/{HF_REPO}'}
+    DATASET_MD5 = {}
+
+    def __init__(self, dataset='CAPEval', **kwargs):
+        super().__init__(dataset=dataset, skip_noimg=False)
+
+    @classmethod
+    def supported_datasets(cls) -> List[str]:
+        return ['CAPEval']
+
+    def load_data(self, dataset: str = 'CAPEval'):
+        checklist_path, image_root = ensure_capeval_data()
+        self.checklist_path = str(checklist_path)
+        self.image_root = str(image_root)
+
+        rows = []
+        for i, obj in enumerate(load_jsonl(str(checklist_path), checklist_rows_only=True)):
+            img_path = str(obj.get('img_path') or '').strip()
+            if not img_path:
+                continue
+            abs_img = image_root / Path(img_path).name
+            stem = Path(img_path).stem
+            prefix = ''.join(ch for ch in stem if ch.isalpha()) or 'unknown'
+            rows.append({
+                'index': i,
+                'image_id': img_path,
+                'image_path': str(abs_img),
+                'question': CAPTION_PROMPT,
+                'category': prefix.upper(),
+            })
+        if len(rows) < EXPECTED_N_IMAGES:
+            warnings.warn(
+                f'CAPEval checklist has {len(rows)} image rows; expected {EXPECTED_N_IMAGES}.'
+            )
+        return pd.DataFrame(rows)
+
+    def build_prompt(self, line) -> List[Dict[str, Any]]:
+        # ImageBaseDataset.build_prompt: meta_only → line['image_path']; else dump_image().
+        # CAPEval TSV-less rows have image_path only, so meta_only stays True.
+        msgs = super().build_prompt(line)
+        for m in msgs:
+            if m.get('type') == 'image' and not osp.isfile(str(m.get('value', ''))):
+                raise FileNotFoundError(f'CAPEval image not found: {m.get("value")}')
+        return msgs
+
+    def evaluate(self, eval_file: str, **judge_kwargs) -> Any:
+        """Score captions with ``build_judge`` + official CAPEval checklist protocol."""
+        nproc = judge_kwargs.pop('nproc', 4)
+        judge_kwargs.pop('use_vllm', None)
+        judge_kwargs.pop('use_verifier', None)
+
+        judge_model = judge_kwargs.pop('model', None) or self.DEFAULT_JUDGE
+        safe_model = _safe_model_name(judge_model)
+        cache_tag = f'{safe_model}_{PROMPT_VERSION}_{EVALUATOR_VERSION}'
+
+        storage = get_intermediate_file_path(eval_file, f'_{cache_tag}_judge', 'json')
+        tmp_file = get_intermediate_file_path(eval_file, f'_{cache_tag}_judge_tmp', 'pkl')
+        score_file = get_intermediate_file_path(eval_file, f'_{cache_tag}_score', 'csv')
+
+        data = load(eval_file)
+        captions = captions_from_eval_file(data)
+        if not captions:
+            raise RuntimeError(
+                f'No captions found in {eval_file}. '
+                'Expected a `prediction` column plus `image_id` / `image_path`.'
+            )
+
+        checklist_path = getattr(self, 'checklist_path', None)
+        if not checklist_path or not osp.isfile(checklist_path):
+            checklist_path, _ = ensure_capeval_data()
+            checklist_path = str(checklist_path)
+        units = prepare_units(captions, checklist_path)
+
+        ans = load_cached_answers(tmp_file, storage)
+        todo = pending_units(units, ans)
+        if todo:
+            model = build_judge(
+                model=judge_model,
+                temperature=0.0,
+                system_prompt=SINGLE_PASS_SYSTEM,
+                max_tokens=8192,
+                **judge_kwargs,
+            )
+            assert model.working(), (
+                'CAPEval evaluation requires a working judge API '
+                f'(default --judge {self.DEFAULT_JUDGE}).\n' + DEBUG_MESSAGE
+            )
+
+            tups = [
+                (model, build_single_pass_user_prompt(u['caption'], u['checklist_items']),
+                 len(u['checklist_items']))
+                for u in todo
+            ]
+            keys = [u['image_id'] for u in todo]
+            track_progress_rich(
+                CAPEval_atomeval,
+                tups,
+                nproc=nproc,
+                chunksize=nproc,
+                keys=keys,
+                save=tmp_file,
+            )
+            ans = load_cached_answers(tmp_file, storage)
+
+        records = assemble_records(units, ans)
+        for rec in records:
+            rec['judge_model'] = judge_model
+            rec['prompt_version'] = PROMPT_VERSION
+            rec['evaluator_version'] = EVALUATOR_VERSION
+        dump(records, storage)
+        ret = records_to_score_df(
+            records,
+            judge_model=judge_model,
+            prompt_version=PROMPT_VERSION,
+            evaluator_version=EVALUATOR_VERSION,
+        )
+        n_error = int(ret.iloc[0]['n_error'])
+        n_ok = int(ret.iloc[0]['n_images'])
+        if n_error:
+            warnings.warn(
+                f'CAPEval partial evaluation: {n_error} image(s) failed the judge; '
+                f'C/P are aggregated over {n_ok} successful image(s) only, '
+                f'not a full {EXPECTED_N_IMAGES}-image score. See eval_status=partial '
+                f'and n_error in {score_file}.'
+            )
+        dump(ret, score_file)
+        return ret

--- a/vlmeval/dataset/utils/capeval/__init__.py
+++ b/vlmeval/dataset/utils/capeval/__init__.py
@@ -1,0 +1,20 @@
+from .evaluator import (CAPEval_atomeval, assemble_records, captions_from_eval_file,
+                        load_cached_answers, pending_units, prepare_units, records_to_score_df)
+from .prompts import CAPTION_PROMPT, PROMPT_VERSION, SINGLE_PASS_SYSTEM
+from .schema import EVALUATOR_VERSION, canonicalize_verdict, validate_unit
+
+__all__ = [
+    'CAPTION_PROMPT',
+    'PROMPT_VERSION',
+    'EVALUATOR_VERSION',
+    'SINGLE_PASS_SYSTEM',
+    'CAPEval_atomeval',
+    'assemble_records',
+    'canonicalize_verdict',
+    'captions_from_eval_file',
+    'load_cached_answers',
+    'pending_units',
+    'prepare_units',
+    'records_to_score_df',
+    'validate_unit',
+]

--- a/vlmeval/dataset/utils/capeval/evaluator.py
+++ b/vlmeval/dataset/utils/capeval/evaluator.py
@@ -1,0 +1,166 @@
+"""CAPEval evaluate via VLMEvalKit ``build_judge``, official checklist protocol."""
+
+import os.path as osp
+from pathlib import Path
+
+import pandas as pd
+
+from vlmeval.smp import load
+from .schema import (CATEGORY_NAMES, aggregate_records, build_checklist_items_with_index,
+                     domain_from_img_path, load_jsonl, normalize_verdict_list,
+                     parse_single_pass_json, validate_unit)
+
+
+def captions_from_eval_file(data):
+    captions = {}
+    for _, row in data.iterrows():
+        pred = row.get('prediction', '')
+        if pred is None or (isinstance(pred, float) and str(pred) == 'nan'):
+            continue
+        key = row.get('image_id') or row.get('img_path')
+        if key is None or (isinstance(key, float) and str(key) == 'nan'):
+            img = row.get('image_path', row.get('image', ''))
+            key = Path(str(img)).name if img is not None else None
+        if not key:
+            continue
+        captions[str(Path(str(key)).name)] = str(pred)
+    return captions
+
+
+def load_checklist_by_image(checklist_path):
+    cl_by_img = {}
+    for r in load_jsonl(checklist_path, checklist_rows_only=True):
+        p = str(r.get('img_path') or '').strip()
+        if not p:
+            continue
+        cl_by_img[p] = r
+        cl_by_img[Path(p).name] = r
+    return cl_by_img
+
+
+def prepare_units(captions, checklist_path):
+    cl_by_img = load_checklist_by_image(checklist_path)
+    units = []
+    skipped = 0
+    for cap_key, caption in captions.items():
+        name = Path(str(cap_key)).name
+        cl_row = cl_by_img.get(name) or cl_by_img.get(str(cap_key))
+        if cl_row is None:
+            skipped += 1
+            continue
+        img_path = str(cl_row.get('img_path') or name).strip()
+        items = build_checklist_items_with_index(cl_row)
+        try:
+            validate_unit(img_path, caption, items)
+        except ValueError:
+            skipped += 1
+            continue
+        units.append({
+            'image_id': img_path,
+            'domain': domain_from_img_path(img_path),
+            'caption': caption,
+            'checklist_items': items,
+        })
+    if not units:
+        raise RuntimeError(
+            'No caption keys matched CAPEval checklist img_path '
+            f'(skipped={skipped}). Expected keys like SO001.jpg.'
+        )
+    return units
+
+
+def is_ok_record(rec):
+    return isinstance(rec, dict) and rec.get('status') == 'ok'
+
+
+def load_cached_answers(tmp_file, storage_file):
+    """Merge incremental pkl + final judge json. Tmp keys win over storage."""
+    ans = {}
+    if osp.exists(storage_file):
+        records = load(storage_file)
+        if isinstance(records, list):
+            for rec in records:
+                if isinstance(rec, dict) and rec.get('image_id'):
+                    ans[rec['image_id']] = rec
+        elif isinstance(records, dict):
+            ans.update(records)
+    if osp.exists(tmp_file):
+        loaded = load(tmp_file)
+        if isinstance(loaded, dict):
+            ans.update(loaded)
+    return ans
+
+
+def pending_units(units, ans):
+    """Skip successful cache hits; retry missing or ``status != ok`` records."""
+    return [u for u in units if not is_ok_record(ans.get(u['image_id']))]
+
+
+def CAPEval_atomeval(model, prompt, n_items):
+    """One image: official user prompt → judge.generate → parse verdicts."""
+    raw = model.generate(prompt)
+    parsed, err = parse_single_pass_json(raw, n_items)
+    if parsed is None:
+        return dict(status='error', error=err, raw_response=raw or '',
+                    yes1=0, no1=0, not_mentioned1=0, total1=0)
+    y, n, nm = normalize_verdict_list(parsed['verdicts'])
+    reasons = parsed.get('reasonings') or [''] * n_items
+    while len(reasons) < n_items:
+        reasons.append('')
+    return dict(
+        status='ok',
+        raw_response=raw or '',
+        yes1=y,
+        no1=n,
+        not_mentioned1=nm,
+        total1=n_items,
+        gt_verdicts=[
+            {
+                'item_index': j,
+                'verdict': parsed['verdicts'][j],
+                'reasoning': reasons[j],
+            }
+            for j in range(n_items)
+        ],
+    )
+
+
+def assemble_records(units, ans):
+    records = []
+    for u in units:
+        rec = dict(ans.get(u['image_id']) or {})
+        rec['image_id'] = u['image_id']
+        rec['domain'] = u['domain']
+        rec['caption'] = u['caption']
+        rec['checklist_items'] = u['checklist_items']
+        if not is_ok_record(rec) and 'status' not in rec:
+            rec.update(status='error', error='missing_judge_result',
+                       yes1=0, no1=0, not_mentioned1=0, total1=0)
+        records.append(rec)
+    return records
+
+
+def records_to_score_df(records, *, judge_model=None, prompt_version=None, evaluator_version=None):
+    metrics = aggregate_records(records)
+    summary = metrics['summary']
+    n_error = int(summary.get('n_error', 0) or 0)
+    n_ok = int(summary.get('n_images', 0) or 0)
+    row = {
+        'C': summary.get('C'),
+        'P': summary.get('P'),
+        'n_images': n_ok,
+        'n_error': n_error,
+        'eval_status': 'partial' if n_error else 'ok',
+    }
+    if judge_model is not None:
+        row['judge_model'] = judge_model
+    if prompt_version is not None:
+        row['prompt_version'] = prompt_version
+    if evaluator_version is not None:
+        row['evaluator_version'] = evaluator_version
+    inv = {v: k for k, v in CATEGORY_NAMES.items()}
+    for cat, blk in (metrics.get('per_category') or {}).items():
+        short = inv.get(cat, cat)
+        row[f'C_{short}'] = blk.get('C')
+        row[f'P_{short}'] = blk.get('P')
+    return pd.DataFrame([row])

--- a/vlmeval/dataset/utils/capeval/prompts.py
+++ b/vlmeval/dataset/utils/capeval/prompts.py
@@ -1,0 +1,58 @@
+"""Official CAPEval checklist-judge prompts. Keep verbatim for leaderboard comparability."""
+
+# Bump this (and judge cache suffix) if the caption / judge prompt text changes.
+PROMPT_VERSION = 'official-single-pass-v1'
+
+CAPTION_PROMPT = 'Analyze the image in a comprehensive and detailed manner.'
+
+SINGLE_PASS_SYSTEM = """You are an expert image-caption judge for a research benchmark.
+
+Behavior:
+- Apply a moderately strict standard: reward clear, accurate coverage; penalize contradictions.
+- When the caption is genuinely ambiguous about a checklist point, prefer "not_mentioned" over guessing "yes".
+- Use only the caption text and the checklist metadata provided; do not invent scene facts from prior knowledge.
+- Output must be one valid JSON object exactly in the form requested by the user—no markdown code fences, no text before or after."""  # noqa: E501
+
+
+def build_single_pass_user_prompt(caption, checklist_items):
+    lines = [
+        'Evaluate the CAPTION against each checklist item below.',
+        '',
+        'For each item_index, based ONLY on the caption, assign exactly one verdict:',
+        '  - "yes": the caption correctly covers the factual content that this checklist item is asking about—'
+        'the caption supports the proposition in the question without contradiction.',
+        '  - "no": the caption engages with the same topic as the question but contradicts it or is clearly inconsistent.',  # noqa: E501
+        '  - "not_mentioned": the caption does not address this checklist point (or is too vague to decide).',
+        'If the question is phrased negatively (e.g. whether something is absent), '
+        '"yes" means the caption is consistent with that negative claim—not that you are answering the word "yes" to English grammar.',  # noqa: E501
+        '',
+        'For every verdict you MUST include a short "reasoning" field (one concise sentence) explaining',
+        'the evidence from the caption (for calibration and auditing).',
+        '',
+        'CAPTION:',
+        caption,
+        '',
+        'CHECKLIST (metadata is for context; the Question text is primary):',
+        '  - item_index: stable id you must echo in gt_verdicts.',
+        '  - tag: fine-grained label for downstream analysis (e.g. color, spatial); do not replace the Question.',
+        '  - type: which checklist channel this question belongs to (e.g. attribute vs relation); use the Question as ground truth.',  # noqa: E501
+        '',
+    ]
+    for it in checklist_items:
+        lines.append(
+            f"  item_index={it['item_index']}  tag={it.get('tags', '')!r}  "
+            f"type={it['checklist_type']}  Q: {it['question']}"
+        )
+    lines.extend(
+        [
+            '',
+            'Return ONLY a JSON object (no markdown) with exactly this structure:',
+            '{"gt_verdicts":['
+            '{"item_index":<int>,"verdict":"yes"|"no"|"not_mentioned","reasoning":"<one short sentence>"},'
+            '...]}',
+            'Rules:',
+            '- Every item_index from the checklist must appear exactly once in gt_verdicts.',
+            '- Every gt_verdicts entry must include non-empty reasoning (at least a few words).',
+        ]
+    )
+    return '\n'.join(lines)

--- a/vlmeval/dataset/utils/capeval/schema.py
+++ b/vlmeval/dataset/utils/capeval/schema.py
@@ -1,0 +1,295 @@
+"""Checklist schema, verdict parsing, and C / P aggregation (official CAPEval protocol)."""
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+# Bump this (and judge cache suffix) if C/P aggregation or verdict parsing changes.
+EVALUATOR_VERSION = 'capeval-cp-v1'
+
+CHECKLIST_KEYS = [
+    'instance_checklist',
+    'attribute_checklist',
+    'relation_checklist',
+    'image_checklist',
+    'text_checklist',
+    'human_checklist',
+    'ui_checklist',
+    'world_knowledge_checklist',
+]
+
+CATEGORY_NAMES = {
+    'SO': 'Scene & Object',
+    'PA': 'People & Activity',
+    'TI': 'Text & Interface',
+    'DK': 'Design & Knowledge',
+}
+
+
+def flatten_items(entry):
+    items = []
+    for ck in CHECKLIST_KEYS:
+        for item in entry.get(ck, []) or []:
+            if not isinstance(item, dict):
+                continue
+            q = str(item.get('Question', '')).strip()
+            if q:
+                items.append({
+                    'checklist_type': ck,
+                    'tags': item.get('Tags', ''),
+                    'question': q,
+                })
+    return items
+
+
+def build_checklist_items_with_index(entry):
+    items = []
+    for idx, it in enumerate(flatten_items(entry)):
+        items.append({
+            'item_index': idx,
+            'checklist_type': it['checklist_type'],
+            'tags': it.get('tags', '') or '',
+            'tag': it.get('tags', '') or '',
+            'question': it['question'],
+        })
+    return items
+
+
+def split_raw_tag_field(tags):
+    if not tags or not str(tags).strip():
+        return []
+    parts = re.split(r'[,，;；|]+', str(tags).strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def domain_from_img_path(img_path):
+    stem = Path(str(img_path)).stem
+    prefix = []
+    for ch in stem:
+        if ch.isalpha():
+            prefix.append(ch)
+        else:
+            break
+    return ''.join(prefix).upper() if prefix else 'unknown'
+
+
+def load_jsonl(path, checklist_rows_only=False):
+    with open(path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    text = text.lstrip('\ufeff').strip()
+    if not text:
+        return []
+    dec = json.JSONDecoder()
+    rows = []
+    idx = 0
+    n = len(text)
+    while idx < n:
+        while idx < n and text[idx].isspace():
+            idx += 1
+        if idx >= n:
+            break
+        obj, end = dec.raw_decode(text, idx)
+        idx = end
+        if not isinstance(obj, dict):
+            continue
+        if checklist_rows_only and not any(obj.get(k) for k in CHECKLIST_KEYS):
+            continue
+        rows.append(obj)
+    return rows
+
+
+def _strip_think(text):
+    for sep in ('</think>', '</thinking>'):
+        if sep in text:
+            text = text.split(sep, 1)[-1]
+    return text.strip()
+
+
+# Exact tokens only (after light cleanup). Do not substring-match "yes" inside a sentence.
+_YES_TOKENS = frozenset({'yes', 'y', 'correct', 'correctly_mentioned', 'b'})
+_NO_TOKENS = frozenset({'no', 'n', 'incorrect', 'incorrectly_mentioned', 'c'})
+_NM_TOKENS = frozenset({
+    'not_mentioned', 'not mentioned', 'not-mentioned', 'notmentioned',
+    'nm', 'a', 'unknown', 'n/a', 'na',
+})
+
+
+def canonicalize_verdict(raw):
+    """Map a judge verdict token to ``yes`` / ``no`` / ``not_mentioned``.
+
+    Normalizes case, surrounding quotes, a trailing period, and
+    ``not mentioned`` / ``not_mentioned``. Returns ``None`` for free-form
+    text such as ``I think this should be yes because...`` so callers must
+    not treat that as ``yes``. Missing / invalid items are later filled as
+    ``not_mentioned`` (official CAPEval behavior).
+    """
+    if raw is None:
+        return None
+    ver = str(raw).strip().lower()
+    if not ver:
+        return None
+    ver = ver.strip('\'"').rstrip('.,;:').strip()
+    ver = re.sub(r'\s+', ' ', ver)
+    compact = ver.replace(' ', '_').replace('-', '_')
+    if ver in _YES_TOKENS or compact in _YES_TOKENS:
+        return 'yes'
+    if ver in _NO_TOKENS or compact in _NO_TOKENS:
+        return 'no'
+    nm_compact = {t.replace(' ', '_').replace('-', '_') for t in _NM_TOKENS}
+    if ver in _NM_TOKENS or compact in nm_compact:
+        return 'not_mentioned'
+    return None
+
+
+def validate_unit(image_id, caption, checklist_items):
+    """Raise ``ValueError`` if a scoring unit is missing required fields."""
+    if image_id is None or str(image_id).strip() in ('', 'nan', 'None'):
+        raise ValueError('image_id is required')
+    if caption is None:
+        raise ValueError(f'caption is required for image_id={image_id!r}')
+    if not checklist_items:
+        raise ValueError(f'checklist is empty for image_id={image_id!r}')
+    return True
+
+
+def parse_single_pass_json(raw, n_items):
+    text = _strip_think(raw or '')
+    m = re.search(r'\{[\s\S]*\}', text)
+    if m:
+        text = m.group(0)
+    decode_err = None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        decode_err = f'json_decode: {e}'
+        data = None
+    if data is None:
+        by_idx, by_reason = {}, {}
+        item_pat = re.compile(
+            r'\{[^{}]*?"item_index"\s*:\s*(\d+)[^{}]*?"verdict"\s*:\s*"([^"]*)"'
+            r'[^{}]*?"reasoning"\s*:\s*"([^"]*)"[^{}]*?\}',
+            re.S,
+        )
+        for mm in item_pat.finditer(text):
+            ver = canonicalize_verdict(mm.group(2))
+            if ver is None:
+                continue
+            ii = int(mm.group(1))
+            by_idx[ii] = ver
+            by_reason[ii] = mm.group(3).strip()
+        if by_idx:
+            return {
+                'verdicts': [by_idx.get(i, 'not_mentioned') for i in range(n_items)],
+                'reasonings': [by_reason.get(i, '') for i in range(n_items)],
+            }, None
+        return None, decode_err or 'json_decode_unknown'
+    if not isinstance(data, dict):
+        return None, 'root_not_object'
+    verdicts = data.get('gt_verdicts')
+    if not isinstance(verdicts, list):
+        return None, 'missing_gt_verdicts'
+
+    by_idx, by_reason = {}, {}
+    for v in verdicts:
+        if not isinstance(v, dict):
+            continue
+        idx = v.get('item_index')
+        if idx is None:
+            continue
+        try:
+            ii = int(idx)
+        except (TypeError, ValueError):
+            continue
+        ver = canonicalize_verdict(v.get('verdict', ''))
+        if ver is None:
+            # Invalid token: do not guess "yes" from prose. Official fill is not_mentioned.
+            continue
+        by_idx[ii] = ver
+        by_reason[ii] = str(v.get('reasoning', '') or '').strip()
+    return {
+        'verdicts': [by_idx.get(i, 'not_mentioned') for i in range(n_items)],
+        'reasonings': [by_reason.get(i, '') for i in range(n_items)],
+    }, None
+
+
+def normalize_verdict_list(verdicts):
+    y = n = nm = 0
+    for v in verdicts:
+        if v == 'yes':
+            y += 1
+        elif v == 'no':
+            n += 1
+        else:
+            nm += 1
+    return y, n, nm
+
+
+def _cp_percent(yes, no, total):
+    """Official CAPEval: C = 100*(yes+no)/total, P = 100*yes/(yes+no).
+
+    When ``yes + no == 0`` (nothing mentioned), P is 0.0 — same as the
+    official scorer, which guards the divide-by-zero.
+    """
+    c = 100.0 * (yes + no) / total if total else 0.0
+    mentioned = yes + no
+    p = 100.0 * yes / mentioned if mentioned else 0.0
+    return c, p
+
+
+def _empty_bucket():
+    return {
+        'yes1': 0, 'no1': 0, 'not_mentioned1': 0, 'total1': 0,
+        'n_images': 0, 'n_error': 0,
+    }
+
+
+def _summary_block(bucket):
+    sy, sn, st = bucket['yes1'], bucket['no1'], bucket['total1']
+    c, p = _cp_percent(sy, sn, st)
+    out = {
+        'C': round(c, 4),
+        'P': round(p, 4),
+        'yes1': sy,
+        'no1': sn,
+        'not_mentioned1': bucket['not_mentioned1'],
+        'total1': st,
+        'n_images': bucket['n_images'],
+    }
+    if bucket.get('n_error'):
+        out['n_error'] = int(bucket['n_error'])
+    return out
+
+
+def aggregate_records(records):
+    g = {
+        **_empty_bucket(),
+        'by_category': defaultdict(_empty_bucket),
+    }
+    for row in records:
+        if row.get('status') != 'ok':
+            g['n_error'] += 1
+            continue
+        y1 = int(row.get('yes1', 0) or 0)
+        n1 = int(row.get('no1', 0) or 0)
+        nm1 = int(row.get('not_mentioned1', 0) or 0)
+        t1 = int(row.get('total1', 0) or 0)
+        g['yes1'] += y1
+        g['no1'] += n1
+        g['not_mentioned1'] += nm1
+        g['total1'] += t1
+        g['n_images'] += 1
+        cat = CATEGORY_NAMES.get((row.get('domain') or '').upper(), row.get('domain') or 'unknown')
+        bc = g['by_category'][cat]
+        bc['yes1'] += y1
+        bc['no1'] += n1
+        bc['not_mentioned1'] += nm1
+        bc['total1'] += t1
+        bc['n_images'] += 1
+
+    order = list(CATEGORY_NAMES.values())
+    cats = sorted(g['by_category'].keys(), key=lambda x: (order.index(x) if x in order else 99, x))
+    return {
+        'summary': _summary_block(g),
+        'per_category': {name: _summary_block(g['by_category'][name]) for name in cats},
+    }


### PR DESCRIPTION
## Summary

Add CAPEval as an image caption benchmark.

The dataset has 300 images. The model produces a caption; a judge LLM scores it against checklist items and reports **Coverage (C) and Precision (P)**, with Scene & Object (SO) / People & Activity (PA) / Text & Interface (TI) / Design & Knowledge (DK) splits.

## Changes

- Register `CAPEval` in `IMAGE_DATASET`
- Add `vlmeval/dataset/capeval.py`
- Add helpers under `vlmeval/dataset/utils/capeval/`
- Auto-download from Hugging Face to `$LMUData/CAPEval/`

Implemented as `ImageBaseDataset` + `build_judge`. No changes to `run.py`, model backends, or shared judge code.

## Usage

```bash
python run.py --data CAPEval --model <VLM> --judge qwen-72b
```
--judge defaults to qwen-72b if omitted.

## References
https://github.com/liuzhipenggg/CAPEval
https://huggingface.co/datasets/LiuzhipengUCAS/CAPEval