### PR TITLE
[Benchmark] Upgrade OmniDocBench to v1.5

### DIFF
--- a/tests/test_omnidocbench.py
+++ b/tests/test_omnidocbench.py
@@ -1,0 +1,39 @@
+import unittest
+
+from vlmeval.dataset.OmniDocBench.omnidocbench import OmniDocBench, parse_omnidocbench_annotation
+
+
+class OmniDocBenchTests(unittest.TestCase):
+
+    def test_v1_0_json_annotation(self):
+        value = '{"page_info": {"image_path": "page.png"}, "layout_dets": [], "extra": {}}'
+        parsed = parse_omnidocbench_annotation(value)
+        self.assertEqual(parsed['page_info']['image_path'], 'page.png')
+
+    def test_v1_5_python_literal_annotation(self):
+        value = "{'page_info': {'image_path': 'page.png'}, 'layout_dets': [], 'extra': {}}"
+        parsed = parse_omnidocbench_annotation(value)
+        self.assertEqual(parsed['page_info']['image_path'], 'page.png')
+
+    def test_non_dictionary_annotation_is_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_omnidocbench_annotation("['not', 'an', 'annotation']")
+
+    def test_literal_fallback_cannot_execute_code(self):
+        with self.assertRaises(ValueError):
+            parse_omnidocbench_annotation("__import__('os').system('false')")
+
+    def test_default_dataset_is_pinned_v1_5(self):
+        self.assertIn(
+            '9702d4ba9a0d30dc5e76789707650c9c54cb0b3b',
+            OmniDocBench.DATASET_URL['OmniDocBench'],
+        )
+        self.assertEqual(
+            OmniDocBench.DATASET_MD5['OmniDocBench'],
+            '995f1af5b4e24ad0a6417cbff708b3fc',
+        )
+        self.assertIn('OmniDocBench_v1_0', OmniDocBench.supported_datasets())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlmeval/dataset/OmniDocBench/omnidocbench.py
+++ b/vlmeval/dataset/OmniDocBench/omnidocbench.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import copy
 import json
@@ -14,7 +15,26 @@ from tqdm import tqdm
 from vlmeval.smp import dump, get_intermediate_file_path, load
 from ..image_base import ImageBaseDataset
 
-# from ..utils import get_intermediate_file_path, load, dump
+
+def parse_omnidocbench_annotation(value):
+    """Parse annotations from both official OmniDocBench TSV versions.
+
+    The v1.0 TSV stores ``answer`` as JSON, while the published v1.5 TSV
+    stores the same dictionary as a Python literal. ``ast.literal_eval`` is
+    intentionally used only as a fallback so no arbitrary code can execute.
+    """
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        raise TypeError(f'Expected a string or dictionary, got {type(value).__name__}')
+
+    try:
+        annotation = json.loads(value)
+    except json.JSONDecodeError:
+        annotation = ast.literal_eval(value)
+    if not isinstance(annotation, dict):
+        raise ValueError(f'Expected an annotation dictionary, got {type(annotation).__name__}')
+    return annotation
 
 
 class OmniDocBench(ImageBaseDataset):
@@ -22,9 +42,20 @@ class OmniDocBench(ImageBaseDataset):
     MODALITY = 'IMAGE'
     TYPE = 'QA'
 
-    DATASET_URL = {'OmniDocBench':'https://huggingface.co/datasets/ouyanglinke/OmniDocBench_tsv/resolve/main/OmniDocBench.tsv'}
-    DATASET_MD5 = {'OmniDocBench': '0fa5ccf31e682e219cb9ca83da741a59'}
-
+    DATASET_URL = {
+        'OmniDocBench': (
+            'https://huggingface.co/datasets/ouyanglinke/OmniDocBench_tsv/resolve/'
+            '9702d4ba9a0d30dc5e76789707650c9c54cb0b3b/OmniDocBench.tsv'
+        ),
+        'OmniDocBench_v1_0': (
+            'https://huggingface.co/datasets/ouyanglinke/OmniDocBench_tsv/resolve/'
+            '5c4d32624f2f828ce73be900cb86d9e3fabaf760/OmniDocBench.tsv'
+        ),
+    }
+    DATASET_MD5 = {
+        'OmniDocBench': '995f1af5b4e24ad0a6417cbff708b3fc',
+        'OmniDocBench_v1_0': '0fa5ccf31e682e219cb9ca83da741a59',
+    }
 
     system_prompt = r'''You are an AI assistant specialized in converting PDF images to Markdown format. Please follow these instructions for the conversion:
 
@@ -102,10 +133,10 @@ class end2end_evaluator():
         load_success,load_fail=0,0
         for i,ans in tqdm(enumerate(references),desc='Loading data'):
             try:
-                ans = json.loads(ans)
+                ans = parse_omnidocbench_annotation(ans)
                 load_success+=1
                 self.references.append(ans) #[{},{}]
-            except json.JSONDecodeError as e:
+            except (SyntaxError, TypeError, ValueError):
                 load_fail+=1
                 continue
         print(f'load_success:{load_success},load_fail:{load_fail}')
@@ -447,14 +478,14 @@ class table_evalutor():
         load_success,load_fail=0,0
         for i,gt_sample in tqdm(enumerate(gt_samples),desc='Loading data'):
             try:
-                ans=json.loads(gt_sample)
+                ans=parse_omnidocbench_annotation(gt_sample)
                 for item in ans['layout_dets']:
                     if item['category_type']=="table":
                         item['pred']=predictions[i]
                         load_success+=1
                         preds.append(ans)
 
-            except json.JSONDecodeError as e:
+            except (SyntaxError, TypeError, ValueError):
                 load_fail+=1
                 continue
         print(f'load_table_success:{load_success},load_table_fail:{load_fail}')


### PR DESCRIPTION
## Summary

- make the pinned 1,355-page OmniDocBench v1.5 TSV the default `OmniDocBench` dataset
- retain the 981-page release as `OmniDocBench_v1_0`
- parse v1.0 JSON and the published v1.5 Python-literal annotation format safely
- pin both Hugging Face revisions and verify each download by MD5

## Why

The v1.5 TSV already published in `ouyanglinke/OmniDocBench_tsv` cannot be evaluated by the current adapter: its `answer` column contains Python dictionary literals, so `json.loads()` rejects all 1,355 rows. The fallback here uses `ast.literal_eval`; it never executes annotation text.

Fixes #1456.

## Validation

- downloaded the pinned 1,506,235,920-byte v1.5 TSV; MD5: `995f1af5b4e24ad0a6417cbff708b3fc`
- parsed all 1,355 contiguous rows and checked `page_info`, `layout_dets`, and `extra` schemas
- decoded and loaded rows 0, 677, and 1,354 (JPEG/JPEG/PNG)
- exercised both end-to-end and table evaluator loading against a real v1.5 row: `load_success=1`, `load_fail=0`
- perfect real-table smoke prediction: TEDS 1.0 and structure-only TEDS 1.0
- 5 focused unit tests pass, including rejection of executable expressions
- `py_compile`, `git diff --check`, and all configured pre-commit hooks pass

Implementation and validation were performed with OpenAI Codex assistance; I reviewed the resulting code, dataset provenance, hashes, and executed checks.