### PR TITLE
[Fix]Fix CCOCR evaluation for long text inputs

### DIFF
--- a/tests/test_ccocr_evaluator.py
+++ b/tests/test_ccocr_evaluator.py
@@ -1,0 +1,31 @@
+import unittest
+
+from vlmeval.dataset.utils.ccocr_evaluator.doc_parsing_evaluator import (
+    CustomConfig,
+    ParsingEvaluator,
+    TableTree,
+)
+
+
+class TestCCOCREvaluator(unittest.TestCase):
+    def test_teds_cell_distance_supports_long_content(self):
+        content_length = 2140
+        predicted = TableTree("td", 1, 1, list("a" * content_length))
+        ground_truth = TableTree("td", 1, 1, list("a" * (content_length - 1) + "b"))
+
+        score = CustomConfig().rename(predicted, ground_truth)
+
+        self.assertAlmostEqual(score, 1 / content_length)
+
+    def test_doc_distance_supports_long_content(self):
+        content_length = 2140
+        predicted = "a" * content_length
+        ground_truth = "a" * (content_length - 1) + "b"
+
+        score = ParsingEvaluator("doc_parsing").eval_doc({"sample": predicted}, {"sample": ground_truth})
+
+        self.assertAlmostEqual(score, 1 - 1 / content_length)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vlmeval/dataset/utils/ccocr_evaluator/doc_parsing_evaluator.py
+++ b/vlmeval/dataset/utils/ccocr_evaluator/doc_parsing_evaluator.py
@@ -1,7 +1,7 @@
 import re
 from collections import deque
 
-import nltk
+import editdistance
 from apted import APTED, Config
 from apted.helpers import Tree
 from tqdm import tqdm
@@ -67,7 +67,7 @@ class CustomConfig(Config):
             return 1.0
         if node1.tag == "td":
             if node1.content or node2.content:
-                return nltk.edit_distance(node1.content, node2.content) / max(len(node1.content), len(node2.content))
+                return editdistance.eval(node1.content, node2.content) / max(len(node1.content), len(node2.content))
         return 0.0
 
 
@@ -197,7 +197,7 @@ class ParsingEvaluator(BaseMetric):
             pred = pred.replace(' ', '').replace('\n', '')
             gt = gt.replace(' ', '').replace('\n', '')
 
-            edit_dist = nltk.edit_distance(pred, gt) / max(len(pred), len(gt))
+            edit_dist = editdistance.eval(pred, gt) / max(len(pred), len(gt))
             results.append(1 - edit_dist)
 
         score = sum(results) / len(results)
@@ -246,7 +246,7 @@ class ParsingEvaluator(BaseMetric):
             elif op_name == 'molecular':
                 pred = pred.replace("\n", "").replace(" ", "").replace("<smiles>", "").replace("</smiles>", "")
                 gt = gt.replace(" ", "")
-            edit_dist = nltk.edit_distance(pred, gt) / max(len(pred), len(gt))
+            edit_dist = editdistance.eval(pred, gt) / max(len(pred), len(gt))
             results.append(1 - edit_dist)
         score = sum(results) / len(results)
         return score


### PR DESCRIPTION
## Problem
CCOCR evaluation uses `nltk.edit_distance` for document parsing and table-cell TEDS comparison. Recent NLTK versions reject inputs longer than 2000 elements, causing evaluation to fail on long OCR/document outputs.

## Changes
- Replace the three CCOCR edit-distance calls with the existing `editdistance` dependency.
- Add regression coverage for 2140-character document and table-cell inputs.

This preserves the Levenshtein-distance metric while avoiding NLTK's fixed safety limit.

## Tests
- `/workspace/s/ljh/env/qwen35_official_vllm/bin/python -m unittest -v tests/test_ccocr_evaluator.py`
- `git diff --check`
- Python syntax compilation passed.