### PR TITLE
[Dataset] Add downloadable OmniMat data URLs

### DIFF
--- a/tests/test_omnimat_data_url.py
+++ b/tests/test_omnimat_data_url.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from vlmeval.dataset import omnimat as omnimat_module
+from vlmeval.dataset.omnimat import OmniMat
+
+EXPECTED_URLS = {
+    'OmniMat_QA': (
+        'https://huggingface.co/datasets/'
+        'Summer12138/OmniMat1K-VLMEvalKit/resolve/main/'
+        'vlmevalkit/OmniMat_QA.tsv'
+    ),
+    'OmniMat_CAL': (
+        'https://huggingface.co/datasets/'
+        'Summer12138/OmniMat1K-VLMEvalKit/resolve/main/'
+        'vlmevalkit/OmniMat_CAL.tsv'
+    ),
+}
+
+
+def test_omnimat_uses_published_tsv_urls():
+    assert OmniMat.DATASET_URL == EXPECTED_URLS
+
+
+def test_omnimat_downloads_published_tsv_when_local_data_is_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(omnimat_module, 'LMUDataRoot', lambda: str(tmp_path))
+    dataset = object.__new__(OmniMat)
+    downloaded = pd.DataFrame(
+        [{'index': '1', 'category_id': '1', 'id': '2', 'question': 'test'}]
+    )
+    called = []
+    dataset.prepare_tsv = lambda url: called.append(url) or downloaded.copy()
+
+    data = dataset.load_data('OmniMat_QA')
+
+    assert called == [EXPECTED_URLS['OmniMat_QA']]
+    assert data.iloc[0]['category_id'] == '01'
+    assert data.iloc[0]['id'] == '002'

--- a/vlmeval/dataset/omnimat.py
+++ b/vlmeval/dataset/omnimat.py
@@ -22,8 +22,16 @@ class OmniMat(ImageBaseDataset):
     DEFAULT_JUDGE = 'gemini-2.5-flash'
 
     DATASET_URL = {
-        'OmniMat_QA': '',
-        'OmniMat_CAL': '',
+        'OmniMat_QA': (
+            'https://huggingface.co/datasets/'
+            'Summer12138/OmniMat1K-VLMEvalKit/resolve/main/'
+            'vlmevalkit/OmniMat_QA.tsv'
+        ),
+        'OmniMat_CAL': (
+            'https://huggingface.co/datasets/'
+            'Summer12138/OmniMat1K-VLMEvalKit/resolve/main/'
+            'vlmevalkit/OmniMat_CAL.tsv'
+        ),
     }
 
     QA_PROMPT = (
@@ -65,6 +73,16 @@ class OmniMat(ImageBaseDataset):
                     data['image_path'] = data['image_path'].fillna('')
                 _normalize_ids(data)
                 return data
+
+        url = self.DATASET_URL.get(dataset)
+        if url:
+            data = self.prepare_tsv(url)
+            if 'image' in data:
+                data['image'] = data['image'].fillna('')
+            if 'image_path' in data:
+                data['image_path'] = data['image_path'].fillna('')
+            _normalize_ids(data)
+            return data
 
         raise FileNotFoundError(
             f'{dataset}.tsv was not found. Run `python scripts/convert_omnimat.py` '


### PR DESCRIPTION
## Summary

- populate the published TSV URLs for `OmniMat_QA` and `OmniMat_CAL`
- fall back to `prepare_tsv()` when no local OmniMat TSV is available
- preserve the existing local-file precedence and ID normalization
- add focused regression tests for the URL contract and download fallback

This PR intentionally does not change the OmniMat prompts or scoring logic. Those concerns are deferred to a separate follow-up.

## Dataset scope and publication status

The linked Hugging Face repository currently contains the OmniMat1K release:

- 498 QA examples
- 502 CAL examples
- 1,000 examples in total

This is not the full 3,171-example dataset described in the paper. The Hugging Face repository is currently public and ungated, but its API metadata does not yet declare a license or dataset owner. This PR is therefore opened as a draft pending confirmation from the maintainers/data owner about the intended upstream naming and publication metadata.

Addresses the OmniMat portion of #1614.

## Verification

- `pytest -q tests/test_omnimat_data_url.py` — 2 passed
- fresh temporary `LMUData` download — 498 QA + 502 CAL loaded successfully
- both published URLs returned HTTP 206 and downloaded successfully
- `uvx pre-commit run --files vlmeval/dataset/omnimat.py tests/test_omnimat_data_url.py` — passed
- `uvx pre-commit run --all-files` — blocked by two pre-existing E226 violations on upstream `main`:
  - `vlmeval/dataset/utils/memlens_utils.py:848`
  - `vlmeval/dataset/utils/mmlongbench_metrics.py:109`
