### PR TITLE
[Feature] Support evaluating selected dataset indices

### DIFF
--- a/docs/en/Quickstart.md
+++ b/docs/en/Quickstart.md
@@ -78,6 +78,7 @@ We use `run.py` for evaluation. To use the script, you can use `$VLMEvalKit/run.
 **Arguments**
 
 - `--data (list[str])`: Set the dataset names that are supported in VLMEvalKit (names can be found in the codebase README).
+- `--data-indices (JSON object)`: Run only selected sample indices for each dataset. Dataset names must match `--data` (or the keys in `--config`).
 - `--model (list[str])`: Set the VLM names that are supported in VLMEvalKit (defined in `supported_VLM` in `vlmeval/config.py`).
 - `--mode (str, default to 'all', choices are ['all', 'infer'])`: When `mode` set to "all", will perform both inference and evaluation; when set to "infer", will only perform the inference.
 - `--api-nproc (int, default to 4)`: The number of threads for OpenAI API calling.
@@ -104,6 +105,17 @@ torchrun --nproc-per-node=8 run.py --data MMBench_DEV_EN MME SEEDBench_IMG --mod
 # Qwen-VL-Chat on MME. On a node with 2 GPU. Inference and Evaluation.
 torchrun --nproc-per-node=2 run.py --data MME --model qwen_chat --verbose
 ```
+
+To rerun only specific samples, pass their `index` values with `--data-indices`. The option works with local, distributed, and `--api-mode` inference. It also limits evaluation to those samples. Indices may be JSON integers or strings; the dataset name must exactly match the name passed to `--data`.
+
+```bash
+python run.py \
+  --data MMBench_DEV_EN \
+  --data-indices '{"MMBench_DEV_EN": [1203, 63384]}' \
+  --model qwen_chat
+```
+
+When using multiple datasets, add a mapping entry for each dataset that should be filtered. Datasets omitted from the mapping run in full. A missing index is reported as an error instead of being silently skipped.
 
 **Command for Evaluating Video Benchmarks**
 

--- a/docs/zh-CN/Quickstart.md
+++ b/docs/zh-CN/Quickstart.md
@@ -77,6 +77,7 @@ max_pixels=1280 * 28 * 28,
 **参数**
 
 - `--data (list[str])`: 设置在 VLMEvalKit 中支持的数据集名称（可以在代码库首页的 README 中找到支持的数据集列表）
+- `--data-indices (JSON object)`: 仅运行各数据集内指定的样本索引。数据集名称必须与 `--data`（或 `--config` 中的键）一致
 - `--model (list[str])`: 设置在 VLMEvalKit 中支持的 VLM 名称（在 `vlmeval/config.py` 中的 `supported_VLM` 中定义）
 - `--mode (str, 默认值为 'all', 可选值为 ['all', 'infer'])`：当 mode 设置为 "all" 时，将执行推理和评估；当设置为 "infer" 时，只执行推理
 - `--api-nproc (int, 默认值为 4)`: 调用 API 的线程数
@@ -103,6 +104,17 @@ torchrun --nproc-per-node=8 run.py --data MMBench_DEV_EN MME SEEDBench_IMG --mod
 # 在 MME 上使用 Qwen-VL-Chat。在具有 2 个 GPU 的节点上进行推理和评估。
 torchrun --nproc-per-node=2 run.py --data MME --model qwen_chat --verbose
 ```
+
+如需仅重跑部分样本，可通过 `--data-indices` 传入样本的 `index`。该参数支持本地、分布式和 `--api-mode` 推理，评测也会仅针对这些样本进行。索引可以是 JSON 整数或字符串；数据集名称必须与 `--data` 中的名称完全一致。
+
+```bash
+python run.py \
+  --data MMBench_DEV_EN \
+  --data-indices '{"MMBench_DEV_EN": [1203, 63384]}' \
+  --model qwen_chat
+```
+
+同时运行多个数据集时，可为每个需要筛选的数据集添加一个映射项；映射中未出现的数据集仍会完整运行。如果指定的索引不存在，程序会直接报错，而不会静默跳过。
 
 **用于评测视频多模态评测集的命令**
 

--- a/run.py
+++ b/run.py
@@ -58,11 +58,13 @@ from vlmeval.dataset.video_dataset_config import supported_video_datasets
 from vlmeval.inference import infer_data_job
 from vlmeval.inference_mt import infer_data_job_mt
 from vlmeval.inference_video import infer_data_job_video
-from vlmeval.smp import (MMBenchOfficialServer, build_eval_id, collect_run_benchmark_report,
+from vlmeval.smp import (MMBenchOfficialServer, build_eval_id, collect_run_benchmark_report, dump,
                          get_eval_file_format, get_logger, get_pred_file_format,
                          get_pred_file_path, githash, is_prediction_complete, listinstr, load,
                          load_env, prepare_reuse_files, proxy_set, setup_logger, timestr,
                          upsert_dataset_status, upsert_run_status)
+from vlmeval.utils.dataset_subset import (filter_frame_by_indices, parse_data_indices,
+                                          subset_dataset, validate_data_indices)
 from vlmeval.utils.result_transfer import MMMU_result_transfer, MMTBench_result_transfer
 
 logger = get_logger(__name__)
@@ -266,6 +268,42 @@ def build_dataset_from_cli(dataset_name, data_config, dataset_kwargs):
             extra_kwargs=dataset_kwargs,
         )
     return build_dataset(dataset_name, **dataset_kwargs)
+
+
+def apply_dataset_subset(dataset, dataset_name, data_indices):
+    requested_indices = data_indices.get(dataset_name)
+    if requested_indices is None:
+        return None
+
+    original_size, selected_size = subset_dataset(dataset, requested_indices)
+    logger.info(
+        f'Selected {selected_size}/{original_size} samples from {dataset_name} '
+        'with --data-indices.'
+    )
+    return requested_indices
+
+
+def trim_prediction_to_subset(result_file, requested_indices):
+    if requested_indices is None or not Path(result_file).exists():
+        return
+
+    predictions = load(result_file)
+    if isinstance(predictions, (list, dict)):
+        predictions = pd.DataFrame(predictions)
+    filtered = filter_frame_by_indices(predictions, requested_indices, require_all=False)
+    if len(filtered) != len(predictions):
+        dump(filtered, result_file)
+        logger.info(f'Trimmed reused predictions in {result_file} to {len(filtered)} selected samples.')
+
+
+def get_effective_reuse_aux(reuse_aux, requested_indices):
+    if requested_indices is not None and reuse_aux == 'all':
+        logger.info(
+            '--data-indices is set; evaluation auxiliary files will not be reused '
+            'because they may contain full-dataset results.'
+        )
+        return 'infer'
+    return reuse_aux
 
 
 def build_model_from_base_url(args):
@@ -525,6 +563,13 @@ You can launch the evaluation by setting either --data and --model or --config.
     parser.add_argument('--config', type=str, help='Path to the Config Json File')
     parser.add_argument('--data-config', type=str, default=None,
                         help='Custom dataset configs as a JSON dict string. Keys must match names passed to --data.')
+    parser.add_argument(
+        '--data-indices',
+        type=str,
+        default=None,
+        help='Run selected sample indices, as a JSON object keyed by dataset name. '
+             'Example: \'{"MMBench_DEV_EN": [1203, 63384]}\'.',
+    )
 
     # Work Dir & Mode
     parser.add_argument('--work-dir', type=str, default='./outputs', help='select the output directory')
@@ -601,6 +646,7 @@ You can launch the evaluation by setting either --data and --model or --config.
     args = parser.parse_args()
     try:
         args.data_config = load_data_config(args.data_config)
+        args.data_indices = parse_data_indices(args.data_indices)
     except ValueError as e:
         parser.error(str(e))
     if args.ignore:
@@ -620,6 +666,8 @@ def run_local_mode(args):
         args.data = list(cfg['data'].keys())
     else:
         assert len(args.data), '--data should be a list of data files'
+
+    validate_data_indices(args.data_indices, args.data)
 
     if 'MMEVAL_ROOT' in os.environ:
         args.work_dir = os.environ['MMEVAL_ROOT']
@@ -754,6 +802,9 @@ def run_local_mode(args):
                             )
                         continue
 
+                requested_indices = apply_dataset_subset(dataset, dataset_name, args.data_indices)
+                reuse_aux = get_effective_reuse_aux(args.reuse_aux, requested_indices)
+
                 judge_dataset_name = get_judge_dataset_name(dataset_name, args.data_config)
                 judge_kwargs = get_judge_kwargs(judge_dataset_name, dataset.TYPE, args)
                 judge_model = judge_kwargs.get('model', '')
@@ -767,7 +818,7 @@ def run_local_mode(args):
                         dataset=dataset,
                         result_file=result_file,
                         reuse=args.reuse,
-                        reuse_aux=args.reuse_aux,
+                        reuse_aux=reuse_aux,
                         retry_failed=not args.keep_failed,
                         judge_model=judge_model if args.mode != 'infer' else None,
                         world_size=WORLD_SIZE,
@@ -778,8 +829,9 @@ def run_local_mode(args):
                         dataset_name=dataset_name,
                         source_run=reuse_ctx['source_eval_id'],
                         judge_model=judge_model,
-                        reuse_aux=args.reuse_aux,
+                        reuse_aux=reuse_aux,
                     )
+                    trim_prediction_to_subset(result_file, requested_indices)
                     logger.info(judge_kwargs)
 
                 if WORLD_SIZE > 1:
@@ -1055,6 +1107,7 @@ def run_api_mode(args):
             f'Unknown adapter: {args.custom_prompt}. Available: {list(registry.keys())}'
 
     assert args.data, '--data must be set in API mode'
+    validate_data_indices(args.data_indices, args.data)
 
     # Prepare work dir and logging
     commit_id = githash(digits=8)
@@ -1126,6 +1179,9 @@ def run_api_mode(args):
                 logger.error(f'Dataset {ds_name} is not valid, will be skipped.')
                 continue
 
+            requested_indices = apply_dataset_subset(dataset, ds_name, args.data_indices)
+            reuse_aux = get_effective_reuse_aux(args.reuse_aux, requested_indices)
+
             # Prepare the result file.
             result_file = get_pred_file_path(
                 pred_root, model_name, ds_name, use_env_format=True)
@@ -1151,7 +1207,7 @@ def run_api_mode(args):
                 dataset=dataset,
                 result_file=result_file,
                 reuse=args.reuse,
-                reuse_aux=args.reuse_aux,
+                reuse_aux=reuse_aux,
                 retry_failed=not args.keep_failed,
                 judge_model=judge_model if args.mode != 'infer' else None,
                 world_size=1,
@@ -1163,8 +1219,9 @@ def run_api_mode(args):
                 prediction_file=result_file,
                 source_run=reuse_ctx['source_eval_id'],
                 judge_model=judge_model,
-                reuse_aux=args.reuse_aux,
+                reuse_aux=reuse_aux,
             )
+            trim_prediction_to_subset(result_file, requested_indices)
             if args.mode == 'eval' and not reuse_ctx['prediction_complete']:
                 logger.error(
                     f'No reusable completed prediction found for {model_name} x {ds_name}, '

--- a/tests/test_dataset_subset.py
+++ b/tests/test_dataset_subset.py
@@ -1,0 +1,79 @@
+import importlib.util
+import unittest
+
+import pandas as pd
+
+
+def _load_dataset_subset():
+    spec = importlib.util.spec_from_file_location(
+        'dataset_subset',
+        'vlmeval/utils/dataset_subset.py',
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeVideoDataset:
+
+    def __init__(self):
+        self.data = pd.DataFrame({
+            'index': [10, 20, 30],
+            'video': ['b.mp4', 'a.mp4', 'b.mp4'],
+        })
+        self.videos = ['a.mp4', 'b.mp4']
+
+
+class TestDatasetSubset(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.subset = _load_dataset_subset()
+
+    def test_parse_data_indices_normalizes_integer_and_string_indices(self):
+        parsed = self.subset.parse_data_indices(
+            '{"MMBench_DEV_EN": [1203, "sample-2"]}'
+        )
+        self.assertEqual(parsed, {'MMBench_DEV_EN': ['1203', 'sample-2']})
+
+    def test_parse_data_indices_rejects_invalid_or_duplicate_values(self):
+        invalid_values = [
+            '[]',
+            '{"MME": []}',
+            '{"MME": [true]}',
+            '{"MME": [1, "1"]}',
+        ]
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                self.subset.parse_data_indices(value)
+
+    def test_validate_data_indices_rejects_unselected_dataset(self):
+        with self.assertRaisesRegex(ValueError, 'not selected'):
+            self.subset.validate_data_indices({'MME': ['1']}, ['MMBench_DEV_EN'])
+
+    def test_filter_frame_matches_index_types_and_preserves_dataset_order(self):
+        frame = pd.DataFrame({'index': [3, 1, 2], 'question': ['c', 'a', 'b']})
+        filtered = self.subset.filter_frame_by_indices(frame, ['2', '3'])
+        self.assertEqual(filtered['index'].tolist(), [3, 2])
+        self.assertEqual(filtered['question'].tolist(), ['c', 'b'])
+
+    def test_filter_frame_reports_missing_indices(self):
+        frame = pd.DataFrame({'index': [1, 2]})
+        with self.assertRaisesRegex(ValueError, '3'):
+            self.subset.filter_frame_by_indices(frame, ['2', '3'])
+
+    def test_filter_frame_can_keep_available_incomplete_predictions(self):
+        frame = pd.DataFrame({'index': [1, 4], 'prediction': ['a', 'd']})
+        filtered = self.subset.filter_frame_by_indices(frame, ['1', '2'], require_all=False)
+        self.assertEqual(filtered['index'].tolist(), [1])
+
+    def test_subset_dataset_refreshes_video_list(self):
+        dataset = FakeVideoDataset()
+        original_size, selected_size = self.subset.subset_dataset(dataset, ['10', '30'])
+        self.assertEqual((original_size, selected_size), (3, 2))
+        self.assertEqual(dataset.data['index'].tolist(), [10, 30])
+        self.assertEqual(dataset.videos, ['b.mp4'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -6,10 +6,13 @@ import os
 import pickle
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from pathlib import Path
 from unittest import mock
+
+import pandas as pd
 
 
 def _dump(obj, path):
@@ -91,7 +94,47 @@ class FakeCrashEvalDataset:
         os._exit(1)
 
 
+class FakeSubsetDataset:
+    data = pd.DataFrame({'index': [2, 3]})
+
+
 class TestInferenceApiProcessHelpers(unittest.TestCase):
+
+    def test_load_checkpoint_ignores_results_outside_dataset_subset(self):
+        inference_api = _load_inference_api()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result_file = str(Path(tmpdir) / 'mock_Subset.xlsx')
+            cfg = inference_api.DatasetConfig(
+                dataset_name='Subset',
+                dataset_obj=FakeSubsetDataset(),
+                model_name='mock',
+                model_obj=None,
+                work_dir=tmpdir,
+                result_file=result_file,
+                judge_kwargs={},
+            )
+            checkpoint_file = Path(tmpdir) / 'mock_Subset_checkpoint.pkl'
+            _dump({'1': 'old-1', '2': 'old-2'}, checkpoint_file)
+            _dump(
+                pd.DataFrame({
+                    'index': [1, 2, 3],
+                    'prediction': ['result-1', 'result-2', 'result-3'],
+                }),
+                result_file,
+            )
+
+            pipeline = inference_api.APIEvalPipeline.__new__(inference_api.APIEvalPipeline)
+            pipeline.states = {'Subset': cfg}
+            pipeline.retry_failed = True
+            pipeline.file_locks = {'Subset': threading.Lock()}
+
+            self.assertEqual(
+                pipeline._load_checkpoint('Subset'),
+                {'2': 'result-2', '3': 'result-3'},
+            )
+            pipeline._save_checkpoint('Subset', {'index': '3', 'prediction': 'new-3'})
+            self.assertEqual(_load(checkpoint_file), {'2': 'old-2', '3': 'new-3'})
 
     def test_async_wait_process_observes_abrupt_exit(self):
         inference_api = _load_inference_api()

--- a/vlmeval/inference_api.py
+++ b/vlmeval/inference_api.py
@@ -317,12 +317,17 @@ class APIEvalPipeline:
         """Load finished inference result from previous runs."""
         cfg = self.states[dataset_name]
         results = {}
+        selected_indices = {str(index) for index in cfg.dataset_obj.data['index']}
 
         # 1. Try to load checkpoint at first.
         checkpoint_file = self._get_checkpoint_file(dataset_name)
         if checkpoint_file.exists():
             try:
-                results = load(str(checkpoint_file))
+                results = {
+                    str(index): prediction
+                    for index, prediction in load(str(checkpoint_file)).items()
+                    if str(index) in selected_indices
+                }
                 if self.retry_failed:
                     results = {k: v for k, v in results.items() if FAIL_MSG not in str(v)}
                 logger.info(f"   [{dataset_name}] Loaded {len(results)} results from checkpoint")
@@ -334,17 +339,20 @@ class APIEvalPipeline:
         if result_path.exists():
             try:
                 data = load(str(result_path))
+                if isinstance(data, (list, dict)):
+                    data = pd.DataFrame(data)
                 if isinstance(data, pd.DataFrame):
                     if self.retry_failed:
                         existing_results = {
                             str(idx): pred
                             for idx, pred in zip(data['index'], data['prediction'])
-                            if FAIL_MSG not in str(pred)
+                            if str(idx) in selected_indices and FAIL_MSG not in str(pred)
                         }
                     else:
                         existing_results = {
                             str(idx): pred
                             for idx, pred in zip(data['index'], data['prediction'])
+                            if str(idx) in selected_indices
                         }
                     results.update(existing_results)
                     logger.info(f"   [{dataset_name}] Loaded {len(existing_results)} "
@@ -352,19 +360,25 @@ class APIEvalPipeline:
             except Exception as e:
                 logger.warning(f"   [{dataset_name}] Failed to load result file: {e}")
 
-        return results
+        return {index: prediction for index, prediction in results.items() if index in selected_indices}
 
     def _save_checkpoint(self, dataset_name: str, result: dict):
         """Save results to checkpoint file threading-safety."""
+        cfg = self.states[dataset_name]
         checkpoint_file = self._get_checkpoint_file(dataset_name)
 
         with self.file_locks[dataset_name]:
+            selected_indices = {str(index) for index in cfg.dataset_obj.data['index']}
             if checkpoint_file.exists():
-                results = load(str(checkpoint_file))
+                results = {
+                    str(index): prediction
+                    for index, prediction in load(str(checkpoint_file)).items()
+                    if str(index) in selected_indices
+                }
             else:
                 results = {}
 
-            results[result['index']] = result['prediction']
+            results[str(result['index'])] = result['prediction']
 
             dump(results, str(checkpoint_file))
 

--- a/vlmeval/utils/dataset_subset.py
+++ b/vlmeval/utils/dataset_subset.py
@@ -1,0 +1,77 @@
+import json
+from numbers import Integral
+
+import pandas as pd
+
+
+def _normalize_requested_index(value):
+    if isinstance(value, bool) or not isinstance(value, (Integral, str)):
+        raise ValueError('dataset indices must be integers or strings')
+    if isinstance(value, str) and not value:
+        raise ValueError('dataset indices must not be empty strings')
+    return str(value)
+
+
+def parse_data_indices(raw_value):
+    """Parse the JSON mapping accepted by ``--data-indices``."""
+    if raw_value is None:
+        return {}
+    try:
+        config = json.loads(raw_value)
+    except (TypeError, json.JSONDecodeError) as e:
+        raise ValueError('Unable to parse --data-indices as a JSON object') from e
+
+    if not isinstance(config, dict):
+        raise ValueError('--data-indices must be a JSON object keyed by dataset name')
+
+    parsed = {}
+    for dataset_name, indices in config.items():
+        if not isinstance(dataset_name, str) or not dataset_name:
+            raise ValueError('--data-indices keys must be non-empty dataset names')
+        if not isinstance(indices, list) or not indices:
+            raise ValueError(f'--data-indices[{dataset_name!r}] must be a non-empty JSON list')
+
+        normalized = [_normalize_requested_index(index) for index in indices]
+        if len(normalized) != len(set(normalized)):
+            raise ValueError(f'--data-indices[{dataset_name!r}] contains duplicate indices')
+        parsed[dataset_name] = normalized
+    return parsed
+
+
+def validate_data_indices(data_indices, dataset_names):
+    unknown = sorted(set(data_indices) - set(dataset_names))
+    if unknown:
+        raise ValueError(
+            '--data-indices contains datasets that are not selected by --data/--config: '
+            + ', '.join(unknown)
+        )
+
+
+def filter_frame_by_indices(frame, requested_indices, *, require_all=True):
+    """Return rows matching requested indices, preserving their source order."""
+    if not isinstance(frame, pd.DataFrame):
+        raise ValueError('dataset data must be a pandas DataFrame')
+    if 'index' not in frame:
+        raise ValueError('dataset data must contain an index column')
+
+    normalized = frame['index'].map(str)
+    requested = set(requested_indices)
+    if require_all:
+        available = set(normalized)
+        missing = [index for index in requested_indices if index not in available]
+        if missing:
+            raise ValueError('requested dataset indices were not found: ' + ', '.join(missing))
+
+    return frame.loc[normalized.isin(requested)].copy().reset_index(drop=True)
+
+
+def subset_dataset(dataset, requested_indices):
+    """Restrict a dataset object to selected sample indices in-place."""
+    original_size = len(dataset.data)
+    dataset.data = filter_frame_by_indices(dataset.data, requested_indices)
+
+    if hasattr(dataset, 'videos') and 'video' in dataset.data:
+        selected_videos = set(dataset.data['video'])
+        dataset.videos = [video for video in dataset.videos if video in selected_videos]
+
+    return original_size, len(dataset.data)


### PR DESCRIPTION
## Summary

- add `--data-indices` as a JSON mapping from dataset names to sample indices
- apply the subset consistently in local, distributed, and async API modes
- keep video pack metadata and reused prediction/checkpoint files scoped to the selected samples
- avoid reusing full-dataset evaluation auxiliary files for subset runs
- document the option in the English and Chinese quickstarts

This lets users rerun a few problematic samples without rebuilding a custom dataset. Unknown datasets, missing indices, invalid values, and duplicates fail explicitly instead of being silently skipped.

```bash
python run.py --data MMBench_DEV_EN --data-indices '{"MMBench_DEV_EN": [1203, 63384]}' --model qwen_chat
```

Closes #1474.

## Tests

- `python -m unittest discover -s tests -p 'test_dataset_subset.py'`
- `python tests/test_inference_api.py TestInferenceApiProcessHelpers.test_load_checkpoint_ignores_results_outside_dataset_subset`
- `pre-commit run --files run.py vlmeval/inference_api.py vlmeval/utils/dataset_subset.py tests/test_dataset_subset.py tests/test_inference_api.py docs/en/Quickstart.md docs/zh-CN/Quickstart.md`

## AI assistance

Implementation and tests were prepared with OpenAI Codex assistance and manually validated before submission.
