### PR TITLE
[Feature] Add multi-turn chat for Gemma 3, Mantis, and Pixtral

### DIFF
--- a/tests/test_vlm_chat_inner_gemma_mantis_pixtral.py
+++ b/tests/test_vlm_chat_inner_gemma_mantis_pixtral.py
@@ -1,0 +1,428 @@
+import contextlib
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pandas as _pandas
+from PIL import Image
+
+
+class FakeBaseModel:
+    pass
+
+
+class FakeInputIds:
+    shape = (1, 2)
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class FakeInputs(dict):
+
+    def __init__(self):
+        super().__init__(input_ids=FakeInputIds())
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class FakeModel:
+    device = 'cuda'
+
+    def __init__(self, model_name=None):
+        if model_name is not None:
+            self.language_model = types.SimpleNamespace(name_or_path=model_name)
+
+    def generate(self, **kwargs):
+        self.generate_kwargs = kwargs
+        return [[1, 2, 3]]
+
+
+def _base_modules():
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = ['vlmeval']
+    vlm = types.ModuleType('vlmeval.vlm')
+    vlm.__path__ = ['vlmeval/vlm']
+    base = types.ModuleType('vlmeval.vlm.base')
+    base.BaseModel = FakeBaseModel
+
+    dataset = types.ModuleType('vlmeval.dataset')
+    dataset.DATASET_TYPE = lambda name: 'VQA'
+    smp = types.ModuleType('vlmeval.smp')
+    smp.cn_string = lambda value: False
+    smp.encode_image_file_to_base64 = lambda path: 'encoded-image'
+    smp.get_cache_path = lambda *args, **kwargs: '/tmp/model'
+    smp.listinstr = lambda needles, value: any(needle in value for needle in needles)
+
+    torch = types.ModuleType('torch')
+    torch.bfloat16 = 'bfloat16'
+    torch.float16 = 'float16'
+    torch.inference_mode = contextlib.nullcontext
+    torch.cuda = types.SimpleNamespace(device_count=lambda: 1, empty_cache=lambda: None)
+
+    huggingface_hub = types.ModuleType('huggingface_hub')
+    huggingface_hub.snapshot_download = mock.Mock()
+    return {
+        'vlmeval': vlmeval,
+        'vlmeval.vlm': vlm,
+        'vlmeval.vlm.base': base,
+        'vlmeval.dataset': dataset,
+        'vlmeval.smp': smp,
+        'torch': torch,
+        'huggingface_hub': huggingface_hub,
+        'pandas': _pandas,
+    }
+
+
+def _load_vlm_module(module_name):
+    modules = _base_modules()
+    full_name = f'vlmeval.vlm.{module_name}'
+    with mock.patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location(full_name, f'vlmeval/vlm/{module_name}.py')
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full_name] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop(full_name, None)
+        return module
+
+
+class FakeGemmaProcessor:
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.messages = messages
+        if kwargs.get('tokenize') is False:
+            return 'gemma-prompt'
+        return FakeInputs()
+
+    def decode(self, *args, **kwargs):
+        return 'gemma-answer'
+
+
+class FakeTokenizer:
+    eos_token_id = 2
+
+    def convert_tokens_to_ids(self, token):
+        return 3
+
+
+class FakeMantisProcessor:
+
+    def __init__(self):
+        self.tokenizer = FakeTokenizer()
+
+    def __call__(self, prompt, images, **kwargs):
+        self.prompt = prompt
+        self.images = images
+        return FakeInputs()
+
+    def decode(self, *args, **kwargs):
+        return 'mantis-answer<|eot_id|>'
+
+
+class FakeMantisIdeficsProcessor(FakeMantisProcessor):
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.messages = messages
+        return 'mantis-idefics-prompt'
+
+
+class FakeConversation:
+    roles = ('USER', 'ASSISTANT')
+    last_messages = None
+
+    def __init__(self):
+        self.messages = []
+
+    def copy(self):
+        return FakeConversation()
+
+    def append_message(self, role, content):
+        self.messages.append([role, content])
+
+    def get_prompt(self):
+        FakeConversation.last_messages = [list(item) for item in self.messages]
+        return 'mantis-prompt'
+
+
+class TextChunk:
+
+    def __init__(self, text):
+        self.text = text
+
+
+class ImageURLChunk:
+
+    def __init__(self, image_url):
+        self.image_url = image_url
+
+
+class BaseMessage:
+
+    def __init__(self, content):
+        self.content = content
+
+
+class UserMessage(BaseMessage):
+    role = 'user'
+
+
+class AssistantMessage(BaseMessage):
+    role = 'assistant'
+
+
+class SystemMessage(BaseMessage):
+    role = 'system'
+
+
+class ChatCompletionRequest:
+
+    def __init__(self, messages):
+        self.messages = messages
+
+
+class FakeMistralTokenizer:
+    instruct_tokenizer = types.SimpleNamespace(
+        tokenizer=types.SimpleNamespace(eos_id=2)
+    )
+
+    def encode_chat_completion(self, request):
+        self.request = request
+        return types.SimpleNamespace(images=['image'], tokens=[1, 2])
+
+    def decode(self, tokens):
+        return 'pixtral-answer'
+
+
+class SamplingParams:
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class FakeVLLM:
+
+    def generate(self, request, sampling_params):
+        self.request = request
+        self.sampling_params = sampling_params
+        return [types.SimpleNamespace(
+            outputs=[types.SimpleNamespace(text='gemma-vllm-answer')]
+        )]
+
+
+def _mistral_modules(generate):
+    common = types.ModuleType('mistral_common')
+    protocol = types.ModuleType('mistral_common.protocol')
+    instruct = types.ModuleType('mistral_common.protocol.instruct')
+    messages = types.ModuleType('mistral_common.protocol.instruct.messages')
+    messages.AssistantMessage = AssistantMessage
+    messages.ImageURLChunk = ImageURLChunk
+    messages.SystemMessage = SystemMessage
+    messages.TextChunk = TextChunk
+    messages.UserMessage = UserMessage
+    request = types.ModuleType('mistral_common.protocol.instruct.request')
+    request.ChatCompletionRequest = ChatCompletionRequest
+    inference = types.ModuleType('mistral_inference')
+    generate_module = types.ModuleType('mistral_inference.generate')
+    generate_module.generate = generate
+    return {
+        'mistral_common': common,
+        'mistral_common.protocol': protocol,
+        'mistral_common.protocol.instruct': instruct,
+        'mistral_common.protocol.instruct.messages': messages,
+        'mistral_common.protocol.instruct.request': request,
+        'mistral_inference': inference,
+        'mistral_inference.generate': generate_module,
+    }
+
+
+class TestAdditionalChatInner(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.image_path = str(Path(self.tempdir.name) / 'image.png')
+        Image.new('RGB', (2, 2), color='white').save(self.image_path)
+        self.messages = [
+            {'role': 'user', 'content': [
+                {'type': 'image', 'value': self.image_path},
+                {'type': 'text', 'value': 'Describe this.'},
+            ]},
+            {'role': 'assistant', 'content': [
+                {'type': 'text', 'value': 'A white square.'},
+            ]},
+            {'role': 'user', 'content': [
+                {'type': 'text', 'value': 'What color?'},
+            ]},
+        ]
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_gemma3_chat_inner_preserves_multimodal_turns(self):
+        module = _load_vlm_module('gemma')
+        model = module.Gemma3.__new__(module.Gemma3)
+        model.use_vllm = False
+        model.system_prompt = 'Be helpful.'
+        model.processor = FakeGemmaProcessor()
+        model.model = FakeModel()
+        model.device = 'cuda'
+        model.kwargs = {'max_new_tokens': 16}
+
+        response = model.chat_inner(self.messages)
+
+        self.assertEqual(response, 'gemma-answer')
+        self.assertEqual(
+            [turn['role'] for turn in model.processor.messages],
+            ['system', 'user', 'assistant', 'user'],
+        )
+        self.assertEqual(
+            model.processor.messages[1]['content'][0],
+            {'type': 'image', 'url': self.image_path},
+        )
+        self.assertEqual(
+            model.processor.messages[-1]['content'],
+            [{'type': 'text', 'text': 'What color?'}],
+        )
+
+    def test_gemma3_single_turn_generation_still_uses_user_message(self):
+        module = _load_vlm_module('gemma')
+        model = module.Gemma3.__new__(module.Gemma3)
+        model.use_vllm = False
+        model.system_prompt = None
+        model.processor = FakeGemmaProcessor()
+        model.model = FakeModel()
+        model.device = 'cuda'
+        model.kwargs = {'max_new_tokens': 16}
+
+        response = model.generate_inner(self.messages[0]['content'])
+
+        self.assertEqual(response, 'gemma-answer')
+        self.assertEqual([turn['role'] for turn in model.processor.messages], ['user'])
+
+    def test_gemma3_vllm_chat_inner_preserves_history_and_images(self):
+        module = _load_vlm_module('gemma')
+        model = module.Gemma3.__new__(module.Gemma3)
+        model.use_vllm = True
+        model.system_prompt = 'Be helpful.'
+        model.processor = FakeGemmaProcessor()
+        model.llm = FakeVLLM()
+        model.limit_mm_per_prompt = 24
+        model.kwargs = {'max_new_tokens': 16}
+
+        import base64
+        image_bytes = Path(self.image_path).read_bytes()
+        model.encode_image = lambda path: base64.b64encode(image_bytes).decode()
+        vllm = types.ModuleType('vllm')
+        vllm.SamplingParams = SamplingParams
+
+        with mock.patch.dict(sys.modules, {'vllm': vllm}):
+            response = model.chat_inner(self.messages)
+
+        self.assertEqual(response, 'gemma-vllm-answer')
+        self.assertEqual(
+            [turn['role'] for turn in model.processor.messages],
+            ['system', 'user', 'assistant', 'user'],
+        )
+        self.assertEqual(len(model.llm.request['multi_modal_data']['image']), 1)
+
+    def test_mantis_chat_inner_builds_native_conversation_history(self):
+        module = _load_vlm_module('mantis')
+        model = module.Mantis.__new__(module.Mantis)
+        model._is_idefics = False
+        model.processor = FakeMantisProcessor()
+        model.model = FakeModel('Mantis-Llama-3')
+        model.conv_templates = {'llama_3': FakeConversation()}
+        model.default_conv = FakeConversation()
+        model.kwargs = {'max_new_tokens': 16}
+
+        response = model.chat_inner(self.messages)
+
+        self.assertEqual(response, 'mantis-answer')
+        self.assertEqual(FakeConversation.last_messages, [
+            ['USER', '<image>\nDescribe this.'],
+            ['ASSISTANT', 'A white square.'],
+            ['USER', 'What color?'],
+            ['ASSISTANT', ''],
+        ])
+        self.assertEqual(len(model.processor.images), 1)
+
+    def test_mantis_single_turn_generation_still_works(self):
+        module = _load_vlm_module('mantis')
+        model = module.Mantis.__new__(module.Mantis)
+        model._is_idefics = False
+        model.processor = FakeMantisProcessor()
+        model.model = FakeModel('Mantis-Llama-3')
+        model.conv_templates = {'llama_3': FakeConversation()}
+        model.default_conv = FakeConversation()
+        model.kwargs = {'max_new_tokens': 16}
+
+        response = model.generate_inner(self.messages[0]['content'])
+
+        self.assertEqual(response, 'mantis-answer')
+        self.assertEqual(len(model.processor.images), 1)
+
+    def test_mantis_idefics_chat_inner_uses_native_chat_template(self):
+        module = _load_vlm_module('mantis')
+        model = module.Mantis.__new__(module.Mantis)
+        model._is_idefics = True
+        model.processor = FakeMantisIdeficsProcessor()
+        model.model = FakeModel()
+        model.kwargs = {'max_new_tokens': 16}
+
+        response = model.chat_inner(self.messages)
+
+        self.assertEqual(response, 'mantis-answer')
+        self.assertEqual(
+            [turn['role'] for turn in model.processor.messages],
+            ['user', 'assistant', 'user'],
+        )
+        self.assertEqual(model.processor.prompt, 'mantis-idefics-prompt')
+        self.assertEqual(len(model.processor.images), 1)
+
+    def test_pixtral_chat_inner_uses_mistral_multi_turn_request(self):
+        module = _load_vlm_module('pixtral')
+        calls = []
+
+        def generate(*args, **kwargs):
+            calls.append((args, kwargs))
+            return [[3]], None
+
+        model = module.Pixtral.__new__(module.Pixtral)
+        model.tokenizer = FakeMistralTokenizer()
+        model.model = object()
+        model.max_tokens = 16
+
+        with mock.patch.dict(sys.modules, _mistral_modules(generate)):
+            response = model.chat_inner(self.messages)
+
+        request = model.tokenizer.request
+        self.assertEqual(response, 'pixtral-answer')
+        self.assertEqual([turn.role for turn in request.messages], ['user', 'assistant', 'user'])
+        self.assertIsInstance(request.messages[0].content[0], ImageURLChunk)
+        self.assertEqual(request.messages[1].content[0].text, 'A white square.')
+        self.assertEqual(len(calls), 1)
+
+    def test_pixtral_single_turn_generation_still_works(self):
+        module = _load_vlm_module('pixtral')
+
+        def generate(*args, **kwargs):
+            return [[3]], None
+
+        model = module.Pixtral.__new__(module.Pixtral)
+        model.tokenizer = FakeMistralTokenizer()
+        model.model = object()
+        model.max_tokens = 16
+
+        with mock.patch.dict(sys.modules, _mistral_modules(generate)):
+            response = model.generate_inner(self.messages[0]['content'])
+
+        self.assertEqual(response, 'pixtral-answer')
+        self.assertEqual([turn.role for turn in model.tokenizer.request.messages], ['user'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlmeval/vlm/gemma.py
+++ b/vlmeval/vlm/gemma.py
@@ -113,20 +113,30 @@ class Gemma3(BaseModel):
         default_kwargs.update(kwargs)
         self.kwargs = default_kwargs
 
-    def message2pipeline(self, message):
+    def _chat_message2pipeline(self, message):
         ret = []
         if hasattr(self, 'system_prompt') and self.system_prompt is not None:
             ret = [
                 dict(role='system', content=[dict(type='text', text=self.system_prompt)])
             ]
-        content = []
-        for m in message:
-            if m['type'] == 'text':
-                content.append(dict(type='text', text=m['value']))
-            elif m['type'] == 'image':
-                content.append(dict(type='image', url=m['value']))
-        ret.append(dict(role='user', content=content))
+        for turn in message:
+            if turn['role'] not in ['user', 'assistant']:
+                raise ValueError(f'Unsupported Gemma 3 chat role: {turn["role"]}')
+            content = []
+            for item in turn['content']:
+                if item['type'] == 'text':
+                    content.append(dict(type='text', text=item['value']))
+                elif item['type'] == 'image':
+                    if turn['role'] != 'user':
+                        raise ValueError('Gemma 3 only supports images in user turns.')
+                    content.append(dict(type='image', url=item['value']))
+            ret.append(dict(role=turn['role'], content=content))
         return ret
+
+    def message2pipeline(self, message):
+        return self._chat_message2pipeline([
+            dict(role='user', content=message),
+        ])
 
     def encode_image(self, image_path):
         mime_type, _ = guess_type(image_path)
@@ -156,7 +166,6 @@ class Gemma3(BaseModel):
     def message_to_promptimg_vllm(self, message, dataset=None):
         processed_message = []
         images = []
-        num_images = 0
         for item in message:
             if item['type'] == 'text':
                 processed_message.append({
@@ -164,7 +173,7 @@ class Gemma3(BaseModel):
                     "text": item['value']
                 })
             elif item['type'] == 'image':
-                if num_images < self.limit_mm_per_prompt:
+                if len(images) < self.limit_mm_per_prompt:
                     image_path = item['value']
                     encoded_image = self.encode_image(image_path)
                     image = Image.open(BytesIO(base64.b64decode(encoded_image)))
@@ -174,16 +183,50 @@ class Gemma3(BaseModel):
                         "image": "",
                     })
                     images.append(image)
-                    num_images += 1
-        if num_images >= self.limit_mm_per_prompt:
+        if len([item for item in message if item['type'] == 'image']) > self.limit_mm_per_prompt:
             logging.warning(
                 f"Number of images exceeds the limit of {self.limit_mm_per_prompt}."
                 f"Only the first {self.limit_mm_per_prompt} images will be used."
             )
         return processed_message, images
 
-    def generate_inner_transformers(self, message, dataset=None):
-        messages = self.message2pipeline(message)
+    def _chat_message2pipeline_vllm(self, message):
+        ret = []
+        if hasattr(self, 'system_prompt') and self.system_prompt is not None:
+            ret.append(dict(
+                role='system',
+                content=[dict(type='text', text=self.system_prompt)],
+            ))
+
+        images = []
+        image_count = 0
+        for turn in message:
+            if turn['role'] not in ['user', 'assistant']:
+                raise ValueError(f'Unsupported Gemma 3 chat role: {turn["role"]}')
+            content = []
+            for item in turn['content']:
+                if item['type'] == 'text':
+                    content.append(dict(type='text', text=item['value']))
+                elif item['type'] == 'image':
+                    if turn['role'] != 'user':
+                        raise ValueError('Gemma 3 only supports images in user turns.')
+                    image_count += 1
+                    if len(images) < self.limit_mm_per_prompt:
+                        encoded_image = self.encode_image(item['value'])
+                        image = Image.open(BytesIO(base64.b64decode(encoded_image)))
+                        image.load()
+                        content.append(dict(type='image', image=''))
+                        images.append(image)
+            ret.append(dict(role=turn['role'], content=content))
+
+        if image_count > self.limit_mm_per_prompt:
+            logging.warning(
+                f"Number of images exceeds the limit of {self.limit_mm_per_prompt}."
+                f"Only the first {self.limit_mm_per_prompt} images will be used."
+            )
+        return ret, images
+
+    def _generate_transformers_messages(self, messages):
         inputs = self.processor.apply_chat_template(
             messages, add_generation_prompt=True, tokenize=True,
             return_dict=True, return_tensors="pt",
@@ -195,15 +238,19 @@ class Gemma3(BaseModel):
             generation = self.model.generate(**inputs, **self.kwargs)
             generation = generation[0][input_len:]
 
-        decoded = self.processor.decode(generation, skip_special_tokens=True)
-        return decoded
+        return self.processor.decode(generation, skip_special_tokens=True)
 
-    def generate_inner_vllm(self, message, dataset=None):
+    def generate_inner_transformers(self, message, dataset=None):
+        messages = self.message2pipeline(message)
+        return self._generate_transformers_messages(messages)
+
+    def chat_inner_transformers(self, message, dataset=None):
+        messages = self._chat_message2pipeline(message)
+        return self._generate_transformers_messages(messages)
+
+    def _generate_vllm_messages(self, messages, images):
         from vllm import SamplingParams
-        prompt, images = self.message_to_promptimg_vllm(message, dataset=dataset)
-        messages = [
-            {'role': 'user', 'content': prompt}
-        ]
+
         prompt = self.processor.apply_chat_template(
             messages,
             tokenize=False,
@@ -220,15 +267,32 @@ class Gemma3(BaseModel):
             },
             sampling_params=sampling_params
         )
-        for o in outputs:
-            generated_text = o.outputs[0].text
+        for output in outputs:
+            generated_text = output.outputs[0].text
         return generated_text
+
+    def generate_inner_vllm(self, message, dataset=None):
+        prompt, images = self.message_to_promptimg_vllm(message, dataset=dataset)
+        messages = [
+            {'role': 'user', 'content': prompt}
+        ]
+        return self._generate_vllm_messages(messages, images)
+
+    def chat_inner_vllm(self, message, dataset=None):
+        messages, images = self._chat_message2pipeline_vllm(message)
+        return self._generate_vllm_messages(messages, images)
 
     def generate_inner(self, message, dataset=None):
         if self.use_vllm:
             return self.generate_inner_vllm(message, dataset=dataset)
         else:
             return self.generate_inner_transformers(message, dataset=dataset)
+
+    def chat_inner(self, message, dataset=None):
+        if self.use_vllm:
+            return self.chat_inner_vllm(message, dataset=dataset)
+        else:
+            return self.chat_inner_transformers(message, dataset=dataset)
 
 
 class Gemma4(BaseModel):

--- a/vlmeval/vlm/mantis.py
+++ b/vlmeval/vlm/mantis.py
@@ -153,6 +153,18 @@ class Mantis(BaseModel):
             answer = answer.split('|ENDOFTEXT|')[0].strip()
         return answer
 
+    def _generate_from_prompt(self, prompt, images):
+        inputs = self.processor(prompt, images, return_tensors='pt', truncation=True)
+        # FIXME: Fuyu model would return a list instead of a pytorch tensor. This weird behavior needs fixing.
+        if 'image_patches' in inputs.keys():
+            inputs['image_patches'] = inputs['image_patches'][0]
+        inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
+        output = self.model.generate(**inputs, **self.kwargs)
+        output = output[0]
+        generated_ids = output[inputs['input_ids'].shape[-1]:]
+        answer = self.processor.decode(generated_ids, skip_special_token=True)
+        return self.output_process(answer)
+
     def generate_inner(self, message, dataset=None):
         content, images = '', []
         ide_content, question = [], ''
@@ -193,14 +205,64 @@ class Mantis(BaseModel):
             assert conv.messages[-1][0] == conv.roles[1] and conv.messages[-1][1] == '', 'Format check'
             prompt = conv.get_prompt()
 
-        inputs = self.processor(prompt, images, return_tensors='pt', truncation=True)
-        # FIXME: Fuyu model would return a list instead of a pytorch tensor. This weird behavior needs fixing.
-        if 'image_patches' in inputs.keys():
-            inputs['image_patches'] = inputs['image_patches'][0]
-        inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
-        output = self.model.generate(**inputs, **self.kwargs)
-        output = output[0]
-        generated_ids = output[inputs['input_ids'].shape[-1]:]
-        answer = self.processor.decode(generated_ids, skip_special_token=True)
-        answer = self.output_process(answer)
-        return answer
+        return self._generate_from_prompt(prompt, images)
+
+    def chat_inner(self, message, dataset=None):
+        images = []
+        if self._is_idefics:
+            prompt = []
+            for turn in message:
+                if turn['role'] not in ['user', 'assistant']:
+                    raise ValueError(f'Unsupported Mantis chat role: {turn["role"]}')
+                content = []
+                for item in turn['content']:
+                    if item['type'] == 'text':
+                        content.append({'type': 'text', 'text': item['value']})
+                    elif item['type'] == 'image':
+                        if turn['role'] != 'user':
+                            raise ValueError('Mantis only supports images in user turns.')
+                        images.append(Image.open(item['value']).convert('RGB'))
+                        content.append({'type': 'image'})
+                prompt.append({'role': turn['role'], 'content': content})
+            prompt = self.processor.apply_chat_template(prompt, add_generation_prompt=True)
+        else:
+            if 'llama-3' in self.model.language_model.name_or_path.lower():
+                conv = self.conv_templates['llama_3']
+                terminators = [
+                    self.processor.tokenizer.eos_token_id,
+                    self.processor.tokenizer.convert_tokens_to_ids('<|eot_id|>')
+                ]
+            else:
+                conv = self.default_conv
+                terminators = [self.processor.tokenizer.eos_token_id]
+
+            if 'eos_token_id' not in self.kwargs:
+                self.kwargs['eos_token_id'] = terminators
+
+            conv = conv.copy()
+            conv.messages = []
+            for turn in message:
+                if turn['role'] == 'user':
+                    role = conv.roles[0]
+                elif turn['role'] == 'assistant':
+                    role = conv.roles[1]
+                else:
+                    raise ValueError(f'Unsupported Mantis chat role: {turn["role"]}')
+
+                content = ''
+                for item in turn['content']:
+                    if item['type'] == 'text':
+                        content += item['value']
+                    elif item['type'] == 'image':
+                        if turn['role'] != 'user':
+                            raise ValueError('Mantis only supports images in user turns.')
+                        images.append(Image.open(item['value']).convert('RGB'))
+                        content += self.DEFAULT_IMAGE_TOKEN + '\n'
+                conv.append_message(role, content)
+
+            if not conv.messages or conv.messages[-1][0] != conv.roles[0]:
+                raise ValueError('Mantis chat history must end with a user turn.')
+            conv.append_message(conv.roles[1], '')
+            prompt = conv.get_prompt()
+
+        return self._generate_from_prompt(prompt, images)

--- a/vlmeval/vlm/pixtral.py
+++ b/vlmeval/vlm/pixtral.py
@@ -35,27 +35,31 @@ class Pixtral(BaseModel):
         self.model = model
         self.max_tokens = 2048
 
-    def generate_inner(self, message, dataset=None):
+    @staticmethod
+    def _mistral_content(message, allow_images=True):
+        from mistral_common.protocol.instruct.messages import ImageURLChunk, TextChunk
+
+        content = []
+        for item in message:
+            if item['type'] == 'text':
+                content.append(TextChunk(text=item['value']))
+            elif item['type'] == 'image':
+                if not allow_images:
+                    raise ValueError('Pixtral only supports images in user turns.')
+                b64 = encode_image_file_to_base64(item['value'])
+                image_url = f'data:image/jpeg;base64,{b64}'
+                content.append(ImageURLChunk(image_url=image_url))
+        return content
+
+    def _run_chat(self, messages):
         try:
-            from mistral_common.protocol.instruct.messages import (ImageURLChunk, TextChunk,
-                                                                   UserMessage)
             from mistral_common.protocol.instruct.request import ChatCompletionRequest
             from mistral_inference.generate import generate
         except ImportError as err:
             logging.critical('Please install `mistral-inference` and `mistral_common`')
             raise err
 
-        msg_new = []
-        for msg in message:
-            tp, val = msg['type'], msg['value']
-            if tp == 'text':
-                msg_new.append(TextChunk(text=val))
-            elif tp == 'image':
-                b64 = encode_image_file_to_base64(val)
-                image_url = f'data:image/jpeg;base64,{b64}'
-                msg_new.append(ImageURLChunk(image_url=image_url))
-
-        completion_request = ChatCompletionRequest(messages=[UserMessage(content=msg_new)])
+        completion_request = ChatCompletionRequest(messages=messages)
         encoded = self.tokenizer.encode_chat_completion(completion_request)
         images = encoded.images
         tokens = encoded.tokens
@@ -70,3 +74,36 @@ class Pixtral(BaseModel):
 
         result = self.tokenizer.decode(out_tokens[0])
         return result
+
+    def generate_inner(self, message, dataset=None):
+        try:
+            from mistral_common.protocol.instruct.messages import UserMessage
+        except ImportError as err:
+            logging.critical('Please install `mistral-inference` and `mistral_common`')
+            raise err
+
+        content = self._mistral_content(message)
+        return self._run_chat([UserMessage(content=content)])
+
+    def chat_inner(self, message, dataset=None):
+        try:
+            from mistral_common.protocol.instruct.messages import (AssistantMessage, SystemMessage,
+                                                                   UserMessage)
+        except ImportError as err:
+            logging.critical('Please install `mistral-inference` and `mistral_common`')
+            raise err
+
+        messages = []
+        for turn in message:
+            if turn['role'] == 'user':
+                content = self._mistral_content(turn['content'])
+                messages.append(UserMessage(content=content))
+            elif turn['role'] == 'assistant':
+                content = self._mistral_content(turn['content'], allow_images=False)
+                messages.append(AssistantMessage(content=content))
+            elif turn['role'] == 'system':
+                content = self._mistral_content(turn['content'], allow_images=False)
+                messages.append(SystemMessage(content=content))
+            else:
+                raise ValueError(f'Unsupported Pixtral chat role: {turn["role"]}')
+        return self._run_chat(messages)


### PR DESCRIPTION
## Summary

- add `chat_inner` for Gemma 3 while preserving complete user/assistant history and images in both Transformers and vLLM backends
- add `chat_inner` for Mantis using its native conversation template, with a separate Idefics chat-template path
- add `chat_inner` for Pixtral using native Mistral `UserMessage`, `AssistantMessage`, and `SystemMessage` requests
- keep each model's existing single-turn `generate_inner` path working through shared generation helpers
- reject images in assistant turns instead of silently constructing unsupported histories

This addresses another group of three models requested in #323. Their upstream documentation confirms the required capabilities:

- Gemma's official Transformers guide documents multimodal multi-turn prompt templates: https://ai.google.dev/gemma/docs/core/huggingface_inference#use_a_prompt_template_2
- Mantis's official model card includes a history-based multi-turn example: https://huggingface.co/TIGER-Lab/Mantis-8B-siglip-llama3
- Pixtral's official model card explicitly supports multi-turn conversations and multiple images: https://huggingface.co/mistralai/Pixtral-12B-2409

## Validation

- `python -m unittest -v tests/test_vlm_chat_inner_gemma_mantis_pixtral.py` (8 tests passed)
- `python -m py_compile vlmeval/vlm/gemma.py vlmeval/vlm/mantis.py vlmeval/vlm/pixtral.py tests/test_vlm_chat_inner_gemma_mantis_pixtral.py`
- `pre-commit run --files vlmeval/vlm/gemma.py vlmeval/vlm/mantis.py vlmeval/vlm/pixtral.py tests/test_vlm_chat_inner_gemma_mantis_pixtral.py`

The tests exercise Gemma's Transformers and vLLM paths, Mantis's native and Idefics paths, Pixtral's Mistral request construction, image ordering, role preservation, and single-turn regression behavior without downloading model weights.

## AI assistance

OpenAI Codex assisted with implementation and testing. I reviewed the model capability sources, code paths, and test outputs before submission.
