### PR TITLE
fix(dataset): preserve literal 'None' options in TSV loading and MCQ prompt building

### DIFF
--- a/vlmeval/dataset/image_mcq.py
+++ b/vlmeval/dataset/image_mcq.py
@@ -223,12 +223,12 @@ class ImageMCQDataset(ImageBaseDataset):
         options = {
             cand: line[cand]
             for cand in string.ascii_uppercase
-            if cand in line and not pd.isna(line[cand])
+            if cand in line and not pd.isna(line[cand]) and str(line[cand]).strip() != ''
         }
         options_prompt = 'Options:\n'
         for key, item in options.items():
             options_prompt += f'{key}. {item}\n'
-        hint = line['hint'] if ('hint' in line and not pd.isna(line['hint'])) else None
+        hint = line['hint'] if ('hint' in line and not pd.isna(line['hint']) and str(line['hint']).strip() != '') else None
         prompt = ''
         if hint is not None:
             prompt += f'Hint: {hint}\n'

--- a/vlmeval/smp/file.py
+++ b/vlmeval/smp/file.py
@@ -269,10 +269,10 @@ def load(f, fmt=None):
         return pd.read_excel(f)
 
     def load_csv(f):
-        return pd.read_csv(f)
+        return pd.read_csv(f, keep_default_na=False)
 
     def load_tsv(f):
-        return pd.read_csv(f, sep='\t')
+        return pd.read_csv(f, sep='\t', keep_default_na=False)
 
     import validators
     if validators.url(f):


### PR DESCRIPTION
### Description

Preserves literal `"None"` option strings in MCQ benchmarks (e.g. SEEDBench_IMG, MMStar):
- In `vlmeval/smp/file.py`, added `keep_default_na=False` to `load_csv` and `load_tsv` so the literal choice string `"None"` (e.g. meaning "zero instances visible" or "None of the above") is not silently converted to `np.nan`.
- In `vlmeval/dataset/image_mcq.py`, updated `build_prompt` to check `str(line[cand]).strip() != ''` in addition to `not pd.isna()`, ensuring valid choices named `"None"` are correctly included in the prompt and presented to the VLM.
