### PR TITLE
fix(molrecbench_wild): give the converter its required track column

### DIFF
--- a/vlmeval/dataset/molrebench_wild.py
+++ b/vlmeval/dataset/molrebench_wild.py
@@ -208,12 +208,16 @@ class MolRecBenchWildDataset(ImageBaseDataset):
             # The official converter keys records by the molecule image name,
             # while VLMEvalKit uses the TSV's integer index during inference.
             'index': sample_ids,
+            # ``convert_dataframe`` reads the track from a required column
+            # rather than a keyword argument, so every row carries this run's
+            # track.
+            'track': [self.track] * len(sample_ids),
             'prediction': [prediction_map[index] for index in selected_indices],
         })
 
         from .utils.molrecbench_wild import convert_dataframe, score_records
 
-        converted, _ = convert_dataframe(selected, track=self.track)
+        converted, _ = convert_dataframe(selected)
         selected_set = set(sample_ids)
         ground_truth = [row for row in self._ground_truth if row['id'] in selected_set]
         result = score_records(


### PR DESCRIPTION
## The bug

`MolRecBenchWildDataset.evaluate()` cannot run at all. It builds a two-column
frame and then calls the converter with a `track=` keyword:

```python
selected = pd.DataFrame({
    'index': sample_ids,
    'prediction': [prediction_map[index] for index in selected_indices],
})

from .utils.molrecbench_wild import convert_dataframe, score_records

converted, _ = convert_dataframe(selected, track=self.track)
```

But `convert_dataframe` takes no `track` argument — it reads the track from a
**required column**:

```python
def convert_dataframe(dataframe, *, sheet="Sheet1", id_suffix=""):
    required_columns = {"index", "track", "prediction"}
```

So every run of any of the three MolRecBench-Wild tracks raises:

```
TypeError: convert_dataframe() got an unexpected keyword argument 'track'
```

and simply deleting the keyword is not enough, because the frame that
`evaluate()` builds has no `track` column either:

```
WorkbookConversionError: sheet 'Sheet1' is missing columns: track
```

(`score_records(ground_truth, converted, self.track, ...)` a few lines below is
correct — `track` really is a positional parameter *there*, which is likely
where the mix-up came from.)

## The fix

Supply the track as the column the converter asks for, and drop the keyword.

## Verification

Ran the real `vlmeval/dataset/utils/molrecbench_wild` package at `main`
(`5a91183`) against the exact frame `evaluate()` constructs.

Before — both failure modes:

```
--- convert_dataframe(selected, track=self.track) ---
TypeError: convert_dataframe() got an unexpected keyword argument 'track'

--- keyword removed but column still absent ---
WorkbookConversionError: sheet 'Sheet1' is missing columns: track
```

After — records convert, no diagnostics:

```
records= 2 issues= 0
  id= mol_0001.png smiles= 'CCO'
  id= mol_0002.png smiles= 'c1ccccc1'
```

(second prediction was fenced ` ```json ` output, to check the normal
extraction path still runs rather than falling back to empty records).

`pre-commit`'s flake8 (7.1.2, `--max-line-length=120 --ignore=W503`) and isort
6.0.1 are clean on the changed file, and yapf produces the same diff before and
after the change — the added lines are untouched by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
