### PR TITLE
fix(distributed): default LOCAL_RANK to 0 instead of 1 in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -33,7 +33,7 @@ def get_gpu_list():
 RANK = int(os.environ.get('RANK', 0))
 WORLD_SIZE = int(os.environ.get('WORLD_SIZE', 1))
 LOCAL_WORLD_SIZE = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
-LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 1))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 0))
 
 GPU_LIST = get_gpu_list()
 if LOCAL_WORLD_SIZE > 1 and len(GPU_LIST):


### PR DESCRIPTION
### Description

Fixes `LOCAL_RANK` default value in `run.py`:
- In `run.py`, `LOCAL_RANK` was defaulting to `1` (`int(os.environ.get("LOCAL_RANK", 1))`), whereas `RANK` defaults to `0`, `WORLD_SIZE` defaults to `1`, and `LOCAL_WORLD_SIZE` defaults to `1`.
- When launchers or custom multi-process scripts initialize processes without explicitly exporting `LOCAL_RANK` for rank 0, process 0 calculated `DEVICE_START_IDX = GPU_PER_PROC * 1` instead of `0`, binding to GPU 1 and causing device collision.
- Fixed the default value to `0`, matching standard distributed environment conventions.
