### PR TITLE
[Fix] Molmo AI2D: map no-letter answers to the option letter, not its…

### DIFF
--- a/vlmeval/vlm/molmo.py
+++ b/vlmeval/vlm/molmo.py
@@ -77,12 +77,13 @@ class molmo(BaseModel):
         assert dataset is None or isinstance(dataset, str)
         tgt_path = self.dump_image(line, dataset)
         prefix = None
+        ai2d_options = None
         if dataset in ['MMMU_DEV_VAL', 'MMMU_TEST']:
             prompt = self.build_prompt_mcq_vqa(line)
         elif dataset in ['MathVista_MINI']:
             prompt = self.build_prompt_mathvista(line)
         elif dataset in ['AI2D_TEST', 'AI2D_TEST_NO_MASK']:
-            prompt = self.build_prompt_ai2d(line)
+            prompt, ai2d_options = self.build_prompt_ai2d(line)
         elif dataset is not None and listinstr(list(DATASET_PROMPTS.keys()), dataset):
             prefix = DATASET_PROMPTS[dataset]  # rest of supervised datasets are in VQA format
             prompt = self.build_prompt_vqa(line, prefix)
@@ -92,6 +93,9 @@ class molmo(BaseModel):
             prompt = self.build_prompt_vqa(line)
 
         message = [dict(type='text', value=prompt)]
+        if ai2d_options is not None:
+            # The no-letter prompt strips the option letters, so carry them for generate_inner
+            message[0]['ai2d_options'] = ai2d_options
         message.extend([dict(type='image', value=s) for s in tgt_path])
 
         # interleave dataset
@@ -127,9 +131,9 @@ class molmo(BaseModel):
                 prompt += f'\n{item}'
             prompt = f"ai2_diagram_no_letter: {prompt}"
             # prompt = self.build_prompt_multiple_choice(line, prefix='ai2_diagram_no_letter:')
-        else:
-            prompt = self.build_prompt_multiple_choice(line, prefix='ai2_diagram:')
-        return prompt
+            return prompt, options
+        prompt = self.build_prompt_multiple_choice(line, prefix='ai2_diagram:')
+        return prompt, None
 
     def build_prompt_mcq_vqa(self, line):
         if line['question_type'] == 'multiple-choice':
@@ -156,6 +160,21 @@ class molmo(BaseModel):
             prompt = f"{prefix} {question}"
 
         return prompt
+
+    @staticmethod
+    def map_ai2d_answer(options, generated_text):
+        # Map to the option's key, not its position: the letters are not always a
+        # contiguous A/B/C prefix (index 83301 has an empty `A` column, so it is B/C/D).
+        def normalize(text):
+            return str(text).strip().strip(string.punctuation).strip().lower()
+
+        keys = list(options.keys())
+        normalized = [normalize(value) for value in options.values()]
+        target = normalize(generated_text)
+        if target in normalized:
+            return keys[normalized.index(target)]
+        logging.warning(f'Molmo AI2D: reply {generated_text!r} matches no option in {options}.')
+        return generated_text
 
     def build_prompt_vqa(self, line, prefix=None):
         question = line['question']
@@ -200,12 +219,9 @@ class molmo(BaseModel):
         generated_text = self.processor.tokenizer.decode(generated_tokens, skip_special_tokens=True).strip()
 
         # AI2D: map direct answer to letter option
-        if dataset in ['AI2D_TEST', 'AI2D_TEST_NO_MASK']:
-            # 'ai2_diagram_no_letter: Which of the following is the magma chamber?\nK\nB\nC\nH'
-            if 'ai2_diagram_no_letter' in prompt:
-                options = prompt.split('\n')[1:]
-                answer = options.index(generated_text)
-                generated_text = chr(answer + ord('A'))
+        ai2d_options = next((m['ai2d_options'] for m in message if 'ai2d_options' in m), None)
+        if ai2d_options is not None:
+            generated_text = self.map_ai2d_answer(ai2d_options, generated_text)
 
         # print(dataset, prompt, generated_text, inputs['images'].size()) # uncomment to debug
 


### PR DESCRIPTION
## Summary

Molmo's `ai2_diagram_no_letter` prompt shows AI2D options with their A/B/C/D
labels stripped, so `generate_inner` maps the model's reply back to a letter.
It did this by position in the printed list, which is only correct when the
option columns are a contiguous prefix.

AI2D_TEST index 83301 has an empty `A` column, so its options are B/C/D. The
prompt lists `['B', 'A', 'C']`; Molmo answered `'C'` — the value of column D,
i.e. correct — but position 2 mapped it to `'C'`. The row was scored wrong and
was unwinnable for any model. The lettered `ai2_diagram:` path already maps to
the column key, so the two paths disagreed.

## Fix

Carry the `{letter: value}` mapping alongside the prompt on the message item
(the same way video datasets carry `role`) and map the reply back to the key.
The prompt text sent to the model is unchanged.

Also stop aborting the run on an unrecognised reply: `options.index()` raised
`ValueError`, which `SKIP_ERR` does not catch (it handles only `RuntimeError`),
so one stray token discarded a full eval. Replies are now normalised for
whitespace, punctuation and case, and returned unchanged when nothing matches,
leaving the decision to the existing answer matcher.

## Validation

Molmo-7B-D-0924, AI2D_TEST, `--judge exact_matching`, `max_crops=36`:

| | before | after |
|---|---|---|
| accuracy | 2511/3088 = 0.813148 | 2512/3088 = 0.813472 |
| predictions changed | — | 1 (index 83301, `C` → `D`) |
| regressions | — | 0 |

3087/3088 predictions are bit-identical — the prompt is unchanged, so no
published Molmo AI2D number moves. Confirmed two independent ways: offline
rescoring of the stored predictions, and a full re-run that reproduced the
same single row.

The `ai2_diagram_no_letter` path was added in #648 to match the official Molmo
eval; this keeps that behaviour and fixes only the letter mapping.
