### PR TITLE
[Fix] Accept numeric LogicVista judge answers

### DIFF
--- a/tests/test_logicvista.py
+++ b/tests/test_logicvista.py
@@ -1,0 +1,104 @@
+import importlib.util
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_logicvista():
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = ['vlmeval']
+    smp = types.ModuleType('vlmeval.smp')
+    smp.__path__ = ['vlmeval/smp']
+    smp_file = types.ModuleType('vlmeval.smp.file')
+    smp_file.load = lambda path: path
+
+    modules = {
+        'vlmeval': vlmeval,
+        'vlmeval.smp': smp,
+        'vlmeval.smp.file': smp_file,
+    }
+    with mock.patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location(
+            'vlmeval.dataset.utils.logicvista',
+            'vlmeval/dataset/utils/logicvista.py',
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+class FakeJudge:
+
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+
+    def generate(self, prompt, temperature):
+        self.calls.append((prompt, temperature))
+        return next(self.responses)
+
+
+class TestLogicVistaAnswerExtraction(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.logicvista = _load_logicvista()
+
+    def test_accepts_numeric_answer(self):
+        judge = FakeJudge(['3'])
+        line = {
+            'question': 'Which answer is correct? Select from 1-5',
+            'prediction': '<answer>3</answer>',
+            'answer': '3',
+        }
+
+        result = self.logicvista.LogicVista_auxeval(judge, line)
+
+        self.assertEqual(result, {'log': 'Succeed', 'res': '3', 'hit': 1})
+        self.assertEqual(len(judge.calls), 1)
+        self.assertIn('option labels chosen (letters or numbers)', judge.calls[0][0])
+
+    def test_normalizes_case_order_and_separators(self):
+        judge = FakeJudge(['c, a'])
+        line = {
+            'question': 'Select all correct answers from A-D',
+            'prediction': 'A and C',
+            'answer': 'A, C',
+        }
+
+        result = self.logicvista.LogicVista_auxeval(judge, line)
+
+        self.assertEqual(result['hit'], 1)
+        self.assertEqual(result['res'], 'c, a')
+
+    def test_retries_explanatory_output_and_logs_actual_response(self):
+        judge = FakeJudge(['I choose 3', '3'])
+        line = {
+            'question': 'Which answer is correct? Select from 1-5',
+            'prediction': '<answer>3</answer>',
+            'answer': '3',
+        }
+
+        result = self.logicvista.LogicVista_auxeval(judge, line)
+
+        self.assertEqual(result['hit'], 1)
+        self.assertEqual(len(judge.calls), 2)
+        self.assertIn('output is I choose 3, failed to parse.', result['log'])
+
+    def test_valid_wrong_choice_is_scored_incorrect(self):
+        judge = FakeJudge(['D'])
+        line = {
+            'question': 'Which answer is correct? Select from A-D',
+            'prediction': '<answer>D</answer>',
+            'answer': 'A',
+        }
+
+        result = self.logicvista.LogicVista_auxeval(judge, line)
+
+        self.assertEqual(result, {'log': 'Succeed', 'res': 'D', 'hit': 0})
+        self.assertEqual(len(judge.calls), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlmeval/dataset/utils/logicvista.py
+++ b/vlmeval/dataset/utils/logicvista.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 
 import pandas as pd
@@ -8,17 +9,32 @@ from vlmeval.smp.file import load
 FAIL_MSG = 'Failed to obtain answer via API.'
 
 
+def normalize_logicvista_answer(value):
+    """Normalize a judge answer while rejecting explanatory text."""
+    text = str(value).strip()
+    if re.fullmatch(r'[A-Za-z0-9]+', text):
+        compact = text
+    else:
+        choices = re.split(r'[\s,;]+', text)
+        if not choices or any(len(choice) != 1 or not choice.isalnum() for choice in choices):
+            return None
+        compact = ''.join(choices)
+    if not compact:
+        return None
+    return ''.join(sorted(compact.lower()))
+
+
 def build_prompt_logicvista(line):
     question = line['question']
     prediction = str(line['prediction'])
     tmpl = (
-        "You are a information extractor that extracts multiple choice letter answer choices "
+        "You are an information extractor that extracts multiple-choice answers "
         "from a paragraph that contains the answer choice and sometimes explaination of why that "
         "choice is correct to the given question.\n"
-        "What letter did the following answer choose? If the answer did not select a letter answer choice, "
+        "What option did the following answer choose? If the answer did not select an answer choice, "
         "first try to infer the answer based off the given choices.\n"
         "If it does not seem like the given answer corresponds to an answer choice OR if there is no selected answer, please just respond with Z.\n"  # noqa: E501
-        "Make sure you answer with ONLY the letters chosen.\n"
+        "Make sure you answer with ONLY the option labels chosen (letters or numbers).\n"
         'Example 1: \n'
         'Question: <start>\nWhat is the main object in image?\nOptions: A. teddy bear B. rabbit C. cat D. dog\n<end>\n'
         'Answer: <start>\na cute teddy bear\n<end>\nYour output: A\n'
@@ -43,29 +59,19 @@ def LogicVista_auxeval(model, line):
     print(prompt)
     log = ''
     retry = 5
+    answer = normalize_logicvista_answer(line['answer'])
 
     for i in range(retry):
-        prediction = line['prediction']
         res = model.generate(prompt, temperature=i * 0.5)
-        answer = line['answer'].split(", ")
-        for j in range(0, len(answer)):
-            answer[j] = answer[j].lower()
-        answer.sort()
-        answer = ''.join(answer)
+        extracted = normalize_logicvista_answer(res)
 
         if FAIL_MSG in res:
-            log += f'Try {i}: output is {prediction}, failed to parse.\n'
-        elif not res.isupper() or not res.isalpha():
-            log += f'Try {i}: output is {prediction}, failed to parse.\n'
+            log += f'Try {i}: output is {res}, failed to parse.\n'
+        elif extracted is None:
+            log += f'Try {i}: output is {res}, failed to parse.\n'
         else:
             log += 'Succeed'
-            hit = 0
-            extracted = [alpha.lower() for alpha in res]
-            extracted.sort()
-            extracted = ''.join(extracted)
-            if extracted == answer:
-                hit = 1
-            return dict(log=log, res=res, hit=hit)
+            return dict(log=log, res=res, hit=int(extracted == answer))
     log += 'All 5 retries failed.\n'
     return dict(log=log, res='', hit=0)
 


### PR DESCRIPTION
## Summary\n\n- accept numeric LogicVista option labels such as 3, not only uppercase letters\n- normalize single and multiple letter/number choices consistently across judge output and ground truth\n- reject explanatory judge responses so they are retried instead of scored\n- log the actual invalid judge response rather than the original model prediction\n\n## Why\n\nLogicVista contains questions whose option labels are numeric. The evaluator currently requires isupper() and isalpha(), so the issue's correct judge output 3 is rejected. A later higher-temperature retry can then return an unrelated uppercase letter and be treated as a valid extraction.\n\nThe extraction prompt now explicitly allows letter or number option labels, and normalization preserves multi-select behavior while accepting numeric answers.\n\nFixes #1621.\n\n## Validation\n\n- 4 focused unit tests pass under Python 3.9 and Python 3.11\n- reproduced the reported numeric path: expected 3, judge output 3 -> hit=1 on the first call\n- covered letter/number labels, multi-select normalization, explanatory-output retry, actual-response logging, and valid wrong choices\n- flake8, isort, YAPF, whitespace, merge-conflict, and line-ending hooks pass on both changed files\n- git diff --check passes\n\nThe repository-wide flake8 invocation still reports two unrelated pre-existing E226 errors in memlens_utils.py and mmlongbench_metrics.py; neither file is changed here.\n\nImplementation and validation were performed with OpenAI Codex assistance; I reviewed the resulting code and executed checks.