### PR TITLE
fix(CGAVCounting): import post_process from the sibling module so evaluate() stops raising TypeError

### DIFF
--- a/vlmeval/dataset/CGAVCounting/cg_av_counting.py
+++ b/vlmeval/dataset/CGAVCounting/cg_av_counting.py
@@ -11,9 +11,9 @@ from PIL import Image
 
 from vlmeval.smp import (dump, get_cache_path, get_file_extension, get_intermediate_file_path,
                          load, md5, modelscope_flag_set)
-from ..utils.cgbench import post_process, unzip_hf_zip
+from ..utils.cgbench import unzip_hf_zip
 from ..video_base import VideoBaseDataset
-from .utils import get_timestampes, rating_func
+from .utils import get_timestampes, post_process, rating_func
 
 
 class CGAVCounting(VideoBaseDataset):


### PR DESCRIPTION
### Problem

`CGAVCounting.evaluate()` can never finish scoring — it dies with a `TypeError` on the first row.

`vlmeval/dataset/CGAVCounting/cg_av_counting.py` imports `post_process` from `..utils.cgbench`:

```python
from ..utils.cgbench import post_process, unzip_hf_zip   # L14
from ..video_base import VideoBaseDataset
from .utils import get_timestampes, rating_func          # L16
```

but that function is the **CG-Bench** variant:

```python
# vlmeval/dataset/utils/cgbench.py:370
def post_process(response, right_answer, task_mode, duration):
```

while the call site passes `category=` and no `duration=`:

```python
# vlmeval/dataset/CGAVCounting/cg_av_counting.py:386
scores_df = data_un.apply(
    lambda row: post_process(
        response=row["prediction"],
        right_answer=row["answer"],
        task_mode=row["task_mode"],
        category=row["category"],
    ),
    axis=1,
    result_type='expand',
)
```

The correct function already exists in the sibling module that line 16 is *also* importing from:

```python
# vlmeval/dataset/CGAVCounting/utils.py:246
def post_process(response, right_answer, task_mode, category):
```

It is the one that understands CG-AV-Counting's `long_acc` / `ref_acc` / `clue_acc` task modes and the
`event` / `object` / `attribute` categories that `cg_av_counting.py` builds the dataframe from
(L151, L224, L245, L275) — `..utils.cgbench.post_process` knows nothing about any of them.

### Fix

One-line import move: take `post_process` from `.utils` instead of `..utils.cgbench`.
No behavior in `cgbench.py` or anywhere else changes — `unzip_hf_zip` is still imported from it,
and CG-Bench's own two call sites (`vlmeval/dataset/cgbench.py:463` and `:1345`, both passing
`duration=`) are untouched.

### Verification

No GPU/model needed — the defect is a signature mismatch, so I replayed the exact call-site
keywords against both `post_process` definitions fetched from `main` (`abbdd1b`'s base,
`470e517`), with the AST-extracted signatures bound via `inspect.Signature.bind`:

```
   TypeError ..utils.cgbench.post_process   (currently imported)  (response, right_answer, task_mode, duration)
              -> missing a required argument: 'duration'
   OK        .utils.post_process            (sibling, correct)    (response, right_answer, task_mode, category)
```

(Supplying only the three shared arguments instead surfaces the other half of the mismatch:
`category` is an unexpected keyword for the `cgbench` variant.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
