### PR TITLE
[Benchmark] Add DocScope dataset

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -23,6 +23,7 @@ from .cmmmu import CMMMU
 from .creation import CreationMMBenchDataset
 from .da2k import DA2K
 from .design2code import Design2Code
+from .docscope import DocScope
 from .dream import DREAM
 from .dsrbench import DSRBench
 from .dude import DUDE
@@ -286,7 +287,8 @@ class ConcatDataset(ImageBaseDataset):
 IMAGE_DATASET = [
     ImageCaptionDataset, ImageYORNDataset, ImageMCQDataset, ImageVQADataset,
     MathVision, LENS, MMMUDataset, OCRBench, MathVista, LLaVABench, LLaVABench_KO, VGRPBench, MMVet,  # noqa: E501
-    MTVQADataset, TableVQABench, MMLongBench, MemLens, MMLongBenchDoc, VCRDataset, MMDUDataset, DUDE, LongDocURL,
+    MTVQADataset, TableVQABench, MMLongBench, MemLens, MMLongBenchDoc, VCRDataset, MMDUDataset, DUDE, DocScope,
+    LongDocURL,
     SlideVQA, MUIRDataset, CCOCRDataset, GMAIMMBenchDataset, MMERealWorld,
     HRBenchDataset, CRPE, MathVerse, NaturalBenchDataset, MIABench,
     OlympiadBench, SeePhys, WildVision, MMMath, QSpatial, Dynamath, GSM8KVDataset, MMGenBench, VizWiz,  # noqa: E501

--- a/vlmeval/dataset/docscope.py
+++ b/vlmeval/dataset/docscope.py
@@ -1,0 +1,984 @@
+import hashlib
+import json
+import os
+import os.path as osp
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+
+import pandas as pd
+from PIL import Image, ImageDraw, ImageFont
+
+from vlmeval.smp import LMUDataRoot, dump, get_intermediate_file_path, get_logger, load
+from vlmeval.utils import track_progress_rich
+from .image_base import ImageBaseDataset
+from .utils.docscope_reasoning_prompts import (INFER_SYSTEM_PROMPT, page_marker_end,
+                                               page_marker_start, page_prf, parse_model_output)
+from .utils.judge_util import build_judge
+
+logger = get_logger(__name__)
+
+PROMPT_DIR = Path(__file__).resolve().parent / 'utils' / 'docscope_prompts'
+HF_REPO_ID = 'MiliLab/DocScope'
+FAIL_MSG = 'Failed to obtain answer via API.'
+
+_DUMP_LOCK = Lock()
+
+
+def _import_fitz():
+    try:
+        import fitz
+    except ImportError as err:
+        logger.error(
+            'Failed to import fitz from PyMuPDF: %s. Install it in the VLMEvalKit '
+            'environment with `pip install PyMuPDF`.',
+            err,
+        )
+        raise
+    return fitz
+
+
+@dataclass
+class DocScopeBenchEntry:
+    qid: str
+    question: str
+    doc_id: str
+    answer_text: str
+    is_answerable: bool
+    evidences: list[dict]
+    facts: list[dict]
+
+    def gold_pages(self):
+        return sorted({
+            int(e['page']) for e in self.evidences
+            if isinstance(e, dict) and isinstance(e.get('page'), (int, float))
+        })
+
+    def evidences_on_page(self, page):
+        return [e for e in self.evidences if e.get('page') == page]
+
+    def facts_on_page(self, page):
+        ev_ids = {e['local_id'] for e in self.evidences_on_page(page) if e.get('local_id')}
+        return [f for f in self.facts if f.get('evidence_local_id') in ev_ids]
+
+    def facts_off_page(self, page):
+        ev_ids = {e['local_id'] for e in self.evidences_on_page(page) if e.get('local_id')}
+        return [f for f in self.facts if f.get('evidence_local_id') not in ev_ids]
+
+
+def _is_missing(value):
+    return value is None or (isinstance(value, float) and pd.isna(value))
+
+
+def _json_dumps(value):
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _json_loads(value, default=None):
+    if isinstance(value, (list, dict)):
+        return value
+    if _is_missing(value):
+        return default
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:
+            return default
+    return default
+
+
+def _load_jsonl(path):
+    rows = []
+    if not osp.exists(path):
+        return rows
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+def _jsonl_done_keys(path, fields):
+    keys = set()
+    for rec in _load_jsonl(path):
+        parts = []
+        for field in fields:
+            value = rec.get(field)
+            if value is None:
+                break
+            if field == 'page':
+                try:
+                    value = int(value)
+                except (TypeError, ValueError):
+                    break
+            else:
+                value = str(value)
+            parts.append(value)
+        else:
+            keys.add(tuple(parts) if len(parts) > 1 else parts[0])
+    return keys
+
+
+def _safe_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _safe_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _append_jsonl(path, rec):
+    os.makedirs(osp.dirname(path), exist_ok=True)
+    with open(path, 'a', encoding='utf-8') as f:
+        f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+
+
+def _append_message_dump(path, rec):
+    if not path:
+        return
+    os.makedirs(osp.dirname(path), exist_ok=True)
+    with _DUMP_LOCK:
+        with open(path, 'a', encoding='utf-8') as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+
+
+def _sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _normalize_messages_for_dump(messages, image_path_map=None):
+    image_path_map = image_path_map or {}
+
+    def convert(obj):
+        if isinstance(obj, list):
+            return [convert(x) for x in obj]
+        if not isinstance(obj, dict):
+            return obj
+        out = {k: convert(v) for k, v in obj.items()}
+        if obj.get('type') == 'image_url':
+            image_url = dict(obj.get('image_url') or {})
+            url = image_url.get('url', '')
+            path = image_path_map.get(url) or image_url.get('path')
+            if path and osp.exists(path):
+                image_url['url'] = str(path)
+                image_url['sha256'] = _sha256_file(path)
+                image_url['bytes'] = osp.getsize(path)
+            out['image_url'] = image_url
+        return out
+
+    return convert(messages)
+
+
+def _parse_judge_json(text):
+    text = (text or '').strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    start = text.find('{')
+    end = text.rfind('}')
+    if 0 <= start < end:
+        try:
+            return json.loads(text[start:end + 1])
+        except Exception:
+            pass
+    return None
+
+
+def _font(size=16):
+    for path in (
+        '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+        '/System/Library/Fonts/Supplemental/Arial.ttf',
+        '/Library/Fonts/Arial.ttf',
+    ):
+        if Path(path).exists():
+            try:
+                return ImageFont.truetype(path, size)
+            except Exception:
+                continue
+    return ImageFont.load_default()
+
+
+def _draw_box(draw, bbox_px, color, label, width=4):
+    x1, y1, x2, y2 = bbox_px
+    if x2 < x1:
+        x1, x2 = x2, x1
+    if y2 < y1:
+        y1, y2 = y2, y1
+    draw.rectangle([x1, y1, x2, y2], outline=color, width=width)
+    if not label:
+        return
+    font = _font(16)
+    try:
+        box = draw.textbbox((0, 0), label, font=font)
+        tw, th = box[2] - box[0], box[3] - box[1]
+    except Exception:
+        tw, th = 20, 16
+    pad = 2
+    ty = max(0, y1 - th - 2 * pad)
+    draw.rectangle([x1, ty, x1 + tw + 2 * pad, ty + th + 2 * pad], fill=color)
+    draw.text((x1 + pad, ty + pad), label, fill='white', font=font)
+
+
+def _render_pdf_page(pdf_path, page, dpi, out_path):
+    fitz = _import_fitz()
+
+    out_path = Path(out_path)
+    if out_path.exists():
+        if out_path.stat().st_size > 0:
+            return out_path
+        logger.warning(f'Removing empty DocScope page cache: {out_path}')
+        out_path.unlink()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    doc = fitz.open(str(pdf_path))
+    try:
+        if page < 1 or page > len(doc):
+            return None
+        matrix = fitz.Matrix(dpi / 72.0, dpi / 72.0)
+        pix = doc[page - 1].get_pixmap(matrix=matrix, alpha=False)
+        pix.save(out_path.as_posix())
+    finally:
+        doc.close()
+    return out_path
+
+
+def _render_pair(pdf_path, page, gold_bboxes_px, pred_bboxes_norm, out_path, cache_root):
+    src = _render_pdf_page(pdf_path, page, 144, Path(cache_root) / Path(pdf_path).stem / f'page_{page:04d}.png')
+    if src is None:
+        return False
+    try:
+        im = Image.open(src).convert('RGB')
+    except OSError as err:
+        logger.warning(f'Removing corrupt DocScope page cache {src}: {err}')
+        Path(src).unlink(missing_ok=True)
+        src = _render_pdf_page(pdf_path, page, 144, Path(cache_root) / Path(pdf_path).stem / f'page_{page:04d}.png')
+        if src is None:
+            return False
+        im = Image.open(src).convert('RGB')
+    width, height = im.size
+    draw = ImageDraw.Draw(im)
+    for i, gb in enumerate(gold_bboxes_px or []):
+        if not gb or len(gb) != 4:
+            continue
+        label = 'GOLD' if len(gold_bboxes_px) == 1 else f'GOLD[{i + 1}]'
+        _draw_box(draw, tuple(gb), 'green', label)
+    pred_count = len([b for b in pred_bboxes_norm if b and len(b) == 4])
+    for idx, b in enumerate(pred_bboxes_norm):
+        if not b or len(b) != 4:
+            continue
+        box_px = (b[0] * width, b[1] * height, b[2] * width, b[3] * height)
+        label = 'PRED' if pred_count == 1 else f'PRED[{idx + 1}]'
+        _draw_box(draw, box_px, 'red', label)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    im.save(out_path)
+    return True
+
+
+def _format_gold_block(evs_on_page):
+    lines = []
+    g_meta = []
+    for i, ev in enumerate(evs_on_page, start=1):
+        gid = f'g{i}'
+        bbox = ev.get('bbox') or []
+        line = (
+            f'id={gid} :: index_on_page={i}, '
+            f"element_type={ev.get('element_type', 'unknown')}, "
+            f'gold_bbox_px={bbox}'
+        )
+        lines.append(line)
+        g_meta.append({
+            'gold_id': gid,
+            'evidence_local_id': ev.get('local_id'),
+            'element_type': ev.get('element_type'),
+            'gold_bbox_px': bbox,
+        })
+    return '\n'.join(lines), g_meta
+
+
+def _format_facts_block(facts_on_page):
+    lines = []
+    meta = []
+    for fa in facts_on_page:
+        fid = fa.get('local_id') or f'f{len(meta) + 1}'
+        text = fa.get('text_description', '') or ''
+        lines.append(f'id={fid} :: {text}')
+        meta.append({
+            'fact_id': fid,
+            'evidence_local_id': fa.get('evidence_local_id'),
+            'key_entity': fa.get('key_entity'),
+            'key_value': fa.get('key_value'),
+            'fact_text': text,
+        })
+    return '\n'.join(lines), meta
+
+
+def _format_siblings(facts_off_page):
+    if not facts_off_page:
+        return '(none)'
+    return '; '.join(f.get('text_description', '') or '' for f in facts_off_page)
+
+
+class DocScope(ImageBaseDataset):
+    TYPE = 'VQA'
+    MODALITY = 'IMAGE'
+    DEFAULT_JUDGE = 'gpt-4o-mini'
+    DATASET_URL = {'DocScope': '', 'DocScope_DEV': '', 'DocScope_TEST': ''}
+    DATASET_MD5 = {}
+    force_use_dataset_prompt = True
+
+    def __init__(
+        self,
+        dataset='DocScope_TEST',
+        max_pages=100,
+        dpi=72,
+        auto_download=True,
+        **kwargs,
+    ):
+        self.docscope_root = Path(LMUDataRoot()) / 'DocScope'
+        self.benchmark_path = self.docscope_root / 'benchmark.json'
+        self.pdf_dir = self.docscope_root / 'pdfs'
+        self.max_pages = int(max_pages)
+        self.dpi = int(dpi)
+        self.auto_download = str(auto_download).lower() not in {'0', 'false', 'no'}
+        super().__init__(dataset=dataset, skip_noimg=False)
+
+    @classmethod
+    def supported_datasets(cls):
+        return list(cls.DATASET_URL)
+
+    @staticmethod
+    def _split_for_dataset(dataset):
+        name = dataset.lower()
+        if name.endswith('_dev'):
+            return 'dev'
+        if name.endswith('_test'):
+            return 'test'
+        return None
+
+    def _setup_hf_cache(self):
+        cache_root = self.docscope_root / '.hf_cache'
+        cache_root.mkdir(parents=True, exist_ok=True)
+        os.environ['HF_HOME'] = str(cache_root / 'home')
+        os.environ['HF_HUB_CACHE'] = str(cache_root / 'hub')
+        os.environ['HF_XET_CACHE'] = str(cache_root / 'xet')
+
+    def _download_hf_file(self, filename):
+        self._setup_hf_cache()
+        try:
+            from huggingface_hub import hf_hub_download, snapshot_download
+        except ImportError as err:
+            raise ImportError(
+                'huggingface_hub is required for DocScope auto download. '
+                'Install it before building the DocScope dataset.'
+            ) from err
+        self.docscope_root.mkdir(parents=True, exist_ok=True)
+        if filename == 'benchmark.json':
+            snapshot_download(
+                repo_id=HF_REPO_ID,
+                repo_type='dataset',
+                local_dir=str(self.docscope_root),
+                allow_patterns=['benchmark.json'],
+            )
+            return self.docscope_root / 'benchmark.json'
+        return Path(hf_hub_download(
+            repo_id=HF_REPO_ID,
+            repo_type='dataset',
+            filename=filename,
+            local_dir=str(self.docscope_root),
+        ))
+
+    def _ensure_benchmark(self):
+        if self.benchmark_path.exists():
+            return self.benchmark_path
+        if not self.auto_download:
+            raise FileNotFoundError(f'DocScope benchmark.json not found: {self.benchmark_path}')
+        logger.warning(f'DocScope benchmark.json not found. Downloading from Hugging Face to {self.docscope_root}.')
+        return self._download_hf_file('benchmark.json')
+
+    def _ensure_pdf(self, doc_id):
+        candidate = self.pdf_dir / f'{doc_id}.pdf'
+        if candidate.exists():
+            return candidate
+        if not self.auto_download:
+            raise FileNotFoundError(f'DocScope PDF not found for {doc_id}: {candidate}')
+        logger.warning(f'DocScope PDF {doc_id}.pdf not found. Downloading from Hugging Face.')
+        path = self._download_hf_file(f'pdfs/{doc_id}.pdf')
+        if path.exists():
+            return path
+        raise FileNotFoundError(f'DocScope PDF download failed for {doc_id}')
+
+    @classmethod
+    def _row_from_entry(cls, entry):
+        pdf_block = entry.get('pdf') or {}
+        answer_block = entry.get('answer') or {}
+        evidences = entry.get('evidences') or []
+        facts = entry.get('facts') or []
+        pages = sorted({
+            int(e['page']) for e in evidences
+            if isinstance(e, dict) and isinstance(e.get('page'), (int, float))
+        })
+        qid = entry.get('id') or entry.get('question_id') or ''
+        return {
+            'index': qid,
+            'question_id': qid,
+            'question': entry.get('question', ''),
+            'answer': answer_block.get('answer_text', '') or '',
+            'is_answerable': bool(answer_block.get('is_answerable', True)),
+            'doc_id': pdf_block.get('doc_id_str', ''),
+            'gold_pages': _json_dumps(pages),
+            'evidences': _json_dumps(evidences),
+            'facts': _json_dumps(facts),
+            'extract_class': entry.get('extract_class', ''),
+            'split': entry.get('split', ''),
+        }
+
+    def load_data(self, dataset):
+        benchmark = self._ensure_benchmark()
+        raw = json.loads(benchmark.read_text(encoding='utf-8'))
+        rows = raw['data'] if isinstance(raw, dict) and 'data' in raw else raw
+        split = self._split_for_dataset(dataset)
+        if split:
+            rows = [r for r in rows if r.get('split') == split]
+        limit = int(os.environ.get('DOCSCOPE_LIMIT', '0') or 0)
+        if limit > 0:
+            rows = rows[:limit]
+        return pd.DataFrame([self._row_from_entry(r) for r in rows])
+
+    def _bench_entry_from_line(self, line):
+        return DocScopeBenchEntry(
+            qid=str(line['question_id']),
+            question=str(line['question']),
+            doc_id=str(line['doc_id']),
+            answer_text=str(line.get('answer', '') or ''),
+            is_answerable=bool(line.get('is_answerable', True)),
+            evidences=_json_loads(line.get('evidences'), []),
+            facts=_json_loads(line.get('facts'), []),
+        )
+
+    def _benchmark_index(self):
+        return {
+            str(line['question_id']): self._bench_entry_from_line(line)
+            for _, line in self.data.iterrows()
+        }
+
+    def _render_pdf_pages(self, pdf_path):
+        fitz = _import_fitz()
+
+        cache_dir = Path(self.img_root) / 'page_cache' / Path(pdf_path).stem / f'{self.dpi}dpi'
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = cache_dir / '.done'
+        if sentinel.exists():
+            pages = sorted(cache_dir.glob('page_*.png'))
+            if pages:
+                return pages
+
+        doc = fitz.open(str(pdf_path))
+        out_paths = []
+        try:
+            matrix = fitz.Matrix(self.dpi / 72.0, self.dpi / 72.0)
+            for i, page in enumerate(doc, start=1):
+                out = cache_dir / f'page_{i:04d}.png'
+                if not out.exists():
+                    pix = page.get_pixmap(matrix=matrix, alpha=False)
+                    pix.save(out.as_posix())
+                out_paths.append(out)
+        finally:
+            doc.close()
+        sentinel.touch()
+        return out_paths
+
+    def dump_image(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+        doc_id = str(line['doc_id'])
+        pdf_path = self._ensure_pdf(doc_id)
+        pages = self._render_pdf_pages(pdf_path)
+        return [str(p) for p in pages[:self.max_pages]]
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+        question = str(line['question'])
+        page_paths = self.dump_image(line)
+        page_numbers = list(range(1, len(page_paths) + 1))
+
+        msgs = [dict(type='text', value=INFER_SYSTEM_PROMPT, role='system')]
+        for page, img_path in zip(page_numbers, page_paths):
+            msgs.append(dict(type='text', value=page_marker_start(page)))
+            msgs.append(dict(type='image', value=img_path))
+            msgs.append(dict(type='text', value=page_marker_end(page)))
+        msgs.append(dict(type='text', value=f'Question: {question}'))
+        return msgs
+
+    def _records_from_eval(self, eval_file):
+        data = load(eval_file)
+        if isinstance(data, list):
+            data = pd.DataFrame(data)
+        elif isinstance(data, dict):
+            data = pd.DataFrame(data)
+        records = []
+        for _, line in data.iterrows():
+            qid = str(line.get('question_id', line.get('index', '')))
+            prediction = str(line.get('prediction', '') or '')
+            status = 'ok'
+            if FAIL_MSG in prediction or prediction == '':
+                status = 'error: empty prediction'
+            records.append({
+                'question_id': qid,
+                'model': Path(eval_file).stem.split('_', 1)[0],
+                'model_raw': prediction,
+                'thinking': str(line.get('thinking', '') or ''),
+                'parsed': parse_model_output(prediction) if status == 'ok' else {},
+                'infer_usage': {},
+                'status': status,
+            })
+        return records
+
+    def _score_pages(self, records, bench, pages_file):
+        existing = _load_jsonl(pages_file)
+        done = {str(r.get('question_id')) for r in existing if r.get('question_id') is not None}
+        sum_p = sum_r = sum_f1 = 0.0
+        n = tp = fp = fn = 0
+        for row in existing:
+            if row.get('status') != 'ok':
+                continue
+            sum_p += _safe_float(row.get('precision'))
+            sum_r += _safe_float(row.get('recall'))
+            sum_f1 += _safe_float(row.get('f1'))
+            tp += _safe_int(row.get('tp'))
+            fp += _safe_int(row.get('fp'))
+            fn += _safe_int(row.get('fn'))
+            n += 1
+        for record in records:
+            qid = str(record.get('question_id'))
+            if qid in done:
+                continue
+            if record.get('status') != 'ok':
+                _append_jsonl(pages_file, {
+                    'question_id': qid,
+                    'status': record.get('status'),
+                    'skipped': True,
+                })
+                continue
+            be = bench.get(qid)
+            parsed = record.get('parsed') or {}
+            pred_pages = parsed.get('predicted_pages') or []
+            gold_pages = be.gold_pages() if be else []
+            prf = page_prf(pred_pages, gold_pages)
+            _append_jsonl(pages_file, {
+                'question_id': qid,
+                'gold_pages': prf['gold'],
+                'predicted_pages': prf['predicted'],
+                'tp': prf['tp'],
+                'fp': prf['fp'],
+                'fn': prf['fn'],
+                'precision': prf['precision'],
+                'recall': prf['recall'],
+                'f1': prf['f1'],
+                'status': 'ok',
+            })
+            sum_p += prf['precision']
+            sum_r += prf['recall']
+            sum_f1 += prf['f1']
+            tp += prf['tp']
+            fp += prf['fp']
+            fn += prf['fn']
+            n += 1
+        micro_p = tp / (tp + fp) if (tp + fp) else 0.0
+        micro_r = tp / (tp + fn) if (tp + fn) else 0.0
+        micro_f1 = 2 * micro_p * micro_r / (micro_p + micro_r) if (micro_p + micro_r) else 0.0
+        return {
+            'pages|macro_precision': sum_p / n if n else 0.0,
+            'pages|macro_recall': sum_r / n if n else 0.0,
+            'pages|macro_f1': sum_f1 / n if n else 0.0,
+            'pages|micro_precision': micro_p,
+            'pages|micro_recall': micro_r,
+            'pages|micro_f1': micro_f1,
+        }
+
+    def _bbox_message(self, template, be, qid, page, record, imgs_dir):
+        evs_on_page = be.evidences_on_page(page)
+        citations = (record.get('parsed') or {}).get('citations') or []
+        pred_on_page = [c for c in citations if c.get('page') == page]
+        pred_norm = []
+        pred_skipped = []
+        for c in pred_on_page:
+            bbox = c.get('bbox') or []
+            if len(bbox) != 4:
+                continue
+            if c.get('is_normalized', False):
+                pred_norm.append(bbox)
+            else:
+                pred_skipped.append(bbox)
+        gold_block, g_meta = _format_gold_block(evs_on_page)
+        img_path = Path(imgs_dir) / f"{qid.replace('::', '__')}__p{page}.png"
+        pdf_path = self._ensure_pdf(be.doc_id)
+        rendered = _render_pair(
+            pdf_path,
+            page,
+            [ev.get('bbox') for ev in evs_on_page],
+            pred_norm,
+            img_path,
+            Path(self.img_root) / 'eval_page_cache',
+        )
+        if not rendered:
+            return None, g_meta, pred_skipped, pred_norm, img_path
+        user_text = template.format(
+            question=be.question,
+            gold_answer=be.answer_text,
+            gt_page=page,
+            gold_total_on_page=len(evs_on_page),
+            gold_facts_block=gold_block,
+            n_pred=len(pred_norm),
+            pred_bboxes_norm=pred_norm,
+        )
+        messages = [{
+            'role': 'user',
+            'content': [
+                {'type': 'image_url', 'image_url': {'url': str(img_path)}},
+                {'type': 'text', 'text': user_text},
+            ],
+        }]
+        return messages, g_meta, pred_skipped, pred_norm, img_path
+
+    def _score_bbox(self, records, bench, bbox_file, imgs_dir, dump_path, dump_only, judge, judge_model, nproc):
+        template = (PROMPT_DIR / 'evidence_grounding.txt').read_text(encoding='utf-8')
+        done = _jsonl_done_keys(bbox_file, ('question_id', 'page'))
+        tasks = []
+        for record in records:
+            if record.get('status') != 'ok':
+                continue
+            qid = str(record.get('question_id'))
+            be = bench.get(qid)
+            if be is None:
+                continue
+            gold_pages = set(be.gold_pages())
+            pred_pages = set((record.get('parsed') or {}).get('predicted_pages') or [])
+            for page in sorted(gold_pages & pred_pages):
+                page = int(page)
+                if (qid, page) in done:
+                    continue
+                evs = be.evidences_on_page(page)
+                if not evs:
+                    continue
+                messages, g_meta, pred_skipped, pred_norm, img_path = self._bbox_message(
+                    template, be, qid, page, record, imgs_dir)
+                if messages is None:
+                    for gm in g_meta:
+                        _append_jsonl(
+                            bbox_file,
+                            {
+                                'question_id': qid,
+                                'page': page,
+                                **gm,
+                                'label': None,
+                                'reason': 'render_failed',
+                                'status': 'render_failed',
+                                'skipped_pred_bboxes': pred_skipped,
+                            },
+                        )
+                    continue
+                dump_messages = _normalize_messages_for_dump(
+                    messages, {str(img_path): str(img_path)})
+                _append_message_dump(
+                    dump_path,
+                    {
+                        'stage': 'judge_bbox',
+                        'question_id': qid,
+                        'page': page,
+                        'messages': dump_messages,
+                    },
+                )
+                tasks.append({
+                    'qid': qid,
+                    'page': page,
+                    'g_meta': g_meta,
+                    'pred_skipped': pred_skipped,
+                    'pred_norm': pred_norm,
+                    'img_path': str(img_path),
+                    'user_text': messages[0]['content'][1]['text'],
+                })
+
+        def _judge_one_bbox(qid, page, g_meta, pred_skipped, pred_norm, img_path, user_text):
+            if dump_only:
+                return [{
+                    'question_id': qid,
+                    'page': page,
+                    **gm,
+                    'n_pred_drawn': len(pred_norm),
+                    'skipped_pred_bboxes': pred_skipped,
+                    'label': None,
+                    'reason': 'message_dumped',
+                    'judge_raw': '',
+                    'judge_usage': {},
+                    'status': 'message_dumped',
+                } for gm in g_meta]
+
+            try:
+                response = judge.generate(
+                    message=[
+                        {'type': 'image', 'value': img_path},
+                        {'type': 'text', 'value': user_text},
+                    ],
+                    dataset=self.dataset_name,
+                )
+                parsed = _parse_judge_json(str(response)) or {}
+                items = parsed.get('items') or []
+                by_id = {it.get('id'): it for it in items if isinstance(it, dict)}
+                error = None
+            except Exception as err:
+                response = f'JUDGE_ERROR: {err}'
+                by_id = {}
+                error = str(err)
+
+            rows = []
+            for gm in g_meta:
+                it = by_id.get(gm['gold_id']) or {}
+                label = it.get('label')
+                status = 'ok' if label in {'covered', 'imprecise', 'not_covered'} else 'judge_parse_error'
+                if error is not None:
+                    status = 'judge_error'
+                rows.append({
+                    'question_id': qid,
+                    'page': page,
+                    **gm,
+                    'n_pred_drawn': len(pred_norm),
+                    'skipped_pred_bboxes': pred_skipped,
+                    'label': label,
+                    'reason': it.get('reason') or error,
+                    'judge_raw': str(response),
+                    'judge_usage': {},
+                    'status': status,
+                })
+            return rows
+
+        if tasks:
+            results = track_progress_rich(_judge_one_bbox, tasks, nproc=nproc)
+            for rows in results:
+                for row in rows:
+                    _append_jsonl(bbox_file, row)
+        return len(done) + len(tasks)
+
+    def _score_facts(self, records, bench, facts_file, dump_path, dump_only, judge, nproc):
+        template = (PROMPT_DIR / 'factucal_consistency.txt').read_text(encoding='utf-8')
+        done = _jsonl_done_keys(facts_file, ('question_id', 'page'))
+        tasks = []
+        for record in records:
+            if record.get('status') != 'ok':
+                continue
+            qid = str(record.get('question_id'))
+            be = bench.get(qid)
+            if be is None:
+                continue
+            gold_pages = set(be.gold_pages())
+            pred_pages = set((record.get('parsed') or {}).get('predicted_pages') or [])
+            for page in sorted(gold_pages & pred_pages):
+                page = int(page)
+                if (qid, page) in done:
+                    continue
+                facts_on = be.facts_on_page(page)
+                if not facts_on:
+                    continue
+                facts_off = be.facts_off_page(page)
+                facts_block, meta = _format_facts_block(facts_on)
+                user_text = template.format(
+                    question=be.question,
+                    gt_page=page,
+                    gold_facts_block=facts_block,
+                    sibling_facts=_format_siblings(facts_off),
+                    model_raw=record.get('model_raw', ''),
+                )
+                messages = [{'role': 'user', 'content': user_text}]
+                _append_message_dump(dump_path, {
+                    'stage': 'judge_facts',
+                    'question_id': qid,
+                    'page': page,
+                    'messages': messages,
+                })
+                tasks.append({
+                    'qid': qid,
+                    'page': page,
+                    'meta': meta,
+                    'user_text': user_text,
+                })
+
+        def _judge_one_facts(qid, page, meta, user_text):
+            if dump_only:
+                return [{
+                    'question_id': qid,
+                    'page': page,
+                    **m,
+                    'label': None,
+                    'reason': 'message_dumped',
+                    'judge_raw': '',
+                    'judge_usage': {},
+                    'status': 'message_dumped',
+                } for m in meta]
+
+            try:
+                response = judge.generate(user_text)
+                parsed = _parse_judge_json(str(response)) or {}
+                items = parsed.get('items') or []
+                by_id = {it.get('id'): it for it in items if isinstance(it, dict)}
+                error = None
+            except Exception as err:
+                response = f'JUDGE_ERROR: {err}'
+                by_id = {}
+                error = str(err)
+
+            rows = []
+            for m in meta:
+                it = by_id.get(m['fact_id']) or {}
+                label = it.get('label')
+                status = 'ok' if label in {'consistent', 'not_consistent'} else 'judge_parse_error'
+                if error is not None:
+                    status = 'judge_error'
+                rows.append({
+                    'question_id': qid,
+                    'page': page,
+                    **m,
+                    'label': label,
+                    'reason': it.get('reason') or error,
+                    'judge_raw': str(response),
+                    'judge_usage': {},
+                    'status': status,
+                })
+            return rows
+
+        if tasks:
+            results = track_progress_rich(_judge_one_facts, tasks, nproc=nproc)
+            for rows in results:
+                for row in rows:
+                    _append_jsonl(facts_file, row)
+        return len(done) + len(tasks)
+
+    def _score_answer(self, records, bench, answer_file, dump_path, dump_only, judge, nproc):
+        template = (PROMPT_DIR / 'answer_verification.txt').read_text(encoding='utf-8')
+        done = _jsonl_done_keys(answer_file, ('question_id',))
+        tasks = []
+        for record in records:
+            if record.get('status') != 'ok':
+                continue
+            qid = str(record.get('question_id'))
+            if qid in done:
+                continue
+            be = bench.get(qid)
+            parsed_record = record.get('parsed') or {}
+            has_answer_tag = bool(parsed_record.get('has_answer_tag'))
+            if has_answer_tag and parsed_record.get('answer'):
+                model_answer = parsed_record.get('answer', '')
+            else:
+                model_answer = record.get('model_raw', '')
+            if be is not None and not be.is_answerable:
+                gold_answer = 'Unanswerable'
+            else:
+                gold_answer = be.answer_text if be else ''
+            user_text = template.format(
+                question=be.question if be else '',
+                gold_answer=gold_answer,
+                model_answer=model_answer,
+            )
+            messages = [{'role': 'user', 'content': user_text}]
+            _append_message_dump(dump_path, {
+                'stage': 'judge_answer',
+                'question_id': qid,
+                'messages': messages,
+            })
+            tasks.append({
+                'qid': qid,
+                'gold_answer': gold_answer,
+                'model_answer': model_answer,
+                'has_answer_tag': has_answer_tag,
+                'user_text': user_text,
+            })
+
+        def _judge_one_answer(qid, gold_answer, model_answer, has_answer_tag, user_text):
+            if dump_only:
+                return {
+                    'question_id': qid,
+                    'gold_answer': gold_answer,
+                    'model_answer': model_answer,
+                    'has_answer_tag': has_answer_tag,
+                    'consistent': None,
+                    'reason': 'message_dumped',
+                    'judge_raw': '',
+                    'judge_usage': {},
+                    'status': 'message_dumped',
+                }
+
+            try:
+                response = judge.generate(user_text)
+                parsed = _parse_judge_json(str(response)) or {}
+                consistent = parsed.get('consistent')
+                error = None
+            except Exception as err:
+                response = f'JUDGE_ERROR: {err}'
+                parsed = {}
+                consistent = None
+                error = str(err)
+
+            status = 'ok' if isinstance(consistent, bool) else 'judge_parse_error'
+            if error is not None:
+                status = 'judge_error'
+            return {
+                'question_id': qid,
+                'gold_answer': gold_answer,
+                'model_answer': model_answer,
+                'has_answer_tag': has_answer_tag,
+                'consistent': bool(consistent) if isinstance(consistent, bool) else None,
+                'reason': parsed.get('reason') or parsed.get('reasoning') or error or '',
+                'judge_raw': str(response),
+                'judge_usage': {},
+                'status': status,
+            }
+
+        if tasks:
+            rows = track_progress_rich(_judge_one_answer, tasks, nproc=nproc)
+            for row in rows:
+                _append_jsonl(answer_file, row)
+        return len(done) + len(tasks)
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        dump_path = os.environ.get('DOCSCOPE_DUMP_MESSAGES', '')
+        dump_only = bool(dump_path) or bool(judge_kwargs.pop('dump_messages', False))
+        nproc = judge_kwargs.pop('nproc', 4)
+        model_name = judge_kwargs.get('model', self.DEFAULT_JUDGE)
+
+        records = self._records_from_eval(eval_file)
+        bench = self._benchmark_index()
+        pages_file = get_intermediate_file_path(eval_file, '_pages', 'jsonl')
+        bbox_file = get_intermediate_file_path(eval_file, f'_{model_name}_bbox', 'jsonl')
+        facts_file = get_intermediate_file_path(eval_file, f'_{model_name}_facts', 'jsonl')
+        answer_file = get_intermediate_file_path(eval_file, f'_{model_name}_answer', 'jsonl')
+        score_file = get_intermediate_file_path(eval_file, '_score', 'json')
+        imgs_dir = Path(self.img_root) / 'eval_imgs' / Path(eval_file).stem
+
+        summary = self._score_pages(records, bench, pages_file)
+        judge = None if dump_only else build_judge(max_tokens=2048, **judge_kwargs)
+        summary['bbox|dumped_messages'] = self._score_bbox(
+            records, bench, bbox_file, imgs_dir, dump_path, dump_only, judge, model_name, nproc)
+        summary['facts|dumped_messages'] = self._score_facts(
+            records, bench, facts_file, dump_path, dump_only, judge, nproc)
+        summary['answer|dumped_messages'] = self._score_answer(
+            records, bench, answer_file, dump_path, dump_only, judge, nproc)
+        summary['status'] = 'message_dumped' if dump_only else 'ok'
+        dump(summary, score_file)
+        return summary

--- a/vlmeval/dataset/utils/docscope_prompts/answer_verification.txt
+++ b/vlmeval/dataset/utils/docscope_prompts/answer_verification.txt
@@ -1,0 +1,22 @@
+You are an answer consistency judge. Determine whether model_answer is factually consistent with gold_answer, using the question as context.
+
+Judging rules:
+1. Compare factual meaning, not exact wording.
+2. Ignore minor formatting differences such as commas, currency symbols, capitalization, punctuation, spacing, or unit spacing. For example, "16Mbytes" and "16 Mbytes" are consistent.
+3. model_answer may include extra explanation, units, or supporting values if they do not contradict gold_answer.
+4. If the core number, entity, category, date, percentage, ratio, or calculation result differs from gold_answer, mark it inconsistent.
+5. If the question or gold_answer requires multiple components, items, or a complete list, model_answer must include all required content. Missing required items or adding incorrect extra items is inconsistent.
+6. If model_answer contains the correct answer but also adds a false or contradictory statement, mark it inconsistent.
+7. Be strict with proper names, organization names, product names, and labels. If the name clearly differs, mark it inconsistent.
+8. Do not use external knowledge. Judge only from question, gold_answer, and model_answer.
+9. If gold_answer gives separate component values but the question asks for a combined total, a correct combined total in model_answer is consistent, as long as it directly answers the question and does not contradict gold_answer.
+
+Return only valid JSON:
+{{
+  "consistent": true or false,
+  "reason": "Briefly explain the judgment in one sentence."
+}}
+
+question: {question}
+gold_answer: {gold_answer}
+model_answer: {model_answer}

--- a/vlmeval/dataset/utils/docscope_prompts/evidence_grounding.txt
+++ b/vlmeval/dataset/utils/docscope_prompts/evidence_grounding.txt
@@ -1,0 +1,122 @@
+You are evaluating whether the model-predicted evidence boxes successfully **recall** each ground-truth (GT) evidence region on a single document page. You will judge **multiple GT boxes at once** for the same page.
+
+The page image contains:
+- **GREEN boxes**: ground-truth evidence regions, each labelled `GOLD[i]` (1-based).
+- **RED boxes**: model-predicted evidence regions.
+
+---
+
+# Special Structural Rules (apply first, before general criteria)
+
+These rules override general size/coverage intuitions for specific structural cases:
+
+**Rule 1 — Table cell/row/column → whole table Pred:**
+If GT marks a single row, column, or cell inside a table, and Pred covers the entire table, treat it as **`covered`**.
+
+**Rule 2 — Bullet/numbered list: one item GT → whole list Pred:**
+If GT marks a single item from a bullet or numbered list, and Pred covers the entire list (multiple items), treat it as **`imprecise`**. The model failed to isolate the specific item.
+
+**Rule 3 — Pred smaller than GT but mostly overlapping:**
+If Pred is smaller than GT but covers the majority of the GT region's content, treat it as **`covered`**.
+
+**Rule 4 — Chart/figure/image as a whole:**
+If GT marks a chart, figure, or image as a whole, Pred does not need to be tight or complete. As long as it is visually clear that Pred is targeting that same object, treat it as **`covered`**.
+
+---
+
+# Input
+
+- **Question being answered:** {question}
+- **Gold answer (for reference only):** {gold_answer}
+- **Page:** {gt_page}
+- **Total GT boxes on this page:** {gold_total_on_page}
+- **GT boxes to judge** (one per row):
+{gold_facts_block}
+- **Predicted boxes (normalized, shared across all GT boxes):**
+  - Count: {n_pred}
+  - Boxes: {pred_bboxes_norm}
+
+Each row looks like `id=g<i> :: index_on_page=<i>, element_type=<...>, gold_bbox_px=<...>`. Echo the `id` verbatim in your output.
+
+---
+
+# Core Criterion
+
+This is a **recall-oriented** judgment. Credit is given if the GT evidence content is effectively included in the **union of all red predicted boxes**, regardless of how large, loose, or imprecise the prediction is.
+
+Always evaluate the **union** of all red boxes. No single red box needs to cover the GT alone.
+
+Judge every GT box **independently**. Never promote or demote one GT box based on another.
+
+---
+
+# Labels
+
+## `"covered"`
+The GT evidence is fully or effectively recalled by the red union.
+
+Use `"covered"` even if:
+- the red prediction is much larger than the GT (whole section, whole table, whole page);
+- the red prediction includes unrelated surrounding content;
+- the red boundary is slightly shifted or has minor clipping artifacts;
+- **the GT is a row/cell/column and Pred covers the whole table** (Rule 1);
+- **the GT is a chart/figure and Pred clearly targets it** (Rule 4).
+
+## `"imprecise"`
+The red union meaningfully overlaps the GT but fails to recall a substantial portion of it.
+
+Use `"imprecise"` when:
+- a significant part of the GT content is outside all red boxes;
+- the red covers only part of a table, chart, paragraph, or header the GT marks as a whole;
+- **the GT is one bullet item and Pred covers the entire list** (Rule 2).
+
+## `"not_covered"`
+The red union does not meaningfully overlap the GT.
+
+Use `"not_covered"` when:
+- red boxes are essentially disjoint from this GT;
+- red boxes only touch the GT boundary without meaningful overlap;
+- red boxes refer to a clearly different region.
+
+---
+
+# Decision Procedure
+
+1. Check if any **Special Structural Rule** applies → apply it directly.
+2. Otherwise: locate `GOLD[i]`, form the union of all red boxes, then ask:
+   - Is GT content effectively recalled by the red union? → **`covered`**
+   - Does the red union meaningfully overlap GT but miss a substantial part? → **`imprecise`**
+   - Otherwise → **`not_covered`**
+
+**Tie-breaking:** If unsure between `"covered"` and `"imprecise"`, choose `"covered"` when ≥90% of the GT content or all semantically important GT content is inside the red union.
+
+---
+
+# Illustrative Examples
+
+| Situation | Label |
+|---|---|
+| Red covers entire page; GT is one paragraph inside | `covered` |
+| Red covers whole table; GT is one row of that table | `covered` (Rule 1) |
+| GT is a chart; Red clearly targets that chart but isn't tight | `covered` (Rule 4) |
+| Red covers whole bullet list; GT is one specific bullet item | `imprecise` (Rule 2) |
+| Red covers only bottom half of a GT table, missing header and top rows | `imprecise` |
+| Red covers GT paragraph plus surrounding paragraphs | `covered` |
+| Red is on a completely different region with no meaningful overlap | `not_covered` |
+| Red covers most of a GT image but clips a small border with no important content | `covered` |
+| Red covers only the right half of a GT chart, missing left half | `imprecise` |
+| Red covers a header region but clips off the last word of the header text | `covered` (minor clipping) |
+
+---
+
+# Output Format
+
+Return exactly one JSON object on one line. No markdown, no commentary.
+
+
+{{"items": [{{"id": "<gt_id>", "label": "covered" | "imprecise" | "not_covered", "reason": "<one concise sentence>"}}, ...]}}
+
+- `id`: verbatim from input (e.g. `g1`, `g2`).
+- `label`: exactly one of the three values.
+- `reason`: one concise sentence specific to this GT box, referencing which rule or criterion was applied.
+- List must contain exactly one entry per input `id`, in order, no duplicates.

--- a/vlmeval/dataset/utils/docscope_prompts/factucal_consistency.txt
+++ b/vlmeval/dataset/utils/docscope_prompts/factucal_consistency.txt
@@ -1,0 +1,198 @@
+You are judging whether a participant model's response supports each ground-truth (GT) fact for a single page. You will be given **multiple GT facts at once** (all from the same page) and must label **every one** of them independently.
+
+# Input
+
+- **Question:** {question}
+- **GT source page (shared by all GT facts below):** {gt_page}
+- **GT facts to judge (one per row, each with a stable `id`):**
+{gold_facts_block}
+- **Sibling GT facts (context only, do NOT judge):** {sibling_facts}
+- **Participant model output:** {model_raw}
+
+Each row in `GT facts to judge` looks like `id=<fact_id> :: <fact text>`. The `id` is a short tag such as `f1`, `f2`, etc. — use it verbatim as the key in your output.
+
+---
+
+# Core Rule: Only structured page citations count
+
+For **every** GT fact, you may use **only** the evidence unit immediately before a structured citation of this exact form:
+
+```
+[page=<number>, doc_page="<string>", bbox=[...]]
+```
+
+A citation is **admissible only when its `page` field equals {gt_page}**.
+
+The `doc_page` field is context only and must **never** be used to decide admissibility.
+
+**These do NOT count as admissible citations:**
+- "page 5", "p. 5", "(page 5)", "[page 5]", "on page 5"
+- Any citation where `page` ≠ {gt_page}, even if `doc_page` matches
+- Any citation with a missing `page` field
+
+**Final answers are always ignored**, regardless of position.
+
+---
+
+# Decision Process (apply independently to EACH GT fact)
+
+## Step 1 — Find admissible citations
+
+Scan for all structured citations beginning with `[page={gt_page},`.
+
+If none exist → label every GT fact as `"not_consistent"`.
+
+## Step 2 — Extract the immediately preceding evidence unit
+
+For each admissible citation, use **only** the single unit immediately before it:
+
+- one sentence, OR
+- one bullet/list item, OR
+- one table row, OR
+- one compact key-value line
+
+If the citation appears inside a sentence, use only the part of that sentence before the citation.
+
+**Consecutive citation sequences:** When multiple citations appear back-to-back with no intervening text, the evidence unit immediately before the **first** citation in that sequence is treated as shared evidence for **all** citations in the sequence.
+
+Do **not** use any other text.
+
+## Step 3 — Judge GT fact support (independently per fact)
+
+For each GT fact `id`, ask: does any extracted evidence unit clearly support **that specific** GT fact?
+
+To label `"consistent"`, the evidence must include:
+- the **same object/target** described by that GT fact, AND
+- the **same value, count, relation, or claim** in that GT fact.
+
+Exact wording is not required. Clear paraphrase is allowed.
+
+The same evidence unit may support multiple GT facts simultaneously — judge each fact on its own merits, never trade one fact's verdict against another's.
+
+---
+
+# Label Definitions (per GT fact)
+
+## `"consistent"`
+At least one admissible evidence unit clearly supports this specific GT fact. Equivalent descriptions and clear paraphrases are accepted.
+
+## `"not_consistent"`
+Use this for every other case for this specific GT fact, including:
+- No admissible citation exists
+- Relevant text is not immediately before an admissible citation
+- Evidence mentions the right object but wrong value, or right value but wrong object
+- Evidence is vague, incomplete, or off-scope
+- Evidence directly conflicts with this GT fact
+
+---
+
+# Additional Rules (apply per-fact)
+
+**R1. Qualifiers are required — with exceptions.**
+If the GT fact includes a qualifier (year, unit, category, role, status, etc.), the admissible evidence must support that qualifier.
+- **Exception — section numbers:** If the GT fact references a section by number (e.g., "section 4.2"), the evidence need only match the section name or content; the section number does not need to be explicitly stated.
+- **Exception — page references in evidence text:** Page numbers mentioned within evidence text (e.g., "on page 8") do not affect admissibility and should not be used to disqualify otherwise supporting evidence.
+
+**R2. Enumeration and counting — inclusion rule.**
+- If the GT fact states that a specific item X exists (typically as part of a counting question), and the admissible evidence lists multiple items **including X**, this counts as `"consistent"` for that GT fact.
+- If the GT fact states there is **exactly 1** item of type X, and the admissible evidence includes X among multiple items of that type, this still counts as `"consistent"` (the GT claim about X's existence is supported).
+- If the GT fact states a **minimum count N** (e.g., "N tables with property X"), and the total items of type X found across all admissible evidence units is **less than N**, label `"not_consistent"`.
+
+**R3. Ordered lists — position inference.**
+If the GT fact specifies that an item is at a particular ordinal position (e.g., "the fourth product type"), the position may be inferred from the order in which items appear in an admissible list. Explicit ordinal labeling (e.g., "fourth") is not required.
+
+**R4. Long lists and broad tables.**
+A match inside a long list or table is admissible only if the specific item immediately before the citation directly supports the GT fact. Incidental matches do not count.
+
+**R5. Secondary errors.**
+If admissible evidence supports the GT fact but contains an unrelated secondary error → still `"consistent"`. If the evidence gives a conflicting value for the same object and same relation → `"not_consistent"`.
+
+**R6. Prefer not_consistent when unclear.**
+Use `"consistent"` only when support is clear and specific. Ambiguous or incomplete evidence → `"not_consistent"`.
+
+**R7. Multiple citations.**
+If multiple admissible citations exist, evaluate each evidence unit separately. Label `"consistent"` for a given GT fact if at least one qualifies for *that* fact.
+
+**R8. Independence across GT facts (BATCH-SPECIFIC).**
+Judge every GT fact on its own. Never:
+- promote one fact to `"consistent"` because a related fact in the batch is `"consistent"`,
+- demote one fact because the model is generally unreliable on the page,
+- collapse all facts to a single label.
+
+You must emit **one label per `id`** in the input.
+
+---
+
+# Examples
+
+**Example 1 — One evidence unit, multiple admissible facts**
+GT page: 5
+Input:
+```
+id=f1 :: The table has 3 columns.
+id=f2 :: The table is on page 5.
+```
+> "The table has 3 columns. `[page=5, doc_page="3", bbox=[...]]`"
+
+→ `f1: consistent` (object + value match), `f2: not_consistent` (the page-5 location is the citation itself, not a claim in the evidence sentence; the evidence sentence does not state where the table is).
+
+**Example 2 — Mixed admissible / inadmissible**
+GT page: 5
+Input:
+```
+id=f1 :: Ward A has an overall score of 65%.
+id=f2 :: Ward A has a water taste score of 44%.
+```
+> "Ward A has water taste of 44% `[page=6, doc_page="5", bbox=[...]]`. Ward A has an overall score of 65% `[page=5, doc_page="3", bbox=[...]]`."
+
+→ `f1: consistent` (admissible evidence supports it), `f2: not_consistent` (the water-taste sentence's citation has `page=6`, not 5, and `doc_page="5"` does not count).
+
+**Example 3 — Shared evidence in consecutive citations**
+GT page: 5
+Input:
+```
+id=f1 :: Table 16 shows a mode value of 6.0.
+id=f2 :: Table 12 shows a mode value of 6.0.
+```
+> "The tables with mode 6.0 are Table 12, Table 16, Table 18. `[page=5, doc_page="4", bbox=[...]]`. `[page=7, doc_page="6", bbox=[...]]`."
+
+→ `f1: consistent`, `f2: consistent` (shared evidence sentence supports both).
+
+**Example 4 — Some facts get no evidence at all**
+GT page: 36
+Input:
+```
+id=f1 :: The fourth product type listed is "Loans secured by guarantees".
+id=f2 :: The seventh product type listed is "Bonds".
+```
+> "Those product types are mortgage loans, collateral loans, unsecured loans, loans secured by guarantees, credit facilities, and financial guarantees `[page=36, doc_page="36", bbox=[...]]`."
+
+→ `f1: consistent` (fourth item matches), `f2: not_consistent` (the list has only six items; "Bonds" is not present and there is no seventh).
+
+**Example 5 — No admissible citation anywhere**
+GT page: 14
+Input:
+```
+id=f1 :: The title of section 4.2 is "Infrastructure EMEA".
+id=f2 :: Section 4.2 contains one table for EBITDA.
+```
+> "The 'Infrastructure EMEA' section contains one table for EBITDA on page 14."
+
+→ `f1: not_consistent`, `f2: not_consistent` (the only page reference is a free-text "on page 14", which is NOT a structured citation; nothing is admissible).
+
+---
+
+# Output Format
+
+Return exactly one JSON object on one line. No markdown, no commentary, no extra text.
+
+The object must have a single key `"items"` whose value is a list of per-fact judgments. Each judgment is an object with exactly three fields: `id`, `label`, `reason`.
+
+- `id` MUST equal one of the input `id`s, verbatim.
+- `label` MUST be exactly `"consistent"` or `"not_consistent"`.
+- `reason` MUST be one concise sentence specific to that GT fact.
+- The list MUST contain exactly one entry per input `id`, in the same order, with no duplicates and no extras.
+
+Schema:
+
+{{"items": [{{"id": "<fact_id>", "label": "consistent" | "not_consistent", "reason": "<one concise sentence>"}}, ...]}}

--- a/vlmeval/dataset/utils/docscope_reasoning_prompts.py
+++ b/vlmeval/dataset/utils/docscope_reasoning_prompts.py
@@ -1,0 +1,599 @@
+"""Shared prompt + parsing helpers for the reasoning-with-citations pipeline.
+
+Citation format (v2 — with global / doc page distinction):
+
+    [page=<int>, doc_page="<string_or_none>", bbox=[x1, y1, x2, y2]]
+
+The model is told that each page image is wrapped by GLOBAL PAGE text markers
+so the `page` field refers to the 1-indexed global order of images, while
+`doc_page` captures whatever page label is printed inside the page content
+(Arabic, Roman, "A-3", or "none" if absent).
+"""
+
+# flake8: noqa
+
+from __future__ import annotations
+import json
+import re
+from dataclasses import asdict, dataclass
+
+try:
+    import icu  # type: ignore
+    _HAS_ICU = True
+except ImportError:
+    icu = None  # type: ignore
+    _HAS_ICU = False
+
+INFER_SYSTEM_PROMPT = """You are an expert document QA system. You are given page images of a PDF document and a question about the document. Each image is wrapped by text markers indicating its global page number.
+
+<hard_constraints>
+BEFORE YOU ANSWER, INTERNALIZE THIS CONTRACT. VIOLATING ANY RULE MEANS COMPLETE FAILURE:
+
+1. ZERO TOLERANCE FOR MISSING CITATIONS: EVERY SINGLE sentence stating a fact from the document MUST end with EXACTLY ONE formal citation. No exceptions. No excuses.
+2. CITATION FORMAT: The citation MUST strictly match this format: `[page=N, doc_page="...", bbox=[x1, y1, x2, y2]]`
+3. SYNTAX ALERT: Pay close attention to the closing brackets. The citation MUST end with TWO right brackets `]]` and then the period. (Correct: `0.512]].` / Incorrect: `0.512].`)
+4. FORBIDDEN: NEVER use natural language to cite pages (e.g., DO NOT write "on page 5", "in Table 7 on global page 51", or "image 58"). You MUST use the bracket format.
+5. MANDATORY FINAL ANSWER TAG: You MUST conclude your response with a concise final answer wrapped STRICTLY and EXACTLY as:
+   `<answer> your final answer </answer>`
+6. NO MARKDOWN: Do not use headings, bold, italics, lists, or tables in your reasoning or answer. Plain prose only (fenced code blocks and LaTeX math are allowed when strictly necessary).
+</hard_constraints>
+
+## Page Numbering Rule
+- Each page image is preceded and followed by a text marker (e.g., `=== GLOBAL PAGE X (start) ===`). `X` is the **global page number** (integer, starting from 1).
+- The document itself may print its own page number inside the page (e.g., "12", "iv"). This is the **document page number**.
+- The `page` field in your citation MUST use the **global page number**.
+- The `doc_page` field MUST use the **document page number** (as a string). If not visible, set `doc_page="none"`.
+
+## CRITICAL Citation Requirement
+- **Fact vs. Reasoning**: A sentence is "fact-bearing" if it contains a number, date, name, quote, or claim from the document. A sentence is "pure reasoning" ONLY if it's arithmetic/logical inference based on already-cited facts. EVERY fact-bearing sentence requires a citation.
+- **Writing Rule (One Citation Per Sentence)**: After stating ONE fact from the document, immediately close the sentence with the citation and a period. Then start a NEW sentence for the next fact. Prefer short sentences.
+- **Coordinates**: The `bbox` uses **normalized coordinates** `[x1, y1, x2, y2]` in the range `[0, 1]`.
+- **Uncertainty Fallback**: If you cannot precisely localize the region, provide a conservative bounding box that safely contains the relevant content. NEVER omit a citation due to bbox uncertainty.
+
+## If Unanswerable (CRITICAL)
+If the question cannot be answered from the document, briefly explain why (still citing any relevant regions you checked, such as the table of contents). Then, you MUST output exactly:
+`<answer> Unanswerable </answer>`
+Do NOT output variations like `<answer> I cannot answer </answer>`.
+
+## Good & Bad Examples
+
+BAD EXAMPLE 1 (Natural language citation - FORBIDDEN):
+The revenue grew 13% in 2023 based on Table 1 on page 5.
+
+BAD EXAMPLE 2 (Missing the second closing bracket `]` - FORBIDDEN):
+Revenue was $5.2B in 2023 [page=5, doc_page="3", bbox=[0.412, 0.215, 0.687, 0.248].
+
+BAD EXAMPLE 3 (Multiple facts, citation in the middle - FORBIDDEN):
+Revenue was $5.2B in 2023 [page=5, doc_page="3", bbox=[0.41, 0.21, 0.68, 0.24]] and $4.6B in 2022.
+
+GOOD EXAMPLE:
+Let me analyze the financial data. The document reports a total revenue of $5.2 billion for fiscal year 2023 [page=5, doc_page="3", bbox=[0.412, 0.215, 0.687, 0.248]]. The total revenue for fiscal year 2022 was $4.6 billion [page=5, doc_page="3", bbox=[0.412, 0.252, 0.687, 0.285]]. The difference is $0.6B, which corresponds to approximately a 13% increase. This growth is confirmed in the management commentary [page=4, doc_page="none", bbox=[0.085, 0.612, 0.915, 0.648]].
+<answer> The company's total revenue in 2023 was $5.2 billion, up approximately 13% from $4.6 billion in 2022. </answer>
+
+## Output Protocol
+1. Output your detailed reasoning process step by step.
+2. Pre-output Self-Check (Perform silently):
+   - Did I use the formal `[page=...]` format instead of saying "on page X"?
+   - Does EVERY bbox array end with `]]`?
+   - Does EVERY fact-bearing sentence have exactly ONE citation at the end?
+   - Is my final answer explicitly wrapped in `<answer>` tags?
+3. Output your final concise answer wrapped STRICTLY as:
+`<answer> your final answer </answer>`
+"""
+
+INFER_SIMPLE_PROMPT = """You are an AI assistant that rigorously follows this response protocol:
+
+1. First, conduct a detailed analysis of the question. Consider different angles, potential solutions, and reason through the problem step-by-step. Enclose this entire thinking process within <think> and </think> tags.
+
+2. After the thinking section, provide a clear, concise, and direct answer to the user's question. Separate the answer from the think section with a newline.
+
+Ensure that the thinking process is thorough but remains focused on the query. The final answer should be standalone and not reference the thinking section."""
+
+
+# ── Judge ─────────────────────────────────────────────────────────────────────
+
+JUDGE_SYSTEM_PROMPT = """\
+You are an expert evaluator for document question answering. You are given \
+a question, a gold answer, and a model-predicted answer. Determine whether \
+the predicted answer is semantically consistent with the gold answer — i.e., \
+they convey the same core factual content, even if they differ in formatting, \
+wording, or level of detail.
+
+Rules:
+- CONSISTENT means the predicted answer agrees with the gold answer on the core factual content.
+- INCONSISTENT means the predicted answer provides different / contradictory factual information, is missing essential information, or refuses unjustifiably.
+- Minor formatting differences (e.g., "21%" vs "21", "14 years" vs "14", "$1,000" vs "1000 dollars") are CONSISTENT.
+- Different numbers, different entities, contradictory conclusions, wrong units, or "Unanswerable" when a real answer is given are INCONSISTENT.
+
+OUTPUT FORMAT (strict JSON, no markdown fences):
+{"consistent": true or false, "reasoning": "<brief explanation>"}
+"""
+
+JUDGE_USER_TEMPLATE = """\
+Question: {question}
+
+Gold answer: {gold}
+
+Model answer: {pred}
+
+Is the model answer semantically consistent with the gold answer?"""
+
+
+# ── Input markers ─────────────────────────────────────────────────────────────
+
+def page_marker_start(i: int) -> str:
+    return f"=== GLOBAL PAGE {i} (start) ==="
+
+
+def page_marker_end(i: int) -> str:
+    return f"=== GLOBAL PAGE {i} (end) ==="
+
+
+# ── Parsing ───────────────────────────────────────────────────────────────────
+
+# Citation regex:
+#   [page=<int>, doc_page="<str>", bbox=[<f>, <f>, <f>, <f>]]
+# doc_page value can be quoted ("12", "iv", "none") or bare (none / 12)
+_CITATION_RE = re.compile(
+    r"\[\s*page\s*=\s*(\d+)\s*,\s*"
+    r"doc_page\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s,\]]+))\s*,\s*"
+    r"bbox\s*=\s*\[\s*"
+    r"([-+]?\d*\.?\d+)\s*,\s*"
+    r"([-+]?\d*\.?\d+)\s*,\s*"
+    r"([-+]?\d*\.?\d+)\s*,\s*"
+    r"([-+]?\d*\.?\d+)\s*\]\s*\]",
+    re.IGNORECASE,
+)
+
+# Loose / "concatenated" form — covers malformed runs like:
+#
+#   [page=9, doc_page="1", bbox=[77, 553, 159, 568],
+#    [page=9, doc_page="1", bbox=[77, 601, 159, 617],
+#    [page=12, doc_page="4", bbox=[186, 121, 452, 137]]]
+#
+# i.e. each item starts with `[page=N, doc_page=..., bbox=[a,b,c,d]` but the
+# closing `]]` may be replaced by a single `]` followed by either `,` (next
+# item in the run) or end-of-text. doc_page may also be missing entirely.
+# Always pulled AFTER the strict pattern, only over text the strict pattern
+# didn't already mask.
+_LOOSE_CITATION_RE = re.compile(
+    r"\[\s*page\s*=\s*(\d+)\s*"
+    r"(?:,\s*doc_page\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s,\]]+))\s*)?,\s*"
+    r"bbox\s*=\s*\[\s*"
+    r"([-+]?\d*\.?\d+)\s*,\s*"
+    r"([-+]?\d*\.?\d+)\s*,\s*"
+    r"([-+]?\d*\.?\d+)\s*,\s*"
+    r"([-+]?\d*\.?\d+)\s*\]",
+    re.IGNORECASE,
+)
+
+_ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.IGNORECASE | re.DOTALL)
+
+# Protection regions (masked before ICU sees the text)
+_FENCED_CODE_RE = re.compile(r"```[\s\S]*?```|~~~[\s\S]*?~~~")
+_BLOCK_LATEX_RE = re.compile(r"\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\]")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_INLINE_LATEX_RE = re.compile(r"\\\([\s\S]*?\\\)")
+
+# Private-use-area placeholder ranges (one char per masked original char)
+PUA_CITATION = "\uE000"
+PUA_CODE_BLOCK = "\uE001"
+PUA_BLOCK_LATEX = "\uE002"
+PUA_INLINE_CODE = "\uE003"
+PUA_INLINE_LATEX = "\uE004"
+_ALL_PUA = "\uE000\uE001\uE002\uE003\uE004"
+
+
+@dataclass
+class Citation:
+    page: int            # global page number
+    doc_page: str        # as printed on the page; "none" if absent
+    bbox: list[float]
+    sentence: str
+    span_start: int
+    span_end: int
+    is_normalized: bool = True   # bbox values all in [0, 1.5]
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def _bbox_is_normalized(bbox: list[float]) -> bool:
+    if not bbox or len(bbox) != 4:
+        return False
+    return all(-0.01 <= v <= 1.5 for v in bbox)
+
+
+@dataclass
+class _Mask:
+    start: int
+    end: int
+    kind: str              # "citation" | "code_block" | "block_latex" | "inline_code" | "inline_latex"
+    original: str
+    meta: dict | None = None   # for citation: parsed metadata
+
+
+def extract_answer(text: str) -> str | None:
+    matches = list(_ANSWER_RE.finditer(text))
+    if not matches:
+        return None
+    return matches[-1].group(1).strip()
+
+
+# ── Masking stage ─────────────────────────────────────────────────────────────
+
+def _parse_citation_match(m: re.Match) -> dict | None:
+    try:
+        page = int(m.group(1))
+    except (ValueError, TypeError):
+        return None
+    doc_page = m.group(2) or m.group(3) or m.group(4) or "none"
+    doc_page = doc_page.strip() or "none"
+    try:
+        bbox = [float(m.group(i)) for i in range(5, 9)]
+    except (ValueError, TypeError):
+        return None
+    return {
+        "page": page,
+        "doc_page": doc_page,
+        "bbox": bbox,
+        "is_normalized": _bbox_is_normalized(bbox),
+    }
+
+
+def _apply_mask(text: str, pattern: re.Pattern, pua_char: str, kind: str,
+                masks: list[_Mask],
+                meta_factory=None) -> str:
+    """Replace every non-overlapping, non-already-masked match with equal-length PUA."""
+    out = list(text)
+    for m in pattern.finditer(text):
+        s, e = m.start(), m.end()
+        # Skip if any char in this span is already a PUA placeholder
+        segment = text[s:e]
+        if any(ch in _ALL_PUA for ch in segment):
+            continue
+        meta = meta_factory(m) if meta_factory else None
+        if meta_factory and meta is None:
+            # factory rejected this match (e.g., malformed citation)
+            continue
+        masks.append(_Mask(start=s, end=e, kind=kind, original=segment, meta=meta))
+        for i in range(s, e):
+            out[i] = pua_char
+    return "".join(out)
+
+
+def mask_regions(text: str) -> tuple[str, list[_Mask]]:
+    """Mask citations / fenced code / block latex / inline code / inline latex
+    with equal-length PUA placeholders.
+
+    Order matters: mask the outermost / least-ambiguous regions first so later
+    patterns do not touch already-masked content.
+    """
+    masks: list[_Mask] = []
+    masked = text
+
+    masked = _apply_mask(masked, _CITATION_RE, PUA_CITATION, "citation",
+                         masks, meta_factory=_parse_citation_match)
+    # Loose / concatenated form — only fires on text the strict pattern didn't
+    # cover (because _apply_mask skips spans containing PUA placeholders).
+    masked = _apply_mask(masked, _LOOSE_CITATION_RE, PUA_CITATION, "citation",
+                         masks, meta_factory=_parse_citation_match)
+    masked = _apply_mask(masked, _FENCED_CODE_RE, PUA_CODE_BLOCK, "code_block",
+                         masks)
+    masked = _apply_mask(masked, _BLOCK_LATEX_RE, PUA_BLOCK_LATEX, "block_latex",
+                         masks)
+    masked = _apply_mask(masked, _INLINE_CODE_RE, PUA_INLINE_CODE, "inline_code",
+                         masks)
+    masked = _apply_mask(masked, _INLINE_LATEX_RE, PUA_INLINE_LATEX, "inline_latex",
+                         masks)
+
+    masks.sort(key=lambda m: m.start)
+    return masked, masks
+
+
+# ── Abbreviation protection ───────────────────────────────────────────────────
+# ICU's default English sentence rules treat "U.S." / "Dr." / "Fig." as sentence
+# terminators. PyICU does not expose FilteredBreakIterator, so we protect the
+# dot inside a known abbreviation list by swapping it with U+00B7 (middle dot)
+# before ICU sees the text, then swap it back after splitting.
+
+_ABBREV_DOT = "\u00B7"
+
+_ABBREV_SINGLE = {
+    # Titles
+    "Mr", "Mrs", "Ms", "Dr", "Prof", "Rev", "Hon", "Jr", "Sr", "St",
+    # Generic
+    "e.g", "i.e", "etc", "vs", "cf", "al", "approx", "est", "ca",
+    # Companies / orgs
+    "Inc", "Ltd", "Co", "Corp", "LLC", "Bros",
+    # Degrees
+    "Ph.D", "M.D", "B.A", "M.A", "B.S", "M.S",
+    # Months (short)
+    "Jan", "Feb", "Mar", "Apr", "Jun", "Jul", "Aug", "Sep", "Sept",
+    "Oct", "Nov", "Dec",
+    # Figures / refs / units in text
+    "Fig", "Figs", "Vol", "No", "Nos", "Ch", "Sec", "App", "Eq",
+    "Tab", "pp", "p", "ed", "Eds", "eds", "n.d",
+}
+
+# Multi-dot abbreviations like U.S., U.S.A., U.K., E.U., Ph.D., M.D. — captured
+# via a structural pattern "(Letter\.){2,}".
+_MULTI_DOT_ABBREV_RE = re.compile(r"\b(?:[A-Za-z]\.){2,}")
+
+# Single-dot abbreviation pattern, built once from the list above.
+_SINGLE_ABBREV_RE = re.compile(
+    r"\b(?:" + "|".join(sorted(map(re.escape, _ABBREV_SINGLE), key=len, reverse=True)) + r")\.",
+    re.IGNORECASE,
+)
+
+
+def _protect_abbreviations(text: str) -> str:
+    """Replace `.` inside known abbreviations with U+00B7 so ICU does not split."""
+    def _sub(m: re.Match) -> str:
+        return m.group(0).replace(".", _ABBREV_DOT)
+
+    text = _MULTI_DOT_ABBREV_RE.sub(_sub, text)
+    text = _SINGLE_ABBREV_RE.sub(_sub, text)
+    return text
+
+
+def _restore_abbreviations(text: str) -> str:
+    return text.replace(_ABBREV_DOT, ".")
+
+
+# ── Sentence splitting ────────────────────────────────────────────────────────
+
+def _icu_split_sentences(text: str, locale: str = "en_US"
+                         ) -> list[tuple[int, int]]:
+    bi = icu.BreakIterator.createSentenceInstance(icu.Locale(locale))
+    bi.setText(text)
+    spans: list[tuple[int, int]] = []
+    start = bi.first()
+    for end in bi:
+        spans.append((start, end))
+        start = end
+    return spans
+
+
+def _regex_split_sentences(text: str) -> list[tuple[int, int]]:
+    """Very rough fallback when ICU is unavailable."""
+    spans: list[tuple[int, int]] = []
+    s = 0
+    term_re = re.compile(r"(?<!\d)[.!?。！？](?!\d)|\n{2,}")
+    for m in term_re.finditer(text):
+        spans.append((s, m.end()))
+        s = m.end()
+    if s < len(text):
+        spans.append((s, len(text)))
+    return spans
+
+
+def split_sentences(text: str, locale: str = "en_US"
+                    ) -> list[tuple[int, int]]:
+    if _HAS_ICU:
+        return _icu_split_sentences(text, locale)
+    return _regex_split_sentences(text)
+
+
+# ── Citation → sentence attribution ───────────────────────────────────────────
+
+def _restore_non_citation(rendered: str, masks: list[_Mask],
+                          slice_start: int) -> str:
+    """Given a slice of the masked text, restore code/latex placeholders back to
+    original characters (but keep citation placeholders as empty — they will be
+    stripped below)."""
+    chars = list(rendered)
+    for mk in masks:
+        if mk.kind == "citation":
+            continue
+        rel_start = mk.start - slice_start
+        rel_end = mk.end - slice_start
+        if rel_end <= 0 or rel_start >= len(chars):
+            continue
+        # Overlap range within this slice
+        overlap_s = max(0, rel_start)
+        overlap_e = min(len(chars), rel_end)
+        # Replace placeholder chars with the corresponding original slice
+        orig_s = overlap_s - rel_start
+        orig_e = overlap_e - rel_start
+        # In-place splice
+        original_piece = mk.original[orig_s:orig_e]
+        chars[overlap_s:overlap_e] = list(original_piece)
+    return "".join(chars)
+
+
+def _clean_sentence(sentence_text: str) -> str:
+    # Strip all citation placeholders (already restored code/latex at this point)
+    cleaned = sentence_text.replace(PUA_CITATION, "")
+    # Strip leading list/heading markers that might remain
+    cleaned = re.sub(r"^\s*(?:[-*+•>]|\d+[.)]|[a-zA-Z][.)])\s+", "", cleaned, count=1)
+    cleaned = re.sub(r"^\s*#{1,6}\s+", "", cleaned, count=1)
+    # Collapse whitespace, then remove whitespace that appears right before
+    # terminal/clause punctuation (a common artefact of stripping a citation
+    # placeholder that stood between the last word and its period).
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    cleaned = re.sub(r"\s+([.!?。！？,，;；:：)\]\}])", r"\1", cleaned)
+    return cleaned
+
+
+def _attribute_and_render(
+    raw: str,
+    masked: str,
+    masks: list[_Mask],
+    sentence_spans: list[tuple[int, int]],
+) -> list[Citation]:
+    # Filter citation masks (preserve insertion order)
+    citation_masks = [m for m in masks if m.kind == "citation"]
+
+    # Build sentence texts:
+    #   - start from the MASKED slice (still has PUA_CITATION and PUA_CODE/LATEX)
+    #   - restore code/latex placeholders back to their original text
+    #   - _clean_sentence() then strips the remaining PUA_CITATION characters
+    sentence_texts: list[str] = []
+    for (s, e) in sentence_spans:
+        masked_slice = masked[s:e]
+        restored = _restore_non_citation(masked_slice, masks, s)
+        sentence_texts.append(_clean_sentence(restored))
+
+    # Build sentence lookup for citation start positions
+    def _find_sentence_idx(pos: int) -> int | None:
+        lo, hi = 0, len(sentence_spans)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            s, e = sentence_spans[mid]
+            if pos < s:
+                hi = mid
+            elif pos >= e:
+                lo = mid + 1
+            else:
+                return mid
+        return None
+
+    # Pre-pass: for each sentence, check if it is "almost empty" aside from PUA citations.
+    # Such sentences are artefacts of "prev_sentence. [cite]" — attribute their citations
+    # to the previous non-empty sentence.
+    def _sentence_is_only_citation(idx: int) -> bool:
+        s, e = sentence_spans[idx]
+        seg = masked[s:e]
+        # Remove citation placeholders and whitespace.
+        leftover = re.sub(rf"[{PUA_CITATION}\s]+", "", seg)
+        if not leftover:
+            return True
+        # If what remains is only punctuation (no letters/digits/CJK chars),
+        # the "sentence" is an artefact of stripping the citation out of
+        # "prev. [cite]." and should be attributed to the previous sentence.
+        return not re.search(r"[^\W_]", leftover, re.UNICODE)
+
+    citations: list[Citation] = []
+    for cm in citation_masks:
+        idx = _find_sentence_idx(cm.start)
+        if idx is None:
+            # Fallback: attach to last sentence
+            idx = len(sentence_spans) - 1
+        # If target sentence is citation-only, walk backwards to a real sentence.
+        while idx > 0 and _sentence_is_only_citation(idx):
+            idx -= 1
+        sentence_text = sentence_texts[idx] if 0 <= idx < len(sentence_texts) else ""
+        meta = cm.meta or {}
+        bbox = meta.get("bbox", [])
+        citations.append(Citation(
+            page=meta.get("page", -1),
+            doc_page=meta.get("doc_page", "none"),
+            bbox=bbox,
+            sentence=sentence_text,
+            span_start=cm.start,
+            span_end=cm.end,
+            is_normalized=meta.get("is_normalized", _bbox_is_normalized(bbox)),
+        ))
+    return citations
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def validate_bbox(bbox: list[float]) -> bool:
+    if not isinstance(bbox, list) or len(bbox) != 4:
+        return False
+    try:
+        x1, y1, x2, y2 = bbox
+    except ValueError:
+        return False
+    return 0.0 <= x1 < x2 <= 1.0 and 0.0 <= y1 < y2 <= 1.0
+
+
+def extract_citations(text: str, locale: str = "en_US") -> list[Citation]:
+    """End-to-end citation extraction with ICU-based sentence attribution."""
+    masked, masks = mask_regions(text)
+    # Abbreviation protection: swap `.` in known abbreviations to U+00B7
+    # (same char length; indexes remain aligned).
+    icu_input = _protect_abbreviations(masked)
+    spans = split_sentences(icu_input, locale=locale)
+    return _attribute_and_render(text, masked, masks, spans)
+
+
+def parse_model_output(text: str, locale: str = "en_US") -> dict:
+    """Parse the full reasoning output into structured fields."""
+    answer = extract_answer(text)
+    citations = extract_citations(text, locale=locale)
+    reasoning = text
+    if answer is not None:
+        last = list(_ANSWER_RE.finditer(text))[-1]
+        reasoning = text[:last.start()].rstrip()
+
+    return {
+        "answer": answer,
+        "reasoning": reasoning,
+        "citations": [c.as_dict() for c in citations],
+        "invalid_citations": [
+            c.as_dict() for c in citations if not validate_bbox(c.bbox)
+        ],
+        "predicted_pages": sorted({c.page for c in citations}),
+        "has_answer_tag": answer is not None,
+        "sentence_splitter": "icu" if _HAS_ICU else "regex_fallback",
+    }
+
+
+# ── Page-level precision / recall ─────────────────────────────────────────────
+
+def page_prf(predicted: list[int] | set[int],
+             gold: list[int] | set[int]) -> dict:
+    """Return precision / recall / f1 / TP / FP / FN for page-id sets.
+
+    Treats the task as set retrieval over 1-indexed global pages.
+    Returns all zeros with sensible edge-case handling:
+      - gold empty & pred empty: precision=recall=f1=1.0
+      - gold empty & pred non-empty: precision=0, recall=1.0, f1=0
+      - pred empty & gold non-empty: precision=1.0, recall=0, f1=0
+    """
+    pred_set = set(predicted)
+    gold_set = set(gold)
+
+    tp = len(pred_set & gold_set)
+    fp = len(pred_set - gold_set)
+    fn = len(gold_set - pred_set)
+
+    if not gold_set and not pred_set:
+        precision = recall = f1 = 1.0
+    elif not gold_set:
+        precision = 0.0
+        recall = 1.0
+        f1 = 0.0
+    elif not pred_set:
+        precision = 1.0
+        recall = 0.0
+        f1 = 0.0
+    else:
+        precision = tp / len(pred_set)
+        recall = tp / len(gold_set)
+        f1 = (2 * precision * recall / (precision + recall)
+              if (precision + recall) > 0 else 0.0)
+
+    return {
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "predicted": sorted(pred_set),
+        "gold": sorted(gold_set),
+    }
+
+
+def parse_judge(response: str) -> tuple[bool | None, str]:
+    candidates = []
+    m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", response, re.DOTALL)
+    if m:
+        candidates.append(m.group(1))
+    m = re.search(r'(\{[^{}]*"consistent"[^{}]*\})', response, re.DOTALL)
+    if m:
+        candidates.append(m.group(1))
+    for raw in candidates:
+        try:
+            obj = json.loads(raw)
+            return bool(obj.get("consistent")), str(obj.get("reasoning", "")).strip()
+        except json.JSONDecodeError:
+            continue
+    m = re.search(r'"consistent"\s*:\s*(true|false)', response, re.IGNORECASE)
+    if m:
+        return m.group(1).lower() == "true", response.strip()[:500]
+    return None, response.strip()[:500]


### PR DESCRIPTION
## Summary

- Integrates the DocScope benchmark into VLMEvalKit.
- Adds the DocScope dataset wrapper, reasoning prompt helpers, and judge prompt templates.
- Registers `DocScope_DEV` as an image dataset.

## DocScope DEV Validation

Setup:

- Dataset: `DocScope_DEV`
- Split: `dev`
- Infer model: `qwen3.8-27b-fp8`
- Infer backend in VLMEvalKit: `LMDeployAPI`
- Judge model: `gpt-4o-mini`
- Infer concurrency: `50`
- Judge concurrency: `50`
- Max pages: `100`
- Render DPI: `72`

Comparison against the official DocScope code with the same intended model/judge setup:

| Metric | VLMEvalKit | Official DocScope |
| --- | ---: | ---: |
| Pages macro precision | 0.8652216805744051 | 0.8457589174645824 |
| Pages macro recall | 0.9443490245971164 | 0.9435131195335278 |
| Pages macro F1 | 0.8825323076216371 | 0.8679356087256754 |
| Pages micro precision | 0.7875383043922369 | 0.7623666343355965 |
| Pages micro recall | 0.8975552968568102 | 0.916083916083916 |
| Pages micro F1 | 0.838955386289445 | 0.8321863419798836 |
| BBox ok rows | 1211 | 1241 |
| Facts ok rows | 1466 | 1503 |
| Answer judged | 393 | 392 |
| Answer correct | 345 | 347 |
| Answer accuracy | 0.8778625954198473 | 0.8852040816326531 |

