### PR TITLE
[Fix] Detect MIME types for extensionless images

### DIFF
--- a/tests/test_smp_file.py
+++ b/tests/test_smp_file.py
@@ -1,0 +1,64 @@
+import functools
+import importlib.util
+import logging
+import sys
+import types
+from unittest import mock
+
+from PIL import Image
+
+
+@functools.lru_cache(maxsize=1)
+def _load_file_module():
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = ['vlmeval']
+
+    smp = types.ModuleType('vlmeval.smp')
+    smp.__path__ = ['vlmeval/smp']
+
+    log = types.ModuleType('vlmeval.smp.log')
+    log.get_logger = logging.getLogger
+
+    misc = types.ModuleType('vlmeval.smp.misc')
+    misc.toliststr = lambda value: value if isinstance(value, list) else [value]
+
+    vlm = types.ModuleType('vlmeval.smp.vlm')
+    vlm.decode_base64_to_image_file = mock.MagicMock()
+
+    validators = types.ModuleType('validators')
+    validators.url = lambda value: False
+
+    modules = {
+        'validators': validators,
+        'vlmeval': vlmeval,
+        'vlmeval.smp': smp,
+        'vlmeval.smp.log': log,
+        'vlmeval.smp.misc': misc,
+        'vlmeval.smp.vlm': vlm,
+    }
+    with mock.patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location(
+            'vlmeval.smp.file',
+            'vlmeval/smp/file.py',
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules['vlmeval.smp.file'] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop('vlmeval.smp.file', None)
+        return module
+
+
+def test_parse_file_detects_extensionless_image(tmp_path):
+    module = _load_file_module()
+    image_path = tmp_path / 'sitebench-image'
+    Image.new('RGB', (4, 4), color='red').save(image_path, format='PNG')
+
+    assert module.parse_file(str(image_path)) == ('image/png', str(image_path))
+
+
+def test_parse_file_keeps_unknown_for_non_image(tmp_path):
+    module = _load_file_module()
+    file_path = tmp_path / 'extensionless-text'
+    file_path.write_text('not an image')
+
+    assert module.parse_file(str(file_path)) == ('unknown', str(file_path))

--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -393,6 +393,16 @@ def last_modified(pth):
     return t
 
 
+def _mime_from_pillow(path):
+    from PIL import Image
+
+    try:
+        with Image.open(path) as image:
+            return Image.MIME.get(image.format, 'unknown')
+    except (OSError, ValueError):
+        return 'unknown'
+
+
 def parse_file(s):
     if osp.exists(s) and s != '.':
         assert osp.isfile(s)
@@ -401,6 +411,8 @@ def parse_file(s):
         if suffix == '.webp':
             return ('image/webp', s)
         mime = mimetypes.types_map.get(suffix, 'unknown')
+        if mime == 'unknown':
+            mime = _mime_from_pillow(s)
         return (mime, s)
     elif s.startswith('data:image/'):
         # To be compatible with OPENAI base64 format


### PR DESCRIPTION
## Summary

- detect the MIME type of local files with unknown or missing extensions using Pillow
- keep the existing extension-based fast path unchanged
- return `unknown` for non-image files instead of raising
- add regression coverage for a real extensionless PNG and an extensionless non-image

This fixes the remaining SiteBenchImage failure reported in #1485. The 3DSRBench `name_str` problem from the same issue was already fixed by #1428.

## Why

Some SiteBenchImage assets have no filename extension. `parse_file` currently maps an empty suffix to `unknown`, so API and model adapters cannot treat those paths as images even though Pillow can identify their encoded format.

## Tests

- `python3 -m pytest -q tests/test_smp_file.py` (2 passed)
- `uvx pre-commit run --files vlmeval/smp/file.py tests/test_smp_file.py` (all passed)
- `git diff --check`

## AI assistance disclosure

I used OpenAI Codex to inspect the issue and repository, implement the change, and draft tests and this description. I reviewed the code and personally ran the tests and checks above.

Closes #1485
