### PR TITLE
[Benchmark] Add SIS-Bench video benchmark

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -127,6 +127,7 @@ from .SGI_Bench_1_0.experimental_reasoning import SGI_Bench_Experimental_Reasoni
 from .SGI_Bench_1_0.idea_generation import SGI_Bench_Idea_Generation
 from .SGI_Bench_1_0.wet_experiment import SGI_Bench_Wet_Experiment
 from .simplevqa import SimpleVQA
+from .sisbench import SISBench
 from .sitebench import SiteBenchImage, SiteBenchVideo
 from .siuo import SIUODataset
 from .siuo_gen import SIUOGenDataset
@@ -332,7 +333,7 @@ VIDEO_DATASET = [
     Video_MMLU_CAP, Video_MMLU_QA,
     Video_Holmes, VCRBench, CGAVCounting,
     EgoExoBench_MCQ, DREAM, VideoTT, VideoMMMU, MVUEval, OMTGBench, V2PBench, AVSpeakerBench,
-    VideoMMEv2, ReVSI
+    VideoMMEv2, ReVSI, SISBench
 ]
 
 # add by EASI team

--- a/vlmeval/dataset/sisbench.py
+++ b/vlmeval/dataset/sisbench.py
@@ -5,14 +5,7 @@ from pathlib import Path
 import pandas as pd
 from huggingface_hub import snapshot_download
 
-from vlmeval.smp import (
-    dump,
-    get_cache_path,
-    get_file_extension,
-    get_intermediate_file_path,
-    load,
-)
-
+from vlmeval.smp import dump, get_cache_path, get_file_extension, get_intermediate_file_path, load
 from .utils.multiple_choice import extract_characters_regex
 from .video_base import VideoBaseDataset
 

--- a/vlmeval/dataset/sisbench.py
+++ b/vlmeval/dataset/sisbench.py
@@ -1,0 +1,265 @@
+import json
+import os.path as osp
+from pathlib import Path
+
+import pandas as pd
+from huggingface_hub import snapshot_download
+
+from vlmeval.smp import (
+    dump,
+    get_cache_path,
+    get_file_extension,
+    get_intermediate_file_path,
+    load,
+)
+
+from .utils.multiple_choice import extract_characters_regex
+from .video_base import VideoBaseDataset
+
+CHOICES = ("A", "B", "C", "D")
+
+SPATIAL_COGNITION_TASKS = {
+    "object_existence",
+    "object_attribute",
+    "relative_direction",
+    "landmark_appearance_order",
+    "landmark_recall",
+    "positional_relationship",
+    "spatial_consistency",
+    "spatio-temporal_consistency",
+}
+
+SELF_AWARENESS_TASKS = {
+    "action_recognition",
+    "action_sequence",
+    "action_recall",
+    "action_prediction",
+    "path_planning",
+}
+
+ALL_TASKS = SPATIAL_COGNITION_TASKS | SELF_AWARENESS_TASKS
+
+TSV_COLUMNS = [
+    "index",
+    "question_id",
+    "video",
+    "concat_num",
+    "task_type",
+    "question",
+    "A",
+    "B",
+    "C",
+    "D",
+    "answer",
+]
+
+
+class SISBench(VideoBaseDataset):
+    """SIS-Bench: spatial intelligence evaluation in UAV videos."""
+
+    TYPE = "Video-MCQ"
+
+    def __init__(self, dataset="SIS-Bench", nframe=32, fps=-1):
+        super().__init__(dataset=dataset, nframe=nframe, fps=fps)
+
+    @classmethod
+    def supported_datasets(cls):
+        return ["SIS-Bench"]
+
+    @staticmethod
+    def _safe_video_name(video_name):
+        path = Path(str(video_name))
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"Invalid SIS-Bench video path: {video_name!r}")
+        if path.suffix.lower() != ".mp4":
+            raise ValueError(f"SIS-Bench video must be an MP4 file: {video_name!r}")
+        return path.as_posix()
+
+    @classmethod
+    def _dimension_for_task(cls, task_type):
+        if task_type in SPATIAL_COGNITION_TASKS:
+            return "spatial_cognition"
+        if task_type in SELF_AWARENESS_TASKS:
+            return "self_awareness"
+        raise ValueError(f"Unknown SIS-Bench task type: {task_type!r}")
+
+    @classmethod
+    def _check_integrity(cls, dataset_path, dataset_name):
+        data_file = osp.join(dataset_path, f"{dataset_name}.tsv")
+        video_root = osp.join(dataset_path, "video")
+        if not osp.isfile(data_file) or not osp.isdir(video_root):
+            return False
+
+        try:
+            data = load(data_file)
+        except Exception:
+            return False
+
+        if any(column not in data for column in TSV_COLUMNS):
+            return False
+        if not data["question_id"].is_unique or not data["index"].is_unique:
+            return False
+        if not set(data["answer"].astype(str).str.upper()).issubset(CHOICES):
+            return False
+        if not set(data["task_type"]).issubset(ALL_TASKS):
+            return False
+
+        for video in data["video"].astype(str).unique():
+            if not osp.isfile(osp.join(video_root, video + ".mp4")):
+                return False
+        return True
+
+    @classmethod
+    def _generate_tsv(cls, dataset_path, dataset_name):
+        jsonl_path = osp.join(dataset_path, "SIS-Bench.jsonl")
+        data_file = osp.join(dataset_path, f"{dataset_name}.tsv")
+        video_root = osp.join(dataset_path, "video")
+        if not osp.isfile(jsonl_path):
+            raise FileNotFoundError(f"SIS-Bench annotations not found: {jsonl_path}")
+        if not osp.isdir(video_root):
+            raise FileNotFoundError(
+                f"SIS-Bench video directory not found: {video_root}"
+            )
+
+        rows = []
+        with open(jsonl_path, "r", encoding="utf-8") as file:
+            for index, raw_line in enumerate(file):
+                item = json.loads(raw_line)
+                video_name = cls._safe_video_name(item["video_name"])
+                options = item["options"]
+                if set(options) != set(CHOICES):
+                    raise ValueError(
+                        f"Expected A-D options for {item['question_id']}, got {sorted(options)}"
+                    )
+                answer = str(item["answer"]).strip().upper()
+                if answer not in CHOICES:
+                    raise ValueError(
+                        f"Invalid answer for {item['question_id']}: {item['answer']!r}"
+                    )
+                task_type = item["task_type"]
+                if task_type not in ALL_TASKS:
+                    raise ValueError(f"Unknown SIS-Bench task type: {task_type!r}")
+
+                video = osp.splitext(video_name)[0]
+                video_path = osp.join(video_root, video_name)
+                if not osp.isfile(video_path):
+                    raise FileNotFoundError(f"SIS-Bench video not found: {video_path}")
+                rows.append(
+                    {
+                        "index": index,
+                        "question_id": item["question_id"],
+                        "video": video,
+                        "concat_num": item["concat_num"],
+                        "task_type": task_type,
+                        "question": item["question"],
+                        "A": options["A"],
+                        "B": options["B"],
+                        "C": options["C"],
+                        "D": options["D"],
+                        "answer": answer,
+                    }
+                )
+
+        data = pd.DataFrame(rows, columns=TSV_COLUMNS)
+        data.to_csv(data_file, sep="\t", index=False)
+        return data_file
+
+    def prepare_dataset(self, dataset_name="SIS-Bench", repo_id="choucsan/SIS-Bench"):
+        dataset_path = get_cache_path(repo_id)
+        if dataset_path is None:
+            dataset_path = snapshot_download(repo_id=repo_id, repo_type="dataset")
+
+        if not self._check_integrity(dataset_path, dataset_name):
+            self._generate_tsv(dataset_path, dataset_name)
+            if not self._check_integrity(dataset_path, dataset_name):
+                raise RuntimeError(
+                    "Generated SIS-Bench metadata failed integrity checks"
+                )
+
+        return {
+            "root": osp.join(dataset_path, "video"),
+            "data_file": osp.join(dataset_path, f"{dataset_name}.tsv"),
+        }
+
+    def build_prompt(self, line, video_llm):
+        if isinstance(line, int):
+            assert line < len(self)
+            line = self.data.iloc[line]
+
+        prompt = (
+            f"{line['question']}\n"
+            "Options:\n"
+            f"(A) {line['A']}\n"
+            f"(B) {line['B']}\n"
+            f"(C) {line['C']}\n"
+            f"(D) {line['D']}\n"
+            "Answer with only the letter of the correct option."
+        )
+        message = []
+        if video_llm:
+            video_path = osp.join(self.data_root, line["video"] + ".mp4")
+            message.append(dict(type="video", value=video_path))
+        else:
+            if not self.split_frame:
+                raise ValueError(
+                    "SIS-Bench frame inference requires nframe or fps to be set."
+                )
+            frames = self.save_video_frames(line["video"])
+            message.extend(dict(type="image", value=frame) for frame in frames)
+        message.append(dict(type="text", value=prompt))
+        return message
+
+    @classmethod
+    def evaluate(cls, eval_file, **judge_kwargs):
+        del judge_kwargs
+        assert get_file_extension(eval_file) in ["xlsx", "json", "tsv"], (
+            "data file should be a supported format (xlsx/json/tsv) file"
+        )
+
+        data = load(eval_file)
+        required_columns = {"prediction", "answer", "task_type"}
+        missing = required_columns - set(data.columns)
+        if missing:
+            raise ValueError(
+                f"SIS-Bench prediction file is missing columns: {sorted(missing)}"
+            )
+
+        dimensions = []
+        parsed_predictions = []
+        scores = []
+        for _, row in data.iterrows():
+            task_type = str(row["task_type"])
+            dimension = cls._dimension_for_task(task_type)
+            prediction = "" if pd.isna(row["prediction"]) else str(row["prediction"])
+            parsed_prediction = extract_characters_regex(
+                prediction, choices=["(A)", "(B)", "(C)", "(D)"]
+            )
+            answer = str(row["answer"]).strip().upper()
+            dimensions.append(dimension)
+            parsed_predictions.append(parsed_prediction)
+            scores.append(int(parsed_prediction == answer))
+
+        data["parsed_prediction"] = parsed_predictions
+        data["dimension"] = dimensions
+        data["score"] = scores
+        score_file = get_intermediate_file_path(eval_file, "_score")
+        dump(data, score_file)
+
+        def accuracy(mask):
+            selected = data.loc[mask, "score"]
+            return 100.0 * selected.mean() if len(selected) else 0.0
+
+        result = {
+            "overall_accuracy": accuracy(pd.Series(True, index=data.index)),
+            "spatial_cognition_accuracy": accuracy(
+                data["dimension"] == "spatial_cognition"
+            ),
+            "self_awareness_accuracy": accuracy(data["dimension"] == "self_awareness"),
+        }
+        for task_type in sorted(ALL_TASKS):
+            metric_name = f"sis_bench_{task_type.replace('-', '_')}_accuracy"
+            result[metric_name] = accuracy(data["task_type"] == task_type)
+
+        rating_file = get_intermediate_file_path(eval_file, "_rating", "json")
+        dump(result, rating_file)
+        return result

--- a/vlmeval/dataset/video_dataset_config.py
+++ b/vlmeval/dataset/video_dataset_config.py
@@ -256,6 +256,9 @@ revsi_dataset = {
     'revsi_64_frame': partial(ReVSI, dataset='ReVSI', nframe=64),
     'revsi_all_frame': partial(ReVSI, dataset='ReVSI', nframe=None),
 }
+sisbench_dataset = {
+    'SIS-Bench_32frame': partial(SISBench, dataset='SIS-Bench', nframe=32),
+}
 
 dream_1k_dataset = {
     'DREAM-1K_8frame': partial(DREAM, dataset='DREAM-1K', nframe=8),
@@ -388,7 +391,8 @@ dataset_groups = [
     longvideobench_dataset, mlvu_dataset, tempcompass_dataset, cgbench_dataset, worldsense_dataset, tamperbench_dataset,
     megabench_dataset, qbench_video_dataset, moviechat1k_dataset, vdc_dataset, video_holmes_dataset, vcrbench_dataset,
     cg_av_counting_dataset, video_mmlu_dataset, egoexobench_dataset, dream_1k_dataset, video_tt_dataset,
-    video_vsi_dataset, mvu_eval_dataset, omtg_dataset, v2pbench_dataset, av_speakerbench_dataset
+    video_vsi_dataset, mvu_eval_dataset, omtg_dataset, v2pbench_dataset, av_speakerbench_dataset,
+    sisbench_dataset
 ]
 
 # add by EASI team


### PR DESCRIPTION
## Summary

Adds support for SIS-Bench, a multiple-choice benchmark for evaluating
spatial intelligence in UAV videos.

## Changes

- Add `SISBench` based on `VideoBaseDataset`.
- Download and prepare `choucsan/SIS-Bench` from Hugging Face.
- Convert the source JSONL annotations into VLMEvalKit TSV format.
- Validate question IDs, task types, answer choices, and video paths.
- Build video MCQ prompts for native video and frame-based models.
- Evaluate overall, spatial-cognition, self-awareness, and per-task accuracy.
- Register the `SIS-Bench_32frame` dataset configuration.

## Testing

- Ran pre-commit on all changed files; all applicable hooks passed.
- Prepared the complete SIS-Bench dataset on Kaggle:
  - 4,856 questions
  - all expected TSV columns present
  - nested MP4 paths resolved successfully
- Loaded `llava-onevision-qwen2-0.5b-ov-hf`.
- Built and submitted a real SIS-Bench video prompt for inference.
- Verified malformed model output is safely scored as incorrect.
- Verified a synthetic correct prediction (`D`) produces:
  - 100% overall accuracy
  - 100% spatial-cognition accuracy
  - 100% `spatio_temporal_consistency` accuracy

This was an integration smoke test, not a full benchmark accuracy run.