### PR TITLE
Add Japanese Heron-Bench support

### DIFF
--- a/tests/test_heron_bench.py
+++ b/tests/test_heron_bench.py
@@ -1,0 +1,224 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pandas as pd
+
+
+class FakeImageBaseDataset:
+
+    def dump_image(self, line):
+        return [line['image_path']]
+
+
+class FakeJudge:
+
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.prompts = []
+
+    def working(self):
+        return True
+
+    def generate(self, prompt):
+        self.prompts.append(prompt)
+        return next(self.responses)
+
+
+def _load_module():
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = ['vlmeval']
+    dataset = types.ModuleType('vlmeval.dataset')
+    dataset.__path__ = ['vlmeval/dataset']
+    image_base = types.ModuleType('vlmeval.dataset.image_base')
+    image_base.ImageBaseDataset = FakeImageBaseDataset
+    dataset_utils = types.ModuleType('vlmeval.dataset.utils')
+    dataset_utils.DEBUG_MESSAGE = 'debug'
+    dataset_utils.build_judge = mock.Mock()
+    llavabench = types.ModuleType('vlmeval.dataset.utils.llavabench')
+    llavabench.build_prompt = lambda line: f"BASE:{line['question']}\n"
+    smp = types.ModuleType('vlmeval.smp')
+    smp.dump = mock.Mock()
+    smp.get_intermediate_file_path = mock.Mock()
+    smp.load = mock.Mock()
+    utils = types.ModuleType('vlmeval.utils')
+    utils.track_progress_rich = mock.Mock()
+    huggingface_hub = types.ModuleType('huggingface_hub')
+    huggingface_hub.snapshot_download = mock.Mock()
+
+    modules = {
+        'vlmeval': vlmeval,
+        'vlmeval.dataset': dataset,
+        'vlmeval.dataset.image_base': image_base,
+        'vlmeval.dataset.utils': dataset_utils,
+        'vlmeval.dataset.utils.llavabench': llavabench,
+        'vlmeval.smp': smp,
+        'vlmeval.utils': utils,
+        'huggingface_hub': huggingface_hub,
+    }
+    name = 'vlmeval.dataset.heron_bench'
+    with mock.patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location(name, 'vlmeval/dataset/heron_bench.py')
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop(name, None)
+        return module
+
+
+class TestHeronBench(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_module()
+
+    def test_parse_score_accepts_official_formats(self):
+        parse = self.module.parse_heron_score
+        self.assertEqual(parse('8 9\nexplanation'), [8.0, 9.0])
+        self.assertEqual(parse('8.5, 9\nexplanation'), [8.5, 9.0])
+        self.assertEqual(parse('8   9'), [8.0, 9.0])
+
+    def test_parse_score_rejects_malformed_or_out_of_range_values(self):
+        parse = self.module.parse_heron_score
+        self.assertEqual(parse('scores: 8 9'), [-1.0, -1.0])
+        self.assertEqual(parse('0 9'), [-1.0, -1.0])
+        self.assertEqual(parse('8 11'), [-1.0, -1.0])
+
+    def test_score_uses_unweighted_mean_of_official_categories(self):
+        data = pd.DataFrame([
+            {'category': 'conv', 'gpt4_score': 10, 'score': 5},
+            {'category': 'detail', 'gpt4_score': 5, 'score': 5},
+            {'category': 'detail', 'gpt4_score': 5, 'score': 5},
+            {'category': 'complex', 'gpt4_score': 4, 'score': 2},
+            {'category': 'complex', 'gpt4_score': -1, 'score': -1},
+        ])
+        result = self.module.heron_bench_score(data)
+        by_split = result.set_index('split')
+
+        self.assertAlmostEqual(by_split.loc['conv', 'Relative Score (main)'], 50.0)
+        self.assertAlmostEqual(by_split.loc['detail', 'Relative Score (main)'], 100.0)
+        self.assertAlmostEqual(by_split.loc['complex', 'Relative Score (main)'], 50.0)
+        self.assertAlmostEqual(by_split.loc['overall', 'Relative Score (main)'], 200 / 3)
+        self.assertEqual(by_split.loc['overall', 'Valid Samples'], 4)
+        self.assertEqual(by_split.loc['overall', 'Parse Errors'], 1)
+
+    def test_load_data_joins_official_questions_answers_and_images(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / 'images').mkdir()
+            for image_id in range(1, 22):
+                (root / 'images' / f'{image_id:03}.jpg').write_bytes(b'image')
+
+            questions = []
+            answers = []
+            for question_id in range(self.module.HERON_BENCH_SAMPLES):
+                category = self.module.HERON_CATEGORIES[question_id % 3]
+                questions.append({
+                    'question_id': question_id,
+                    'image': f'{question_id % 21 + 1:03}.jpg',
+                    'category': category,
+                    'image_category': 'landscape',
+                    'context': f'context {question_id}',
+                    'text': f'question {question_id}',
+                })
+                answers.append({
+                    'question_id': question_id,
+                    'text': f'answer {question_id}',
+                })
+
+            for name, records in (
+                ('questions_ja.jsonl', questions),
+                ('answers_gpt4.jsonl', answers),
+            ):
+                with (root / name).open('w', encoding='utf-8') as f:
+                    for record in records:
+                        f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+            with mock.patch.object(self.module, 'snapshot_download', return_value=str(root)):
+                benchmark = self.module.HeronBench.__new__(self.module.HeronBench)
+                data = benchmark.load_data(self.module.HERON_BENCH_DATASET)
+
+            self.assertEqual(len(data), self.module.HERON_BENCH_SAMPLES)
+            self.assertEqual(data.iloc[0]['question'], 'question 0')
+            self.assertEqual(data.iloc[0]['gpt4_ans'], 'answer 0')
+            self.assertTrue(Path(data.iloc[-1]['image_path']).is_file())
+
+    def test_build_prompt_keeps_japanese_question_unmodified(self):
+        benchmark = self.module.HeronBench.__new__(self.module.HeronBench)
+        line = {'image_path': '/tmp/example.jpg', 'question': '何が見えますか？'}
+        self.assertEqual(benchmark.build_prompt(line), [
+            {'type': 'image', 'value': '/tmp/example.jpg'},
+            {'type': 'text', 'value': '何が見えますか？'},
+        ])
+
+    def test_judge_prompt_includes_official_low_score_instruction(self):
+        prompt = self.module.build_heron_judge_prompt({'question': '質問'})
+        self.assertIn('BASE:質問', prompt)
+        self.assertIn('give it a low score', prompt)
+
+    def test_evaluate_runs_pairwise_judge_and_aggregates_scores(self):
+        data = pd.DataFrame([
+            {
+                'index': 0, 'caption': 'context', 'question': 'conv question',
+                'gpt4_ans': 'reference', 'prediction': 'candidate', 'category': 'conv',
+            },
+            {
+                'index': 1, 'caption': 'context', 'question': 'detail question',
+                'gpt4_ans': 'reference', 'prediction': 'candidate', 'category': 'detail',
+            },
+            {
+                'index': 2, 'caption': 'context', 'question': 'complex question',
+                'gpt4_ans': 'reference', 'prediction': 'candidate', 'category': 'complex',
+            },
+        ])
+        judge = FakeJudge(['10 5\nreason', '5 5\nreason', '4 2\nreason'])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eval_file = str(root / 'predictions.xlsx')
+            Path(eval_file).touch()
+            storage = {eval_file: data}
+
+            def intermediate(_, suffix, extension='xlsx'):
+                return str(root / f'{suffix}.{extension}')
+
+            def load(path):
+                value = storage[str(path)]
+                return value.copy() if hasattr(value, 'copy') else value
+
+            def dump(value, path):
+                storage[str(path)] = value.copy() if hasattr(value, 'copy') else value
+                Path(path).touch()
+
+            def run_jobs(func, jobs, **kwargs):
+                return [func(*job) for job in jobs]
+
+            with (
+                mock.patch.object(self.module, 'get_intermediate_file_path', side_effect=intermediate),
+                mock.patch.object(self.module, 'load', side_effect=load),
+                mock.patch.object(self.module, 'dump', side_effect=dump),
+                mock.patch.object(self.module, 'build_judge', return_value=judge) as build_judge,
+                mock.patch.object(self.module, 'track_progress_rich', side_effect=run_jobs),
+            ):
+                result = self.module.HeronBench.evaluate(
+                    eval_file, model='fake-judge', nproc=2
+                )
+
+        overall = result.set_index('split').loc['overall']
+        self.assertAlmostEqual(overall['Relative Score (main)'], 66.67, places=2)
+        self.assertEqual(len(judge.prompts), 3)
+        self.assertTrue(all('give it a low score' in prompt for prompt in judge.prompts))
+        build_judge.assert_called_once_with(
+            model='fake-judge',
+            system_prompt=self.module.HERON_SYSTEM_PROMPT,
+            temperature=0,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -44,6 +44,7 @@ from .GUI.screenspot_pro import ScreenSpot_Pro
 from .GUI.screenspot_v2 import ScreenSpotV2
 from .GUI.vbgd import VBGD
 from .GUI.venusbench import VenusBench_GD
+from .heron_bench import HeronBench
 from .hipho import HiPhODataset
 from .image_base import ImageBaseDataset, img_root_map
 from .image_caption import ImageCaptionDataset
@@ -312,7 +313,7 @@ IMAGE_DATASET = [
     SciDocBench, OmniMat,
     MMRarebenchDiagnosis, MMRarebenchTreatment, MMRarebenchCrossmodal, MMRarebenchExamination,
     MRareBenchDiagnosis, MRareBenchEvidenceVerif,
-    BabyVision, WildprobeDataset, PerceptionBench, SUPERChemDataset,
+    BabyVision, WildprobeDataset, HeronBench, PerceptionBench, SUPERChemDataset,
 ]
 
 # add by EASI team

--- a/vlmeval/dataset/heron_bench.py
+++ b/vlmeval/dataset/heron_bench.py
@@ -1,0 +1,282 @@
+import json
+import os.path as osp
+import re
+
+import numpy as np
+import pandas as pd
+from huggingface_hub import snapshot_download
+
+from vlmeval.smp import dump, get_intermediate_file_path, load
+from vlmeval.utils import track_progress_rich
+from .image_base import ImageBaseDataset
+from .utils import DEBUG_MESSAGE, build_judge
+from .utils.llavabench import build_prompt as build_llavabench_prompt
+
+HERON_BENCH_DATASET = 'Japanese-Heron-Bench'
+HERON_BENCH_REPO = 'turing-motors/Japanese-Heron-Bench'
+HERON_BENCH_REVISION = 'dabd13314f2eac26204b982ec098049fdbbd1322'
+HERON_BENCH_SAMPLES = 103
+HERON_CATEGORIES = ('conv', 'detail', 'complex')
+HERON_SYSTEM_PROMPT = 'You are a helpful and precise assistant for checking the quality of the answer.'
+HERON_SCORE_PATTERN = re.compile(
+    r'^\s*(-?(?:\d+(?:\.\d*)?|\.\d+))\s*(?:,|\s)\s*'
+    r'(-?(?:\d+(?:\.\d*)?|\.\d+))\s*$'
+)
+
+
+def _load_jsonl(path):
+    records = []
+    with open(path, encoding='utf-8') as f:
+        for line_number, line in enumerate(f, 1):
+            if not line.strip():
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as err:
+                raise ValueError(f'Invalid JSON in {path} at line {line_number}') from err
+    return records
+
+
+def _safe_model_name(model_name):
+    return re.sub(r'[^0-9A-Za-z_.-]+', '_', str(model_name))
+
+
+def parse_heron_score(review):
+    """Parse the official two-score first line returned by the judge."""
+    first_line = str(review).strip().splitlines()[0] if str(review).strip() else ''
+    match = HERON_SCORE_PATTERN.fullmatch(first_line)
+    if match is None:
+        return [-1.0, -1.0]
+
+    scores = [float(match.group(1)), float(match.group(2))]
+    if not all(1 <= score <= 10 for score in scores):
+        return [-1.0, -1.0]
+    return scores
+
+
+def build_heron_judge_prompt(line):
+    """Build the pairwise prompt used by the official Heron evaluator."""
+    prompt = build_llavabench_prompt(line)
+    return (
+        prompt
+        + 'If it is not relevant to the context, does not answer directly, or says the wrong thing, '
+        + 'give it a low score.\n\n'
+    )
+
+
+def heron_bench_atomeval(model, prompt):
+    return parse_heron_score(model.generate(prompt))
+
+
+def heron_bench_score(data):
+    """Aggregate category-relative scores following the official Heron protocol."""
+    required = {'category', 'gpt4_score', 'score'}
+    missing = required.difference(data.columns)
+    if missing:
+        raise ValueError(f'Heron-Bench score data is missing columns: {sorted(missing)}')
+
+    rows = []
+    for category in HERON_CATEGORIES:
+        category_data = data[data['category'] == category]
+        valid = category_data[
+            category_data['gpt4_score'].between(1, 10)
+            & category_data['score'].between(1, 10)
+        ]
+        parse_errors = len(category_data) - len(valid)
+        if len(valid):
+            reference_score = float(valid['gpt4_score'].mean() * 10)
+            model_score = float(valid['score'].mean() * 10)
+            relative_score = float(model_score / reference_score * 100)
+        else:
+            reference_score = np.nan
+            model_score = np.nan
+            relative_score = np.nan
+        rows.append({
+            'split': category,
+            'Relative Score (main)': relative_score,
+            'VLM Score': model_score,
+            'GPT4 Score': reference_score,
+            'Valid Samples': len(valid),
+            'Parse Errors': parse_errors,
+        })
+
+    valid_rows = [row for row in rows if not np.isnan(row['Relative Score (main)'])]
+    overall = {
+        'split': 'overall',
+        'Relative Score (main)': (
+            float(np.mean([row['Relative Score (main)'] for row in valid_rows]))
+            if valid_rows else np.nan
+        ),
+        'VLM Score': (
+            float(np.mean([row['VLM Score'] for row in valid_rows]))
+            if valid_rows else np.nan
+        ),
+        'GPT4 Score': (
+            float(np.mean([row['GPT4 Score'] for row in valid_rows]))
+            if valid_rows else np.nan
+        ),
+        'Valid Samples': sum(row['Valid Samples'] for row in rows),
+        'Parse Errors': sum(row['Parse Errors'] for row in rows),
+    }
+    return pd.DataFrame([overall] + rows)
+
+
+class HeronBench(ImageBaseDataset):
+    """Japanese Heron-Bench VQA dataset and LLM-as-a-judge evaluation.
+
+    Paper: https://arxiv.org/abs/2404.07824
+    Dataset: https://huggingface.co/datasets/turing-motors/Japanese-Heron-Bench
+    The downloaded images retain the per-item terms documented in ``LICENCE.md``.
+    """
+
+    TYPE = 'VQA'
+    MODALITY = 'IMAGE'
+    DEFAULT_JUDGE = 'gpt-4o'
+    DATASET_URL = {
+        HERON_BENCH_DATASET: f'https://huggingface.co/datasets/{HERON_BENCH_REPO}',
+    }
+
+    @classmethod
+    def supported_datasets(cls):
+        return [HERON_BENCH_DATASET]
+
+    def load_data(self, dataset):
+        if dataset != HERON_BENCH_DATASET:
+            raise ValueError(f'Unsupported Heron-Bench dataset: {dataset}')
+
+        dataset_path = snapshot_download(
+            repo_id=HERON_BENCH_REPO,
+            repo_type='dataset',
+            revision=HERON_BENCH_REVISION,
+            allow_patterns=[
+                'questions_ja.jsonl',
+                'answers_gpt4.jsonl',
+                'images/*.jpg',
+                'LICENCE.md',
+                'README.md',
+            ],
+        )
+        question_path = osp.join(dataset_path, 'questions_ja.jsonl')
+        answer_path = osp.join(dataset_path, 'answers_gpt4.jsonl')
+        self.data_path = question_path
+
+        questions = _load_jsonl(question_path)
+        answers = _load_jsonl(answer_path)
+        if len(questions) != HERON_BENCH_SAMPLES or len(answers) != HERON_BENCH_SAMPLES:
+            raise ValueError(
+                f'Expected {HERON_BENCH_SAMPLES} Heron-Bench questions and answers, '
+                f'got {len(questions)} and {len(answers)}'
+            )
+
+        answer_map = {}
+        for answer in answers:
+            question_id = answer.get('question_id')
+            if question_id in answer_map:
+                raise ValueError(f'Duplicate Heron-Bench answer question_id: {question_id}')
+            answer_map[question_id] = answer
+
+        rows = []
+        seen_question_ids = set()
+        for question in questions:
+            question_id = question.get('question_id')
+            if question_id in seen_question_ids:
+                raise ValueError(f'Duplicate Heron-Bench question_id: {question_id}')
+            seen_question_ids.add(question_id)
+
+            if question_id not in answer_map:
+                raise ValueError(f'Missing Heron-Bench reference answer for question_id {question_id}')
+            if question.get('category') not in HERON_CATEGORIES:
+                raise ValueError(
+                    f'Unknown Heron-Bench category for question_id {question_id}: '
+                    f'{question.get("category")}'
+                )
+
+            image_path = osp.join(dataset_path, 'images', str(question.get('image', '')))
+            if not osp.isfile(image_path):
+                raise FileNotFoundError(
+                    f'Missing Heron-Bench image for question_id {question_id}: {image_path}'
+                )
+
+            answer = answer_map[question_id]
+            rows.append({
+                'index': question_id,
+                'image_path': image_path,
+                'question': str(question.get('text', '')),
+                'caption': str(question.get('context', '')),
+                'category': question['category'],
+                'image_category': str(question.get('image_category', '')),
+                'answer': str(answer.get('text', '')),
+                'gpt4_ans': str(answer.get('text', '')),
+            })
+
+        extra_answers = set(answer_map).difference(seen_question_ids)
+        if extra_answers:
+            raise ValueError(
+                f'Heron-Bench has reference answers without questions: {sorted(extra_answers)}'
+            )
+        return pd.DataFrame(rows)
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+        image_paths = self.dump_image(line)
+        messages = [dict(type='image', value=path) for path in image_paths]
+        messages.append(dict(type='text', value=str(line['question'])))
+        return messages
+
+    @classmethod
+    def evaluate(cls, eval_file, **judge_kwargs):
+        judge_model_name = judge_kwargs.pop('model', cls.DEFAULT_JUDGE)
+        nproc = int(judge_kwargs.pop('nproc', 4))
+        judge_kwargs.setdefault('temperature', 0)
+
+        safe_model_name = _safe_model_name(judge_model_name)
+        record_file = get_intermediate_file_path(
+            eval_file, f'_{safe_model_name}_heron_judge'
+        )
+        checkpoint_file = get_intermediate_file_path(
+            eval_file, f'_{safe_model_name}_heron_judge_tmp', 'pkl'
+        )
+        score_file = get_intermediate_file_path(
+            eval_file, f'_{safe_model_name}_heron_score', 'csv'
+        )
+
+        if not osp.exists(record_file):
+            data = load(eval_file)
+            required = {
+                'index', 'caption', 'question', 'gpt4_ans', 'prediction', 'category',
+            }
+            missing = required.difference(data.columns)
+            if missing:
+                raise ValueError(f'Heron-Bench eval file is missing columns: {sorted(missing)}')
+
+            scores = load(checkpoint_file) if osp.exists(checkpoint_file) else {}
+            pending = [data.iloc[i] for i in range(len(data)) if data.iloc[i]['index'] not in scores]
+            if pending:
+                judge = build_judge(
+                    model=judge_model_name,
+                    system_prompt=HERON_SYSTEM_PROMPT,
+                    **judge_kwargs,
+                )
+                assert judge.working(), (
+                    'Heron-Bench evaluation requires a working judge API\n' + DEBUG_MESSAGE
+                )
+                keys = [line['index'] for line in pending]
+                prompts = [build_heron_judge_prompt(line) for line in pending]
+                new_scores = track_progress_rich(
+                    heron_bench_atomeval,
+                    [(judge, prompt) for prompt in prompts],
+                    nproc=nproc,
+                    chunksize=nproc,
+                    keys=keys,
+                    save=checkpoint_file,
+                )
+                scores.update(zip(keys, new_scores))
+
+            data['gpt4_score'] = [scores[index][0] for index in data['index']]
+            data['score'] = [scores[index][1] for index in data['index']]
+            dump(data, record_file)
+
+        result = heron_bench_score(load(record_file)).round(2)
+        dump(result, score_file)
+        return result


### PR DESCRIPTION
## Summary

- register `Japanese-Heron-Bench` as a supported image VQA dataset
- download a pinned snapshot of the official `turing-motors/Japanese-Heron-Bench` data and validate all 103 question/reference pairs and image paths
- implement the official pairwise LLM-as-a-judge protocol, including category-relative aggregation across `conv`, `detail`, and `complex`
- cache per-sample judge results so interrupted evaluations can resume without repeating paid API calls
- add offline coverage for data preparation, prompts, score parsing, aggregation, and the end-to-end mocked judge path

The implementation downloads the original images at runtime and retains the dataset's per-image `LICENCE.md`; no benchmark images are redistributed in this repository.

Closes #1011

## Validation

- `python -m unittest -v tests/test_heron_bench.py` (7 tests passed)
- `python -m py_compile vlmeval/dataset/heron_bench.py vlmeval/dataset/__init__.py tests/test_heron_bench.py`
- `pre-commit run --files vlmeval/dataset/heron_bench.py vlmeval/dataset/__init__.py tests/test_heron_bench.py`
- downloaded the pinned official snapshot, loaded all 103 rows, verified all 21 unique images with Pillow, and built the first inference prompt successfully

## AI assistance

OpenAI Codex assisted with implementation and testing. I reviewed the resulting code, source alignment, and test outputs before submission.
