### PR TITLE
[Feature] Add multi-turn chat for Kimi-VL, Aria, and Phi-4

### DIFF
--- a/tests/test_vlm_chat_inner.py
+++ b/tests/test_vlm_chat_inner.py
@@ -1,0 +1,246 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from PIL import Image
+
+
+class FakeBaseModel:
+    pass
+
+
+class FakeInputs(dict):
+
+    def __init__(self):
+        super().__init__(input_ids=FakeInputIds(), pixel_values=FakeTensor())
+        self.input_ids = [[1, 2]]
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class FakeInputIds:
+    shape = (1, 2)
+
+    def size(self, dim):
+        return self.shape[dim]
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class FakeTensor:
+
+    def to(self, *args, **kwargs):
+        return self
+
+    def cpu(self):
+        return self
+
+    def __getitem__(self, key):
+        return self
+
+
+class FakeGenerated:
+
+    def __iter__(self):
+        return iter([[1, 2, 3]])
+
+    def __getitem__(self, key):
+        return FakeTensor()
+
+
+def _base_modules():
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = ['vlmeval']
+    vlm = types.ModuleType('vlmeval.vlm')
+    vlm.__path__ = ['vlmeval/vlm']
+    base = types.ModuleType('vlmeval.vlm.base')
+    base.BaseModel = FakeBaseModel
+    return {
+        'vlmeval': vlmeval,
+        'vlmeval.vlm': vlm,
+        'vlmeval.vlm.base': base,
+    }
+
+
+def _load_vlm_module(module_name, extra_modules=None):
+    modules = _base_modules()
+    modules.update(extra_modules or {})
+    full_name = f'vlmeval.vlm.{module_name}'
+    with mock.patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location(full_name, f'vlmeval/vlm/{module_name}.py')
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full_name] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop(full_name, None)
+        return module
+
+
+class FakeKimiProcessor:
+
+    def __init__(self):
+        self.messages = None
+        self.images = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.messages = messages
+        return 'kimi-prompt'
+
+    def __call__(self, *, images, text, **kwargs):
+        self.images = images
+        self.text = text
+        return FakeInputs()
+
+    def batch_decode(self, *args, **kwargs):
+        return ['kimi-answer']
+
+
+class FakeAriaProcessor:
+
+    def __init__(self):
+        self.messages = None
+        self.images = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.messages = messages
+        return 'aria-prompt'
+
+    def __call__(self, *, text, images=None, **kwargs):
+        self.images = images
+        return FakeInputs()
+
+
+class FakePhiProcessor:
+
+    def __init__(self):
+        self.prompt = None
+        self.images = None
+
+    def __call__(self, *, text, images, **kwargs):
+        self.prompt = text
+        self.images = images
+        return FakeInputs()
+
+    def batch_decode(self, *args, **kwargs):
+        return ['phi-answer']
+
+
+class FakeModel:
+    device = 'cuda'
+    dtype = 'bfloat16'
+
+    def generate(self, **kwargs):
+        return FakeGenerated()
+
+
+class FakeTokenizer:
+
+    def decode(self, *args, **kwargs):
+        return 'aria-answer<|im_end|>'
+
+
+class TestVLMChatInner(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.image_path = str(Path(self.tempdir.name) / 'image.png')
+        Image.new('RGB', (2, 2), color='white').save(self.image_path)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_kimi_chat_inner_preserves_turns_and_images(self):
+        transformers = types.ModuleType('transformers')
+        transformers.AutoModelForCausalLM = object
+        transformers.AutoProcessor = object
+        module = _load_vlm_module('kimi_vl', {'transformers': transformers})
+
+        model = module.KimiVL.__new__(module.KimiVL)
+        model.processor = FakeKimiProcessor()
+        model.model = FakeModel()
+        model.temperature = 0.0
+        model.max_tokens = 32
+        model.extract_summary = False
+
+        response = model.chat_inner([
+            {'role': 'user', 'content': [
+                {'type': 'image', 'value': self.image_path},
+                {'type': 'text', 'value': 'Describe this.'},
+            ]},
+            {'role': 'assistant', 'content': [{'type': 'text', 'value': 'A white square.'}]},
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'What color?'}]},
+        ])
+
+        self.assertEqual(response, 'kimi-answer')
+        self.assertEqual([turn['role'] for turn in model.processor.messages], ['user', 'assistant', 'user'])
+        self.assertEqual(len(model.processor.images), 1)
+        self.assertEqual(model.processor.messages[-1]['content'], [{'type': 'text', 'text': 'What color?'}])
+
+    def test_aria_chat_inner_uses_native_chat_template(self):
+        dataset = types.ModuleType('vlmeval.dataset')
+        dataset.DATASET_MODALITY = lambda name: 'IMAGE'
+        dataset.DATASET_TYPE = lambda name: 'VQA'
+        smp = types.ModuleType('vlmeval.smp')
+        smp.listinstr = lambda needles, value: any(needle in value for needle in needles)
+        torch = types.ModuleType('torch')
+        torch.bfloat16 = 'bfloat16'
+        torch.cuda = types.SimpleNamespace(empty_cache=lambda: None)
+        module = _load_vlm_module('aria', {
+            'torch': torch,
+            'vlmeval.dataset': dataset,
+            'vlmeval.smp': smp,
+        })
+
+        model = module.Aria.__new__(module.Aria)
+        model.processor = FakeAriaProcessor()
+        model.tokenizer = FakeTokenizer()
+        model.model = FakeModel()
+        model.kwargs = {'max_new_tokens': 16}
+
+        response = model.chat_inner([
+            {'role': 'user', 'content': [
+                {'type': 'image', 'value': self.image_path},
+                {'type': 'text', 'value': 'Describe this.'},
+            ]},
+            {'role': 'assistant', 'content': [{'type': 'text', 'value': 'A white square.'}]},
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'What color?'}]},
+        ], dataset=None)
+
+        self.assertEqual(response, 'aria-answer')
+        self.assertEqual([turn['role'] for turn in model.processor.messages], ['user', 'assistant', 'user'])
+        self.assertEqual(len(model.processor.images), 1)
+        self.assertEqual(model.processor.messages[0]['content'][0], {'type': 'image'})
+
+    def test_phi4_chat_inner_numbers_images_across_turns(self):
+        module = _load_vlm_module('phi4_multimodal')
+        model = module.Phi4Multimodal.__new__(module.Phi4Multimodal)
+        model.processor = FakePhiProcessor()
+        model.model = FakeModel()
+        model.generation_config = object()
+
+        response = model.chat_inner([
+            {'role': 'user', 'content': [
+                {'type': 'image', 'value': self.image_path},
+                {'type': 'text', 'value': 'Describe this.'},
+            ]},
+            {'role': 'assistant', 'content': [{'type': 'text', 'value': 'A white square.'}]},
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'What color?'}]},
+        ])
+
+        self.assertEqual(response, 'phi-answer')
+        self.assertEqual(len(model.processor.images), 1)
+        self.assertEqual(
+            model.processor.prompt,
+            '<|user|><|image_1|>Describe this.<|end|>'
+            '<|assistant|>A white square.<|end|>'
+            '<|user|>What color?<|end|><|assistant|>',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlmeval/vlm/aria.py
+++ b/vlmeval/vlm/aria.py
@@ -206,3 +206,45 @@ class Aria(BaseModel):
         answer = self.tokenizer.decode(pred[0][encoded['input_ids'].size(1):].cpu(), skip_special_tokens=True).strip()
         answer = answer.replace('<|im_end|>', '')
         return answer
+
+    def chat_inner(self, message, dataset=None):
+        assert len(message) % 2 == 1 and message[-1]['role'] == 'user'
+
+        messages = []
+        images = []
+        for turn in message:
+            content = []
+            for item in turn['content']:
+                if item['type'] == 'image':
+                    content.append({'type': 'image'})
+                    images.append(Image.open(item['value']).convert('RGB'))
+                elif item['type'] == 'text':
+                    content.append({'type': 'text', 'text': item['value']})
+            messages.append({'role': turn['role'], 'content': content})
+
+        prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True)
+        kwargs = self.adjust_kwargs(dataset) if dataset is not None else cp.deepcopy(self.kwargs)
+        max_image_size = kwargs.pop('max_image_size', 980)
+        split_image = kwargs.pop('split_image', False)
+
+        if images:
+            encoded = self.processor(
+                text=prompt,
+                images=images,
+                return_tensors='pt',
+                padding='longest',
+                max_image_size=max_image_size,
+                split_image=split_image,
+            )
+        else:
+            encoded = self.processor(text=prompt, return_tensors='pt', padding='longest')
+        if 'pixel_values' in encoded:
+            encoded['pixel_values'] = encoded['pixel_values'].to(self.model.dtype)
+        encoded = {key: value.to(self.model.device) for key, value in encoded.items()}
+
+        pred = self.model.generate(**encoded, **kwargs)
+        answer = self.tokenizer.decode(
+            pred[0][encoded['input_ids'].size(1):].cpu(),
+            skip_special_tokens=True,
+        ).strip()
+        return answer.replace('<|im_end|>', '')

--- a/vlmeval/vlm/kimi_vl.py
+++ b/vlmeval/vlm/kimi_vl.py
@@ -120,6 +120,9 @@ class KimiVL(BaseModel):
         messages = [
             {'role': 'user', 'content': prompt}
         ]
+        return self._generate_from_messages(messages, images, dataset=dataset)
+
+    def _generate_from_messages(self, messages, images, dataset=None):
         text = self.processor.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt")
         inputs = self.processor(
             images=images, text=text,
@@ -142,3 +145,14 @@ class KimiVL(BaseModel):
             if dataset in ["MMMU_DEV_VAL", "MMStar"]:
                 response = extract_boxed_content(response)
         return response
+
+    def chat_inner(self, message, dataset=None):
+        assert len(message) % 2 == 1 and message[-1]['role'] == 'user'
+
+        messages = []
+        images = []
+        for turn in message:
+            content, turn_images = self.message_to_promptimg(turn['content'], dataset=dataset)
+            messages.append({'role': turn['role'], 'content': content})
+            images.extend(turn_images)
+        return self._generate_from_messages(messages, images, dataset=dataset)

--- a/vlmeval/vlm/phi4_multimodal.py
+++ b/vlmeval/vlm/phi4_multimodal.py
@@ -55,3 +55,32 @@ class Phi4Multimodal(BaseModel):
             generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
         )[0]
         return response
+
+    def chat_inner(self, message, dataset=None):
+        assert len(message) % 2 == 1 and message[-1]['role'] == 'user'
+
+        prompt = ''
+        images = []
+        for turn in message:
+            prompt += f"<|{turn['role']}|>"
+            for item in turn['content']:
+                if item['type'] == 'image':
+                    images.append(Image.open(item['value']).convert('RGB'))
+                    prompt += f'<|image_{len(images)}|>'
+                elif item['type'] == 'text':
+                    prompt += item['value']
+            prompt += '<|end|>'
+        prompt += '<|assistant|>'
+
+        inputs = self.processor(text=prompt, images=images, return_tensors='pt').to('cuda')
+        generate_ids = self.model.generate(
+            **inputs,
+            max_new_tokens=1000,
+            generation_config=self.generation_config,
+        )
+        generate_ids = generate_ids[:, inputs['input_ids'].shape[1]:]
+        return self.processor.batch_decode(
+            generate_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0]


### PR DESCRIPTION
## Summary

Add multi-turn `chat_inner` support for three existing VLM adapters:

- Kimi-VL
- Aria
- Phi-4 Multimodal

This implements the three-model contribution unit requested in #323. Each adapter now preserves alternating user/assistant history, interleaved images, and the model's native conversation format.

## Implementation

- Kimi-VL reuses its existing multimodal content conversion and chat template for the full conversation.
- Aria passes role-aware multimodal history through the processor's native chat template.
- Phi-4 Multimodal builds the documented `<|role|>...<|end|>` history and numbers image placeholders across turns.
- New offline tests verify turn order, image handling, native prompt construction, generation, and response decoding without downloading model weights.

The model capabilities and formats were checked against the official model cards:

- https://huggingface.co/moonshotai/Kimi-VL-A3B-Thinking
- https://huggingface.co/rhymes-ai/Aria
- https://huggingface.co/microsoft/Phi-4-multimodal-instruct

## Tests

- `python -m unittest discover -s tests -p 'test_vlm_chat_inner.py'`
- `python -m py_compile vlmeval/vlm/kimi_vl.py vlmeval/vlm/aria.py vlmeval/vlm/phi4_multimodal.py tests/test_vlm_chat_inner.py`
- `pre-commit run --files vlmeval/vlm/kimi_vl.py vlmeval/vlm/aria.py vlmeval/vlm/phi4_multimodal.py tests/test_vlm_chat_inner.py`

## AI assistance

Implementation and tests were prepared with OpenAI Codex assistance and manually validated before submission.
