### PR TITLE
feat(api): add OrcaRouter provider

### DIFF
--- a/tests/test_orcarouter_api.py
+++ b/tests/test_orcarouter_api.py
@@ -1,0 +1,290 @@
+"""Tests for the OrcaRouter API provider (vlmeval/api/orcarouter.py).
+
+Runs without heavy VLMEvalKit dependencies — stubs out vlmeval.smp
+and vlmeval.api.base so only orcarouter.py is exercised.
+"""
+import importlib.util
+import logging
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub the vlmeval package so we can import orcarouter in isolation
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _stub_vlmeval(monkeypatch):
+    """Install minimal stubs for vlmeval.smp and vlmeval.api.base."""
+    vlmeval = types.ModuleType('vlmeval')
+    vlmeval.__path__ = []
+    monkeypatch.setitem(sys.modules, 'vlmeval', vlmeval)
+
+    smp = types.ModuleType('vlmeval.smp')
+    smp.concat_images_vlmeval = lambda *a, **k: None
+    smp.get_logger = lambda name: logging.getLogger(name)
+    smp.parse_file = lambda x: (None, x)
+    smp.encode_image_to_base64 = mock.MagicMock(return_value='c3R1Yg==')
+    monkeypatch.setitem(sys.modules, 'vlmeval.smp', smp)
+    vlmeval.smp = smp
+
+    base_spec = importlib.util.spec_from_file_location(
+        'vlmeval.api.base',
+        'vlmeval/api/base.py',
+    )
+    base_mod = importlib.util.module_from_spec(base_spec)
+    monkeypatch.setitem(sys.modules, 'vlmeval.api.base', base_mod)
+    base_spec.loader.exec_module(base_mod)
+
+    yield
+
+
+def _load_module():
+    """Load the orcarouter module and return it."""
+    spec = importlib.util.spec_from_file_location(
+        'vlmeval.api.orcarouter',
+        'vlmeval/api/orcarouter.py',
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['vlmeval.api.orcarouter'] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_orcarouter_api():
+    return _load_module().OrcaRouterAPI
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_response(content='4'):
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        'choices': [{'message': {'content': content}}],
+    }
+    return resp
+
+
+@pytest.fixture
+def provider_and_mod(monkeypatch):
+    """Return (OrcaRouterAPI instance, module) with requests mocked."""
+    mod = _load_module()
+    fake_post = mock.MagicMock(return_value=_make_response())
+    monkeypatch.setattr(mod.requests, 'post', fake_post)
+    p = mod.OrcaRouterAPI(model='orcarouter/auto', key='sk-test', retry=1)
+    return p, mod, fake_post
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestOrcaRouterAPIInit:
+
+    def test_default_params(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='sk-test', retry=1)
+        assert p.model == 'orcarouter/auto'
+        assert p.temperature == 0
+        assert p.max_tokens == 2048
+        assert p.timeout == 300
+        assert p.key == 'sk-test'
+        assert p.api_base == 'https://api.orcarouter.ai/v1/chat/completions'
+
+    def test_custom_params(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(
+            model='orcarouter/deepseek/deepseek-v4-pro',
+            key='sk-test-key',
+            api_base='https://api.orcarouter.ai/v1/chat/completions',
+            temperature=0.7,
+            max_tokens=100,
+            timeout=60,
+            retry=1,
+        )
+        assert p.model == 'orcarouter/deepseek/deepseek-v4-pro'
+        assert p.api_base == 'https://api.orcarouter.ai/v1/chat/completions'
+        assert p.temperature == 0.7
+        assert p.max_tokens == 100
+
+    def test_key_from_env(self, monkeypatch):
+        monkeypatch.setenv('ORCAROUTER_API_KEY', 'env-key-123')
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', retry=1)
+        assert p.key == 'env-key-123'
+
+    def test_key_param_overrides_env(self, monkeypatch):
+        monkeypatch.setenv('ORCAROUTER_API_KEY', 'env-key')
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='param-key', retry=1)
+        assert p.key == 'param-key'
+
+    def test_api_base_from_env(self, monkeypatch):
+        monkeypatch.setenv('ORCAROUTER_API_BASE', 'https://custom.example/v1/chat/completions')
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='sk', retry=1)
+        assert p.api_base == 'https://custom.example/v1/chat/completions'
+
+    def test_missing_key_raises(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        with pytest.raises(ValueError, match='OrcaRouter API key is required'):
+            OrcaRouterAPI(model='orcarouter/auto', key=None, retry=1)
+
+
+class TestPrepareContent:
+
+    def test_text_only(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='sk', retry=1)
+        inputs = [
+            {'type': 'text', 'value': 'Hello'},
+            {'type': 'text', 'value': 'World'},
+        ]
+        result = p._prepare_content(inputs)
+        assert len(result) == 1
+        assert result[0]['type'] == 'text'
+        assert result[0]['text'] == 'Hello\nWorld'
+
+    def test_image_and_text(self, tmp_path):
+        from PIL import Image
+        img_path = str(tmp_path / 'test.jpg')
+        Image.new('RGB', (10, 10), color='red').save(img_path)
+
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='sk', retry=1)
+        inputs = [
+            {'type': 'text', 'value': 'Describe this image'},
+            {'type': 'image', 'value': img_path},
+        ]
+        result = p._prepare_content(inputs)
+        assert len(result) == 2
+        assert result[0] == {'type': 'text', 'text': 'Describe this image'}
+        assert result[1]['type'] == 'image_url'
+        assert 'data:image/jpeg;base64,' in result[1]['image_url']['url']
+
+
+class TestPrepareMessages:
+
+    def test_flat_inputs(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='sk', retry=1)
+        inputs = [{'type': 'text', 'value': 'Hello'}]
+        msgs = p._prepare_messages(inputs)
+        assert len(msgs) == 1
+        assert msgs[0]['role'] == 'user'
+
+    def test_system_prompt(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', system_prompt='Be concise.', key='sk', retry=1)
+        inputs = [{'type': 'text', 'value': 'Hello'}]
+        msgs = p._prepare_messages(inputs)
+        assert len(msgs) == 2
+        assert msgs[0]['role'] == 'system'
+        assert msgs[0]['content'] == 'Be concise.'
+        assert msgs[1]['role'] == 'user'
+
+    def test_role_based_inputs(self):
+        OrcaRouterAPI = _load_orcarouter_api()
+        p = OrcaRouterAPI(model='orcarouter/auto', key='sk', retry=1)
+        inputs = [
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'Hi'}]},
+            {'role': 'assistant', 'content': [{'type': 'text', 'value': 'Hello!'}]},
+            {'role': 'user', 'content': [{'type': 'text', 'value': 'Bye'}]},
+        ]
+        msgs = p._prepare_messages(inputs)
+        assert len(msgs) == 3
+        assert msgs[0]['role'] == 'user'
+        assert msgs[1]['role'] == 'assistant'
+        assert msgs[2]['role'] == 'user'
+
+
+class TestGenerateInner:
+
+    def test_success(self, provider_and_mod):
+        p, mod, fake_post = provider_and_mod
+
+        inputs = [{'type': 'text', 'value': 'What is 6*7?'}]
+        ret_code, answer, log = p.generate_inner(inputs)
+
+        assert ret_code == 0
+        assert answer == '4'
+        call_args = fake_post.call_args
+        assert call_args.args[0] == 'https://api.orcarouter.ai/v1/chat/completions'
+        assert call_args.kwargs['headers']['Authorization'] == 'Bearer sk-test'
+        import json as _json
+        payload = _json.loads(call_args.kwargs['data'])
+        assert payload['model'] == 'orcarouter/auto'
+        assert payload['messages'][0]['role'] == 'user'
+        assert payload['temperature'] == 0
+        assert payload['max_tokens'] == 2048
+
+    def test_error_returns_negative_one(self, provider_and_mod, monkeypatch):
+        p, mod, fake_post = provider_and_mod
+        p.verbose = False
+        fake_post.side_effect = Exception('API down')
+
+        inputs = [{'type': 'text', 'value': 'test'}]
+        ret_code, answer, log = p.generate_inner(inputs)
+
+        assert ret_code == -1
+        assert 'Failed' in answer
+        assert 'API down' in log
+
+    def test_http_error_returns_status(self, provider_and_mod):
+        p, mod, fake_post = provider_and_mod
+        resp = mock.MagicMock(status_code=401, text='Unauthorized')
+        resp.json.side_effect = ValueError('no json')
+        fake_post.return_value = resp
+
+        inputs = [{'type': 'text', 'value': 'test'}]
+        ret_code, answer, log = p.generate_inner(inputs)
+
+        assert ret_code == 401
+        assert 'Failed' in answer
+
+    def test_temperature_override(self, provider_and_mod):
+        p, mod, fake_post = provider_and_mod
+
+        p.generate_inner(
+            [{'type': 'text', 'value': 'test'}],
+            temperature=0.9,
+        )
+        import json as _json
+        payload = _json.loads(fake_post.call_args.kwargs['data'])
+        assert payload['temperature'] == 0.9
+
+    def test_max_tokens_override(self, provider_and_mod):
+        p, mod, fake_post = provider_and_mod
+
+        p.generate_inner(
+            [{'type': 'text', 'value': 'test'}],
+            max_tokens=500,
+        )
+        import json as _json
+        payload = _json.loads(fake_post.call_args.kwargs['data'])
+        assert payload['max_tokens'] == 500
+
+
+class TestConfigRegistration:
+
+    def test_orcarouter_entries_in_config(self):
+        with open('vlmeval/config.py') as f:
+            content = f.read()
+        assert 'OrcaRouter_Auto' in content
+        assert 'OrcaRouter_DeepSeek_V4_Pro' in content
+        assert 'OrcaRouter_Qwen3_5_Flash' in content
+        assert 'api.OrcaRouterAPI' in content
+
+    def test_orcarouter_in_init_all(self):
+        with open('vlmeval/api/__init__.py') as f:
+            content = f.read()
+        assert 'from .orcarouter import OrcaRouterAPI' in content
+        assert "'OrcaRouterAPI'" in content
+
+    def test_api_base_constant(self):
+        with open('vlmeval/api/orcarouter.py') as f:
+            content = f.read()
+        assert 'https://api.orcarouter.ai/v1/chat/completions' in content

--- a/vlmeval/api/__init__.py
+++ b/vlmeval/api/__init__.py
@@ -19,6 +19,7 @@ from .lmdeploy import LMDeployAPI, LMDeployWrapper
 from .minimax_api import MiniMaxAPI
 from .mug_u import MUGUAPI
 from .openai_sdk import OpenAISDKWrapper
+from .orcarouter import OrcaRouterAPI
 from .qwen_api import QwenAPI
 from .qwen_vl_api import Qwen2VLAPI, QwenVLAPI, QwenVLWrapper
 from .rbdashmm_chat3_5_api import RBdashMMChat3_5_38B_API, RBdashMMChat3_78B_API
@@ -42,5 +43,5 @@ __all__ = [
     'TaichuVLAPI', 'TaichuVLRAPI', 'DoubaoVL', "MUGUAPI", 'KimiVLAPIWrapper', 'KimiVLAPI',
     'RBdashMMChat3_API', 'RBdashChat3_5_API', 'RBdashMMChat3_78B_API', 'RBdashMMChat3_5_38B_API',
     'VideoChatOnlineV2API', 'TeleMM2_API', 'TeleMM2Thinking_API', 'TogetherAPI', 'GCPVertexAPI',
-    'BedrockAPI', 'SenseChatVisionV2API', 'MiniMaxAPI', 'LiteLLMAPI',
+    'BedrockAPI', 'SenseChatVisionV2API', 'MiniMaxAPI', 'LiteLLMAPI', 'OrcaRouterAPI',
 ]

--- a/vlmeval/api/orcarouter.py
+++ b/vlmeval/api/orcarouter.py
@@ -1,0 +1,153 @@
+"""
+OrcaRouter API support for VLMEvalKit.
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that
+routes to frontier open-source and commercial LLMs through a single endpoint
+(`https://api.orcarouter.ai/v1`).  Model strings follow the form
+``orcarouter/<model>``; the special ``orcarouter/auto`` model routes each
+request to the best available model for the task.
+
+Set ``ORCAROUTER_API_KEY`` or pass ``key=...``.  Optionally override the
+endpoint with ``ORCAROUTER_API_BASE`` or ``api_base=...``.
+"""
+import json
+import os
+
+import numpy as np
+import requests
+
+from ..smp import encode_image_to_base64, get_logger
+from .base import BaseAPI
+
+logger = get_logger(__name__)
+
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1/chat/completions"
+
+
+class OrcaRouterAPI(BaseAPI):
+    """VLM/LLM API using OrcaRouter (OpenAI-compatible; supports vision).
+
+    It also runs gateway-level, zero-trust security for AI agents on the
+    same endpoint — screening every prompt/response and governing every tool
+    call on a default-deny basis, with no application code changes.
+    """
+
+    is_api: bool = True
+
+    def __init__(
+        self,
+        model: str = "orcarouter/auto",
+        key: str = None,
+        api_base: str = None,
+        retry: int = 10,
+        wait: int = 1,
+        system_prompt: str = None,
+        verbose: bool = True,
+        temperature: float = 0,
+        max_tokens: int = 2048,
+        timeout: int = 300,
+        img_size: int = -1,
+        **kwargs,
+    ):
+        self.model = model
+        self.key = key or os.environ.get("ORCAROUTER_API_KEY")
+        self.api_base = api_base or os.environ.get(
+            "ORCAROUTER_API_BASE", ORCAROUTER_API_BASE
+        )
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.timeout = timeout
+        self.img_size = img_size
+
+        if not self.key:
+            raise ValueError(
+                "OrcaRouter API key is required. Set ORCAROUTER_API_KEY or pass key=..."
+            )
+
+        super().__init__(
+            retry=retry,
+            wait=wait,
+            system_prompt=system_prompt,
+            verbose=verbose,
+            **kwargs,
+        )
+
+        logger.info(f"OrcaRouterAPI: model={self.model}, api_base={self.api_base}")
+
+    def _prepare_content(self, inputs):
+        """Build OpenAI-style content list (text + image_url with base64)."""
+        assert all(isinstance(x, dict) for x in inputs)
+        has_images = np.sum([x["type"] == "image" for x in inputs])
+        if has_images:
+            content_list = []
+            for item in inputs:
+                if item["type"] == "text" and item["value"]:
+                    content_list.append({"type": "text", "text": item["value"]})
+                elif item["type"] == "image":
+                    from PIL import Image
+
+                    img = Image.open(item["value"])
+                    b64 = encode_image_to_base64(img, target_size=self.img_size)
+                    content_list.append({
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+                    })
+            return content_list
+        text = "\n".join([x["value"] for x in inputs if x["type"] == "text"])
+        return [{"type": "text", "text": text or ""}]
+
+    def _prepare_messages(self, inputs):
+        if self.system_prompt:
+            out = [{"role": "system", "content": self.system_prompt}]
+        else:
+            out = []
+        if inputs and "role" in inputs[0]:
+            for item in inputs:
+                out.append({
+                    "role": item["role"],
+                    "content": self._prepare_content(item["content"]),
+                })
+        else:
+            out.append({"role": "user", "content": self._prepare_content(inputs)})
+        return out
+
+    def generate_inner(self, inputs, **kwargs):
+        temperature = kwargs.pop("temperature", self.temperature)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
+
+        messages = self._prepare_messages(inputs)
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        try:
+            response = requests.post(
+                self.api_base,
+                headers={
+                    "Authorization": f"Bearer {self.key}",
+                    "Content-Type": "application/json",
+                },
+                data=json.dumps(payload),
+                timeout=self.timeout * 1.1,
+            )
+        except Exception as err:
+            if self.verbose:
+                logger.error(f"{type(err).__name__}: {err}")
+            return -1, self.fail_msg, str(err)
+
+        ret_code = response.status_code
+        ret_code = 0 if (200 <= ret_code < 300) else ret_code
+        answer = self.fail_msg
+
+        try:
+            data = response.json()
+            answer = data["choices"][0]["message"]["content"].strip()
+        except Exception as err:
+            if self.verbose:
+                logger.error(f"{type(err).__name__}: {err}")
+                logger.error(response.text)
+
+        return ret_code, answer, response

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -482,6 +482,29 @@ api_models = {
         max_tokens=2048,
         retry=10,
     ),
+    # OrcaRouter — OpenAI-compatible gateway (set ORCAROUTER_API_KEY)
+    # Docs: https://www.orcarouter.ai
+    "OrcaRouter_Auto": partial(
+        api.OrcaRouterAPI,
+        model="orcarouter/auto",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "OrcaRouter_DeepSeek_V4_Pro": partial(
+        api.OrcaRouterAPI,
+        model="orcarouter/deepseek/deepseek-v4-pro",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
+    "OrcaRouter_Qwen3_5_Flash": partial(
+        api.OrcaRouterAPI,
+        model="orcarouter/qwen/qwen3.5-flash",
+        temperature=0,
+        max_tokens=2048,
+        retry=10,
+    ),
     # LiteLLM — unified gateway to 100+ providers (pip install litellm)
     # Use any litellm model string. Set provider-specific env vars for auth.
     # Docs: https://docs.litellm.ai/docs/providers


### PR DESCRIPTION
Add a named [OrcaRouter](https://www.orcarouter.ai) provider for VLMEvalKit.

OrcaRouter is an OpenAI-compatible gateway that routes to frontier open-source and commercial LLMs through a single endpoint (`https://api.orcarouter.ai/v1`), with model strings of the form `orcarouter/<model>` (e.g. the special `orcarouter/auto` routes each request to the best available model). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**Changes**
- New `vlmeval/api/orcarouter.py`: `OrcaRouterAPI` (a `BaseAPI` subclass), mirroring the existing OpenAI-compatible providers. Supports text and image (base64 `image_url`) inputs, `ORCAROUTER_API_KEY` / `ORCAROUTER_API_BASE` / `api_base` overrides, default model `orcarouter/auto`.
- Register `OrcaRouter_Auto`, `OrcaRouter_DeepSeek_V4_Pro`, `OrcaRouter_Qwen3_5_Flash` in `vlmeval/config.py` `api_models`.
- Export `OrcaRouterAPI` from `vlmeval/api/__init__.py`.
- Add `tests/test_orcarouter_api.py` covering init, content/message building, `generate_inner`, and config registration.

**Verification**
- `pytest tests/test_orcarouter_api.py`: 19 passed.
- `pytest tests/test_litellm_api.py`: 22 passed (regression).
- `pre-commit run --all-files`: all hooks pass.
- Live test: `OrcaRouterAPI(model='orcarouter/auto')` against `https://api.orcarouter.ai/v1/chat/completions` returned `ret_code=0` and the expected response.

Disclosure: I'm an engineer on the OrcaRouter team.
